### PR TITLE
fix(ai-coach): use max_completion_tokens for GPT-5 models

### DIFF
--- a/ai-coach-service/app/api/v1/chat.py
+++ b/ai-coach-service/app/api/v1/chat.py
@@ -114,7 +114,7 @@ async def simple_chat(
             model=settings.openai_model,
             messages=messages,
             temperature=0.7,
-            max_tokens=500
+            max_completion_tokens=500
         )
         
         return ChatResponse(

--- a/ai-coach-service/app/api/v1/exercises.py
+++ b/ai-coach-service/app/api/v1/exercises.py
@@ -77,7 +77,7 @@ async def suggest_exercise(request: ExerciseSuggestionRequest) -> ExerciseSugges
                 {"role": "user", "content": prompt}
             ],
             temperature=0.3,  # Lower temperature for more consistent/accurate responses
-            max_tokens=800
+            max_completion_tokens=800
         )
 
         content = response.choices[0].message.content.strip()
@@ -176,7 +176,7 @@ async def stream_exercise_suggestions(exercise_name: str):
                 {"role": "user", "content": prompt}
             ],
             temperature=0.3,
-            max_tokens=800,
+            max_completion_tokens=800,
             stream=True
         )
 

--- a/ai-coach-service/app/api/v1/progressions.py
+++ b/ai-coach-service/app/api/v1/progressions.py
@@ -141,7 +141,7 @@ async def suggest_progression(request: ProgressionSuggestionRequest) -> Progress
                 {"role": "user", "content": prompt}
             ],
             temperature=0.4,
-            max_tokens=1500
+            max_completion_tokens=1500
         )
 
         content = response.choices[0].message.content.strip()
@@ -251,7 +251,7 @@ async def stream_progression_suggestion(goal_exercise: str, current_level: str, 
                 {"role": "user", "content": prompt}
             ],
             temperature=0.4,
-            max_tokens=1500,
+            max_completion_tokens=1500,
             stream=True
         )
 

--- a/ai-coach-service/app/api/v1/suggestions.py
+++ b/ai-coach-service/app/api/v1/suggestions.py
@@ -143,7 +143,7 @@ USER DATA:
             model="gpt-4o-mini",  # Use faster/cheaper model for suggestions
             messages=messages,
             temperature=0.8,  # Slightly higher for variety
-            max_tokens=200
+            max_completion_tokens=200
         )
 
         response_text = response.choices[0].message.content.strip()

--- a/ai-coach-service/app/api/v1/train_now.py
+++ b/ai-coach-service/app/api/v1/train_now.py
@@ -352,7 +352,7 @@ CALENDAR CONTEXT:
             model="gpt-4o-mini",
             messages=messages,
             temperature=0.7,
-            max_tokens=1500
+            max_completion_tokens=1500
         )
 
         response_text = response.choices[0].message.content.strip()

--- a/ai-coach-service/app/core/agents/base.py
+++ b/ai-coach-service/app/core/agents/base.py
@@ -38,7 +38,7 @@ class BaseAgent(ABC):
                 "model": self.settings.openai_model,
                 "messages": messages,
                 "temperature": temperature,
-                "max_tokens": max_tokens
+                "max_completion_tokens": max_tokens
             }
             
             if response_format:

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -439,7 +439,7 @@ USER DATA:
                 tools=self.get_tools(),
                 tool_choice="auto",
                 temperature=0.7,
-                max_tokens=2500,
+                max_completion_tokens=2500,
                 stream=True
             )
 
@@ -560,7 +560,7 @@ USER DATA:
                             tools=self.get_tools(),  # Keep tools available for chaining
                             tool_choice="auto",
                             temperature=0.7,
-                            max_tokens=1500,
+                            max_completion_tokens=1500,
                             stream=True
                         )
 
@@ -801,7 +801,7 @@ USER DATA:
                     ],
                     response_format={"type": "json_object"},
                     temperature=REFLECTION_CONFIG["temperature"],
-                    max_tokens=REFLECTION_CONFIG["max_tokens"],
+                    max_completion_tokens=REFLECTION_CONFIG["max_tokens"],
                 )
 
             # Parse JSON response


### PR DESCRIPTION
## Problem

The deployed AI-coach service on Render crashes on every OpenAI call with:

```
openai.BadRequestError: 400 - Unsupported parameter: 'max_tokens' is not
supported with this model. Use 'max_completion_tokens' instead.
```

The configured model `gpt-5.4-mini` (GPT-5 series) no longer accepts the
legacy `max_tokens` parameter on `chat.completions.create`. This breaks the
streaming chat endpoint (`orchestrator.py:436`) and every other LLM call.

## Fix

Rename `max_tokens` → `max_completion_tokens` at all 8 `chat.completions.create`
call sites plus the shared `_call_llm` helper:

- `app/core/agents/base.py`
- `app/core/agents/orchestrator.py`
- `app/api/v1/suggestions.py`
- `app/api/v1/chat.py`
- `app/api/v1/exercises.py`
- `app/api/v1/progressions.py`
- `app/api/v1/train_now.py`

## Verification

- Confirmed against the live API that `gpt-5.4-mini` accepts
  `max_completion_tokens`, and still accepts `temperature` and
  `response_format` (no further parameter changes needed).
- `python -m py_compile` passes on all changed files.

## Note (out of scope for this PR)

The logs also show MongoDB timeouts against the old `ymgwmek` cluster
(`ReplicaSetNoPrimary`). That is a **deployment env** issue — the Render
`MONGODB_URL` still points at the dead cluster and needs to be repointed to
`production.viu4amc.mongodb.net/production`. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)