### PR TITLE
feat(backend): MCP server — manage workouts from Claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ CLAUDE.md
 
 # MCP config contains DB credentials
 .mcp.json
+
+#development
+/development/
+development/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -44,3 +44,16 @@ STRAVA_WEBHOOK_VERIFY_TOKEN=your-random-webhook-verify-token
 
 # Admin API Key (for webhook subscription management)
 ADMIN_API_KEY=your-admin-api-key-for-webhook-setup
+
+# MCP Connector (Claude custom connector) Configuration
+# Public origin of this backend as users type it into Claude, no trailing slash.
+# Must be HTTPS in production; localhost http is allowed for local dev.
+# The connector URL users add in Claude is `${MCP_BASE_URL}/mcp`.
+MCP_BASE_URL=http://localhost:5001
+# Secret used to sign short-lived consent tickets during the Google login hop.
+# Falls back to JWT_SECRET if unset; set a distinct value in production.
+MCP_CONSENT_TICKET_SECRET=change-this-in-production
+# Token lifetimes (seconds). Defaults: access 1h, refresh 30d, auth code 10m.
+MCP_ACCESS_TOKEN_TTL_SECONDS=3600
+MCP_REFRESH_TOKEN_TTL_SECONDS=2592000
+MCP_AUTH_CODE_TTL_SECONDS=600

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "seed:predefined-workouts": "node scripts/seed-predefined-workouts.js"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.11.0",
     "bcryptjs": "^2.4.3",
     "compression": "^1.7.4",
@@ -35,7 +36,8 @@
     "openai": "^5.11.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
-    "winston": "^3.11.0"
+    "winston": "^3.11.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/backend/src/mcp/__tests__/invoke.test.js
+++ b/backend/src/mcp/__tests__/invoke.test.js
@@ -1,0 +1,84 @@
+const { body } = require('express-validator');
+const { callController, toToolResult, runTool } = require('../invoke');
+const { validationResult } = require('express-validator');
+
+describe('MCP controller bridge (invoke.js)', () => {
+  test('captures a success response and its status code', async () => {
+    const handler = (req, res) => res.status(200).json({ success: true, data: { id: 'w1' } });
+    const result = await callController(handler, { user: { _id: 'u1' } });
+    expect(result).toEqual({ statusCode: 200, payload: { success: true, data: { id: 'w1' } } });
+
+    const tool = toToolResult(result);
+    expect(tool.isError).toBeFalsy();
+    expect(JSON.parse(tool.content[0].text)).toEqual({ id: 'w1' });
+  });
+
+  test('chainable res.status(201).json(...) preserves the status', async () => {
+    const handler = (req, res) => res.status(201).json({ success: true, data: { created: true } });
+    const result = await callController(handler, {});
+    expect(result.statusCode).toBe(201);
+  });
+
+  test('maps a 4xx { success:false } response to a tool error', async () => {
+    const handler = (req, res) => res.status(404).json({ success: false, message: 'Workout not found' });
+    const tool = toToolResult(await callController(handler, {}));
+    expect(tool.isError).toBe(true);
+    expect(tool.content[0].text).toBe('Error: Workout not found');
+  });
+
+  test('treats { success:false } as an error even on a 200 status', async () => {
+    const handler = (req, res) => res.status(200).json({ success: false, message: 'nope' });
+    const tool = toToolResult(await callController(handler, {}));
+    expect(tool.isError).toBe(true);
+  });
+
+  test('runs express-validator chains against the same req the handler reads', async () => {
+    // Handler mimics real controllers: reads validationResult(req).
+    const handler = (req, res) => {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ success: false, message: 'Validation errors', errors: errors.array() });
+      }
+      return res.status(201).json({ success: true, data: { ok: true } });
+    };
+    const validators = [body('title').trim().isLength({ min: 2 }).withMessage('title too short')];
+
+    // Invalid input → validators populate req, handler returns 400.
+    const bad = toToolResult(await callController(handler, { body: { title: 'x' } }, validators));
+    expect(bad.isError).toBe(true);
+    expect(bad.content[0].text).toContain('title too short');
+
+    // Valid input → handler returns success.
+    const good = toToolResult(await callController(handler, { body: { title: 'Leg day' } }, validators));
+    expect(good.isError).toBeFalsy();
+  });
+
+  test('captures a thrown controller error as a 500 tool error', async () => {
+    const handler = () => { throw new Error('boom'); };
+    const result = await callController(handler, {});
+    expect(result.statusCode).toBe(500);
+    const tool = toToolResult(result);
+    expect(tool.isError).toBe(true);
+    expect(tool.content[0].text).toContain('boom');
+  });
+
+  test('captures async controller rejections as a 500', async () => {
+    const handler = async () => { await Promise.resolve(); throw new Error('async boom'); };
+    const result = await callController(handler, {});
+    expect(result.statusCode).toBe(500);
+  });
+
+  test('runTool applies a transform to the success data', async () => {
+    const handler = (req, res) => res.status(200).json({ success: true, data: { exercises: [{ _id: 'e1', extra: 'drop' }] } });
+    const tool = await runTool(handler, {}, {
+      transform: (d) => ({ exercises: d.exercises.map((e) => ({ _id: e._id })) })
+    });
+    expect(JSON.parse(tool.content[0].text)).toEqual({ exercises: [{ _id: 'e1' }] });
+  });
+
+  test('joins express-validator error messages in the tool error', async () => {
+    const payload = { success: false, errors: [{ msg: 'a bad' }, { msg: 'b bad' }] };
+    const tool = toToolResult({ statusCode: 400, payload });
+    expect(tool.content[0].text).toBe('Error: a bad; b bad');
+  });
+});

--- a/backend/src/mcp/authProvider.js
+++ b/backend/src/mcp/authProvider.js
@@ -1,0 +1,328 @@
+/**
+ * OAuthServerProvider implementation backing the MCP connector's OAuth 2.0
+ * authorization server (DCR + PKCE S256, authorization-code + refresh grants).
+ *
+ * The SDK's mcpAuthRouter drives the spec-level HTTP handling (metadata,
+ * /authorize, /token, /register, /revoke) and does PKCE verification itself;
+ * this provider supplies the storage-backed logic: client registration,
+ * rendering the consent page, and minting/rotating/verifying opaque tokens.
+ *
+ * Design notes:
+ * - Clients are forced to be PUBLIC (token_endpoint_auth_method: 'none'). Claude
+ *   and Claude Code both register as public clients + PKCE, so we never store an
+ *   OAuth client secret at rest.
+ * - Tokens are opaque random strings stored only as SHA-256 hashes. They are
+ *   structurally distinct from the app's login JWTs and independently revocable.
+ * - Refresh tokens rotate on use; reuse of a rotated refresh token revokes the
+ *   whole token family (OAuth 2.1 token-theft response).
+ */
+
+const crypto = require('crypto');
+const {
+  InvalidTokenError,
+  InvalidGrantError,
+  InvalidClientMetadataError
+} = require('@modelcontextprotocol/sdk/server/auth/errors.js');
+
+const OAuthClient = require('../models/OAuthClient');
+const OAuthAuthorizationCode = require('../models/OAuthAuthorizationCode');
+const OAuthToken = require('../models/OAuthToken');
+const OAuthPendingAuthorization = require('../models/OAuthPendingAuthorization');
+const { renderLoginConsent } = require('./consentPage');
+
+const SCOPES = [
+  'workouts:read',
+  'workouts:write',
+  'calendar:read',
+  'calendar:write',
+  'exercises:read'
+];
+
+const ACCESS_TTL = parseInt(process.env.MCP_ACCESS_TOKEN_TTL_SECONDS, 10) || 3600;
+const REFRESH_TTL = parseInt(process.env.MCP_REFRESH_TOKEN_TTL_SECONDS, 10) || 2592000;
+const CODE_TTL = parseInt(process.env.MCP_AUTH_CODE_TTL_SECONDS, 10) || 600;
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function randomToken(prefix) {
+  return `${prefix}${crypto.randomBytes(32).toString('base64url')}`;
+}
+
+function isAllowedRedirectUri(uri) {
+  try {
+    const u = new URL(uri);
+    if (u.protocol === 'https:') return true;
+    if (u.protocol === 'http:' && (u.hostname === 'localhost' || u.hostname === '127.0.0.1')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// Restrict requested scopes to the ones we support; default to all if none asked.
+function normalizeScopes(requested) {
+  const filtered = (requested || []).filter((s) => SCOPES.includes(s));
+  return filtered.length ? filtered : SCOPES.slice();
+}
+
+/**
+ * Mint an access + refresh token pair sharing a familyId. Returns the
+ * OAuthTokens response object (with the plaintext tokens for the client).
+ */
+async function issueTokenPair({ userId, clientId, scope, resource, familyId }) {
+  const family = familyId || crypto.randomUUID();
+  const accessToken = randomToken('sfmcp_at_');
+  const refreshToken = randomToken('sfmcp_rt_');
+  const now = Date.now();
+
+  await OAuthToken.create([
+    {
+      tokenHash: sha256(accessToken),
+      kind: 'access',
+      userId,
+      clientId,
+      scope,
+      familyId: family,
+      resource: resource || null,
+      expiresAt: new Date(now + ACCESS_TTL * 1000)
+    },
+    {
+      tokenHash: sha256(refreshToken),
+      kind: 'refresh',
+      userId,
+      clientId,
+      scope,
+      familyId: family,
+      resource: resource || null,
+      expiresAt: new Date(now + REFRESH_TTL * 1000)
+    }
+  ]);
+
+  return {
+    access_token: accessToken,
+    token_type: 'Bearer',
+    expires_in: ACCESS_TTL,
+    refresh_token: refreshToken,
+    scope: scope.join(' '),
+    _familyId: family
+  };
+}
+
+const clientsStore = {
+  async getClient(clientId) {
+    const c = await OAuthClient.findOne({ clientId });
+    if (!c) return undefined;
+
+    // Fire-and-forget last-used bump (don't block the auth path).
+    OAuthClient.updateOne({ clientId }, { lastUsedAt: new Date() }).catch(() => {});
+
+    // Note: deliberately no `client_secret` field → the SDK treats this as a
+    // public client and requires only PKCE, never a secret.
+    return {
+      client_id: c.clientId,
+      redirect_uris: c.redirectUris,
+      token_endpoint_auth_method: 'none',
+      grant_types: c.grantTypes,
+      response_types: c.responseTypes,
+      scope: c.scope || undefined,
+      client_name: c.clientName || undefined,
+      client_id_issued_at: c.clientIdIssuedAt
+    };
+  },
+
+  async registerClient(clientInfo) {
+    const redirectUris = clientInfo.redirect_uris || [];
+    if (!redirectUris.length || !redirectUris.every(isAllowedRedirectUri)) {
+      throw new InvalidClientMetadataError('redirect_uris must be https or loopback http URLs');
+    }
+
+    await OAuthClient.create({
+      clientId: clientInfo.client_id,
+      clientSecretHash: null,
+      clientName: clientInfo.client_name || null,
+      redirectUris,
+      grantTypes: clientInfo.grant_types || ['authorization_code', 'refresh_token'],
+      responseTypes: clientInfo.response_types || ['code'],
+      tokenEndpointAuthMethod: 'none',
+      scope: clientInfo.scope || null,
+      clientIdIssuedAt: clientInfo.client_id_issued_at
+    });
+
+    // Return as a public client — strip any secret the SDK generated so the
+    // client (Claude) never receives one and behaves as a public + PKCE client.
+    const { client_secret, client_secret_expires_at, ...rest } = clientInfo;
+    return {
+      ...rest,
+      token_endpoint_auth_method: 'none'
+    };
+  }
+};
+
+const provider = {
+  clientsStore,
+
+  /**
+   * Render the login/consent page. The SDK has already validated client_id,
+   * redirect_uri (against registered URIs), response_type=code and PKCE.
+   */
+  async authorize(client, params, res) {
+    const scopes = normalizeScopes(params.scopes);
+
+    // Persist the authorize request so the "Continue with Google" hop can
+    // recover it after the Google round-trip (keyed by requestId in `state`).
+    const requestId = crypto.randomUUID();
+    await OAuthPendingAuthorization.create({
+      requestId,
+      clientId: client.client_id,
+      redirectUri: params.redirectUri,
+      codeChallenge: params.codeChallenge,
+      state: params.state || null,
+      scope: scopes,
+      resource: params.resource ? params.resource.href : null,
+      expiresAt: new Date(Date.now() + CODE_TTL * 1000)
+    });
+
+    const html = renderLoginConsent({
+      clientName: client.client_name,
+      scopes,
+      requestId
+    });
+
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    res.status(200).send(html);
+  },
+
+  async challengeForAuthorizationCode(client, authorizationCode) {
+    const record = await OAuthAuthorizationCode.findOne({ codeHash: sha256(authorizationCode) });
+    if (!record || record.clientId !== client.client_id) {
+      throw new InvalidGrantError('Invalid authorization code');
+    }
+    return record.codeChallenge;
+  },
+
+  /**
+   * Redeem a single-use authorization code for a token pair. The SDK has
+   * already verified PKCE (code_verifier vs the stored challenge).
+   */
+  async exchangeAuthorizationCode(client, authorizationCode, _codeVerifier, redirectUri, resource) {
+    const codeHash = sha256(authorizationCode);
+    const record = await OAuthAuthorizationCode.findOne({ codeHash });
+
+    if (!record || record.clientId !== client.client_id) {
+      throw new InvalidGrantError('Invalid authorization code');
+    }
+
+    // Single-use enforcement: a replayed code means the code leaked — revoke
+    // every token minted from it.
+    if (record.usedAt) {
+      if (record.issuedTokenFamilyId) {
+        await OAuthToken.deleteMany({ familyId: record.issuedTokenFamilyId });
+      }
+      throw new InvalidGrantError('Authorization code already used');
+    }
+
+    if (redirectUri && redirectUri !== record.redirectUri) {
+      throw new InvalidGrantError('redirect_uri mismatch');
+    }
+    if (record.expiresAt.getTime() < Date.now()) {
+      throw new InvalidGrantError('Authorization code expired');
+    }
+
+    const tokens = await issueTokenPair({
+      userId: record.userId,
+      clientId: client.client_id,
+      scope: record.scope,
+      resource: record.resource
+    });
+
+    record.usedAt = new Date();
+    record.issuedTokenFamilyId = tokens._familyId;
+    await record.save();
+
+    delete tokens._familyId;
+    return tokens;
+  },
+
+  /**
+   * Rotate a refresh token. Reuse of an already-rotated token revokes the
+   * whole family.
+   */
+  async exchangeRefreshToken(client, refreshToken, scopes) {
+    const tokenHash = sha256(refreshToken);
+    const record = await OAuthToken.findOne({ tokenHash, kind: 'refresh' });
+
+    if (!record || record.clientId !== client.client_id) {
+      throw new InvalidGrantError('Invalid refresh token');
+    }
+
+    // Reuse detection: a refresh token that was already rotated is being
+    // replayed. Treat it as token theft (OAuth 2.1) and revoke the whole
+    // family — both the attacker's and the legitimate client's tokens.
+    if (record.rotatedAt) {
+      await OAuthToken.deleteMany({ familyId: record.familyId });
+      throw new InvalidGrantError('Refresh token reuse detected');
+    }
+
+    if (record.expiresAt.getTime() < Date.now()) {
+      throw new InvalidGrantError('Refresh token expired');
+    }
+
+    // Requested scopes (if any) must be a subset of the originally granted set.
+    let scope = record.scope;
+    if (scopes && scopes.length) {
+      if (!scopes.every((s) => record.scope.includes(s))) {
+        throw new InvalidGrantError('Requested scope exceeds original grant');
+      }
+      scope = scopes;
+    }
+
+    // Rotate: mark the old refresh token spent (kept for reuse detection until
+    // its TTL removes it) rather than deleting it, then issue the new pair in
+    // the same family.
+    record.rotatedAt = new Date();
+    await record.save();
+
+    const tokens = await issueTokenPair({
+      userId: record.userId,
+      clientId: client.client_id,
+      scope,
+      resource: record.resource,
+      familyId: record.familyId
+    });
+
+    delete tokens._familyId;
+    return tokens;
+  },
+
+  async verifyAccessToken(token) {
+    const record = await OAuthToken.findOne({ tokenHash: sha256(token), kind: 'access' });
+    if (!record) {
+      throw new InvalidTokenError('Invalid or expired access token');
+    }
+    if (record.expiresAt.getTime() < Date.now()) {
+      throw new InvalidTokenError('Access token expired');
+    }
+    return {
+      token,
+      clientId: record.clientId,
+      scopes: record.scope,
+      expiresAt: Math.floor(record.expiresAt.getTime() / 1000), // epoch seconds
+      extra: { userId: record.userId.toString() }
+    };
+  },
+
+  async revokeToken(client, request) {
+    if (!request || !request.token) return;
+    await OAuthToken.deleteOne({ tokenHash: sha256(request.token) });
+  }
+};
+
+module.exports = {
+  provider,
+  SCOPES,
+  sha256,
+  randomToken,
+  CODE_TTL
+};

--- a/backend/src/mcp/config.js
+++ b/backend/src/mcp/config.js
@@ -1,0 +1,23 @@
+/**
+ * Shared MCP/OAuth URL configuration.
+ *
+ * MCP_BASE_URL is the public origin of this backend as users type it into
+ * Claude (no trailing slash), e.g. https://synergyfit-api.onrender.com. The
+ * OAuth issuer is this origin; the protected resource is `${origin}/mcp` and
+ * MUST exactly match the connector URL the user enters.
+ */
+
+const RAW_BASE = process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || 5001}`;
+const MCP_BASE_URL = RAW_BASE.replace(/\/+$/, '');
+const MCP_PATH = '/mcp';
+const MCP_RESOURCE_URL = `${MCP_BASE_URL}${MCP_PATH}`;
+
+// The SDK serves protected-resource metadata at the RFC 9728 path-suffixed URL.
+const RESOURCE_METADATA_URL = `${MCP_BASE_URL}/.well-known/oauth-protected-resource${MCP_PATH}`;
+
+module.exports = {
+  MCP_BASE_URL,
+  MCP_PATH,
+  MCP_RESOURCE_URL,
+  RESOURCE_METADATA_URL
+};

--- a/backend/src/mcp/consentController.js
+++ b/backend/src/mcp/consentController.js
@@ -1,0 +1,192 @@
+/**
+ * Consent-flow handlers for the MCP OAuth authorize step. These live at
+ * /oauth/consent/* — deliberately NOT under /mcp — so they stay outside the
+ * bearer-auth boundary and any /mcp rate limiter.
+ *
+ * Two ways to reach `approve`:
+ *  - Password: request_id + email + password (verified against the User model).
+ *  - Google:   a signed consent_ticket minted after passport-google auth.
+ *
+ * Both resolve to a userId + the authoritative pending-authorization record
+ * (never trusted hidden authorize params), then mint a single-use auth code and
+ * 302 back to the client's redirect_uri.
+ */
+
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+const OAuthClient = require('../models/OAuthClient');
+const OAuthAuthorizationCode = require('../models/OAuthAuthorizationCode');
+const OAuthPendingAuthorization = require('../models/OAuthPendingAuthorization');
+const { renderLoginConsent, renderGoogleConsent } = require('./consentPage');
+const { sha256, randomToken, CODE_TTL } = require('./authProvider');
+
+const CONSENT_TICKET_SECRET = process.env.MCP_CONSENT_TICKET_SECRET || process.env.JWT_SECRET;
+const CONSENT_TICKET_TTL = '5m';
+const CONSENT_TICKET_AUD = 'mcp-consent';
+
+function ticketFor(userId, requestId) {
+  return jwt.sign({ userId: String(userId), requestId }, CONSENT_TICKET_SECRET, {
+    expiresIn: CONSENT_TICKET_TTL,
+    audience: CONSENT_TICKET_AUD
+  });
+}
+
+function verifyTicket(token) {
+  return jwt.verify(token, CONSENT_TICKET_SECRET, { audience: CONSENT_TICKET_AUD });
+}
+
+// Simple standalone HTML error (used when we can't safely redirect anywhere).
+function errorPage(res, status, message) {
+  res.status(status).set('Content-Type', 'text/html; charset=utf-8').send(
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Error</title></head>` +
+    `<body style="font-family:sans-serif;max-width:420px;margin:80px auto;padding:0 24px;text-align:center"><h1>Something went wrong</h1><p>${message}</p></body></html>`
+  );
+}
+
+function redirectWithError(res, redirectUri, error, state) {
+  const url = new URL(redirectUri);
+  url.searchParams.set('error', error);
+  if (state) url.searchParams.set('state', state);
+  res.redirect(302, url.href);
+}
+
+async function issueCodeAndRedirect(res, { pending, userId }) {
+  const code = randomToken('sfmcp_code_');
+  await OAuthAuthorizationCode.create({
+    codeHash: sha256(code),
+    clientId: pending.clientId,
+    userId,
+    redirectUri: pending.redirectUri,
+    codeChallenge: pending.codeChallenge,
+    scope: pending.scope,
+    resource: pending.resource,
+    expiresAt: new Date(Date.now() + CODE_TTL * 1000)
+  });
+
+  // Pending record is single-use — consume it.
+  await OAuthPendingAuthorization.deleteOne({ _id: pending._id });
+
+  const url = new URL(pending.redirectUri);
+  url.searchParams.set('code', code);
+  if (pending.state) url.searchParams.set('state', pending.state);
+  res.redirect(302, url.href);
+}
+
+// POST /oauth/consent/approve
+async function approve(req, res) {
+  try {
+    const { consent_ticket, request_id, email, password } = req.body;
+
+    let userId;
+    let requestId;
+
+    if (consent_ticket) {
+      // Google branch — identity carried by the signed ticket.
+      let decoded;
+      try {
+        decoded = verifyTicket(consent_ticket);
+      } catch {
+        return errorPage(res, 400, 'Your sign-in session expired. Please start again from Claude.');
+      }
+      userId = decoded.userId;
+      requestId = decoded.requestId;
+    } else {
+      // Password branch.
+      requestId = request_id;
+      if (!email || !password) {
+        // Re-render the form with an error if we can recover the request.
+        const pendingForForm = requestId
+          ? await OAuthPendingAuthorization.findOne({ requestId })
+          : null;
+        if (pendingForForm) {
+          const client = await OAuthClient.findOne({ clientId: pendingForForm.clientId });
+          return res.status(400).set('Content-Type', 'text/html; charset=utf-8').send(
+            renderLoginConsent({
+              clientName: client && client.clientName,
+              scopes: pendingForForm.scope,
+              requestId,
+              error: 'Email and password are required.'
+            })
+          );
+        }
+        return errorPage(res, 400, 'Missing credentials.');
+      }
+    }
+
+    const pending = await OAuthPendingAuthorization.findOne({ requestId });
+    if (!pending) {
+      return errorPage(res, 400, 'This request expired. Please start again from Claude.');
+    }
+
+    if (!consent_ticket) {
+      // Verify password credentials.
+      const user = await User.findOne({ email: String(email).toLowerCase().trim() }).select('+password');
+      const invalid = !user || (!user.password && user.googleId) || !(await user.comparePassword(password));
+      if (invalid) {
+        const client = await OAuthClient.findOne({ clientId: pending.clientId });
+        return res.status(401).set('Content-Type', 'text/html; charset=utf-8').send(
+          renderLoginConsent({
+            clientName: client && client.clientName,
+            scopes: pending.scope,
+            requestId,
+            error: 'Invalid email or password.'
+          })
+        );
+      }
+      userId = user._id;
+    }
+
+    return await issueCodeAndRedirect(res, { pending, userId });
+  } catch (err) {
+    console.error('MCP consent approve error:', err);
+    return errorPage(res, 500, 'Server error. Please try again.');
+  }
+}
+
+// POST /oauth/consent/deny
+async function deny(req, res) {
+  try {
+    const { request_id } = req.body;
+    const pending = request_id
+      ? await OAuthPendingAuthorization.findOne({ requestId: request_id })
+      : null;
+    if (!pending) {
+      return errorPage(res, 400, 'Request cancelled.');
+    }
+    await OAuthPendingAuthorization.deleteOne({ _id: pending._id });
+    return redirectWithError(res, pending.redirectUri, 'access_denied', pending.state);
+  } catch (err) {
+    console.error('MCP consent deny error:', err);
+    return errorPage(res, 500, 'Server error.');
+  }
+}
+
+/**
+ * Called from the Google OAuth callback when `state` is `mcp:<requestId>`.
+ * The user is already authenticated (req.user); mint a consent ticket and
+ * render the Google consent confirmation page.
+ */
+async function renderGoogleConsentAfterAuth(req, res, requestId) {
+  const pending = await OAuthPendingAuthorization.findOne({ requestId });
+  if (!pending) {
+    return errorPage(res, 400, 'This request expired. Please start again from Claude.');
+  }
+  const client = await OAuthClient.findOne({ clientId: pending.clientId });
+  const consentTicket = ticketFor(req.user._id, requestId);
+
+  res.status(200).set('Content-Type', 'text/html; charset=utf-8').send(
+    renderGoogleConsent({
+      clientName: client && client.clientName,
+      scopes: pending.scope,
+      email: req.user.email,
+      consentTicket,
+      requestId
+    })
+  );
+}
+
+module.exports = {
+  approve,
+  deny,
+  renderGoogleConsentAfterAuth
+};

--- a/backend/src/mcp/consentPage.js
+++ b/backend/src/mcp/consentPage.js
@@ -1,0 +1,171 @@
+/**
+ * Server-rendered login + consent pages for the MCP OAuth flow.
+ *
+ * Pure functions returning HTML strings — NO client-side JavaScript, inline
+ * CSS only, so the existing helmet CSP (`scriptSrc 'self'`) is untouched. All
+ * forms post to same-origin `/oauth/consent/*`; the only cross-origin hop is
+ * the final 302 to the client's redirect_uri (e.g. claude.ai), not a form action.
+ */
+
+const SCOPE_LABELS = {
+  'workouts:read': 'View your workouts and training stats',
+  'workouts:write': 'Create, update and delete your workouts',
+  'calendar:read': 'View your training calendar',
+  'calendar:write': 'Schedule and reschedule calendar events',
+  'exercises:read': 'Search the exercise library'
+};
+
+function escapeHtml(value) {
+  if (value === undefined || value === null) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function hiddenField(name, value) {
+  if (value === undefined || value === null || value === '') return '';
+  return `<input type="hidden" name="${escapeHtml(name)}" value="${escapeHtml(value)}">`;
+}
+
+function scopeList(scopes) {
+  const items = (scopes || [])
+    .map((s) => `<li>${escapeHtml(SCOPE_LABELS[s] || s)}</li>`)
+    .join('');
+  return `<ul class="scopes">${items}</ul>`;
+}
+
+const PAGE_CSS = `
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    margin: 0; padding: 24px; background: #f5f6f8; color: #1a1a2e;
+    display: flex; min-height: 100vh; align-items: center; justify-content: center;
+  }
+  .card {
+    background: #fff; border-radius: 16px; padding: 32px; width: 100%; max-width: 420px;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.08);
+  }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  .sub { color: #6b7280; font-size: 14px; margin: 0 0 24px; }
+  .app { font-weight: 600; }
+  label { display: block; font-size: 13px; font-weight: 600; margin: 16px 0 6px; }
+  input[type=email], input[type=password] {
+    width: 100%; padding: 12px 14px; border: 1px solid #d1d5db; border-radius: 10px;
+    font-size: 16px; background: #fff; color: #1a1a2e;
+  }
+  .scopes { margin: 12px 0 24px; padding-left: 20px; font-size: 14px; color: #374151; }
+  .scopes li { margin: 6px 0; }
+  .box {
+    background: #f0f1f5; border-radius: 10px; padding: 14px 16px; margin-bottom: 20px;
+    font-size: 14px;
+  }
+  button {
+    width: 100%; padding: 13px; border: none; border-radius: 10px; font-size: 16px;
+    font-weight: 600; cursor: pointer; margin-top: 8px;
+  }
+  .primary { background: #4f46e5; color: #fff; }
+  .secondary { background: transparent; color: #6b7280; }
+  .divider { text-align: center; color: #9ca3af; font-size: 13px; margin: 18px 0; }
+  .google {
+    display: block; text-align: center; text-decoration: none; padding: 12px;
+    border: 1px solid #d1d5db; border-radius: 10px; color: #1a1a2e; font-weight: 600; font-size: 15px;
+  }
+  .error { background: #fef2f2; color: #b91c1c; border-radius: 10px; padding: 12px 14px; font-size: 14px; margin-bottom: 16px; }
+  .foot { text-align: center; font-size: 12px; color: #9ca3af; margin-top: 20px; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #0f1117; color: #e5e7eb; }
+    .card { background: #1a1d29; box-shadow: 0 10px 40px rgba(0,0,0,0.4); }
+    .sub, .scopes { color: #9ca3af; }
+    input[type=email], input[type=password] { background: #0f1117; border-color: #374151; color: #e5e7eb; }
+    .box { background: #0f1117; }
+    .google { background: #1a1d29; border-color: #374151; color: #e5e7eb; }
+  }
+`;
+
+function shell(title, inner) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>${PAGE_CSS}</style>
+</head>
+<body>
+<div class="card">
+${inner}
+<p class="foot">SynergyFit · Model Context Protocol connector</p>
+</div>
+</body>
+</html>`;
+}
+
+/**
+ * Password login + consent (the default /authorize screen). Everything is
+ * keyed on `requestId` — the authoritative authorize parameters live in the
+ * server-side pending-authorization record, never in trusted hidden fields.
+ */
+function renderLoginConsent(params) {
+  const { clientName, scopes, requestId, error } = params;
+
+  const googleHref = `/api/v1/auth/google?state=${encodeURIComponent('mcp:' + requestId)}`;
+
+  const inner = `
+<h1>Connect to Claude</h1>
+<p class="sub"><span class="app">${escapeHtml(clientName || 'An MCP client')}</span> wants to access your SynergyFit account.</p>
+${error ? `<div class="error">${escapeHtml(error)}</div>` : ''}
+<p class="sub">This will allow it to:</p>
+${scopeList(scopes)}
+<form method="POST" action="/oauth/consent/approve" autocomplete="on">
+  ${hiddenField('request_id', requestId)}
+  <label for="email">Email</label>
+  <input id="email" name="email" type="email" required autocomplete="email">
+  <label for="password">Password</label>
+  <input id="password" name="password" type="password" required autocomplete="current-password">
+  <button type="submit" class="primary">Sign in &amp; Allow</button>
+</form>
+<div class="divider">or</div>
+<a class="google" href="${escapeHtml(googleHref)}">Continue with Google</a>
+<form method="POST" action="/oauth/consent/deny">
+  ${hiddenField('request_id', requestId)}
+  <button type="submit" class="secondary">Cancel</button>
+</form>`;
+
+  return shell('Connect to Claude', inner);
+}
+
+/**
+ * Consent confirmation after the user authenticated via Google. No password
+ * fields — the user is identified by a short-lived signed `consentTicket`
+ * (which itself carries the requestId).
+ */
+function renderGoogleConsent(params) {
+  const { clientName, scopes, email, consentTicket, requestId } = params;
+
+  const inner = `
+<h1>Connect to Claude</h1>
+<p class="sub"><span class="app">${escapeHtml(clientName || 'An MCP client')}</span> wants to access your SynergyFit account.</p>
+<div class="box">Signed in as <strong>${escapeHtml(email)}</strong></div>
+<p class="sub">This will allow it to:</p>
+${scopeList(scopes)}
+<form method="POST" action="/oauth/consent/approve">
+  ${hiddenField('consent_ticket', consentTicket)}
+  <button type="submit" class="primary">Allow</button>
+</form>
+<form method="POST" action="/oauth/consent/deny">
+  ${hiddenField('request_id', requestId)}
+  <button type="submit" class="secondary">Cancel</button>
+</form>`;
+
+  return shell('Connect to Claude', inner);
+}
+
+module.exports = {
+  renderLoginConsent,
+  renderGoogleConsent,
+  SCOPE_LABELS
+};

--- a/backend/src/mcp/invoke.js
+++ b/backend/src/mcp/invoke.js
@@ -1,0 +1,103 @@
+/**
+ * Controller-reuse bridge for MCP tools.
+ *
+ * Existing Express controllers are `(req, res)` functions that read
+ * `req.user/params/query/body`, run express-validator chains, and reply via
+ * `res.status(x).json(y)`. Rather than duplicate that CRUD + validation logic,
+ * a tool builds a minimal req, runs the same validator chains, and captures the
+ * response with a chainable res stub.
+ *
+ * `req.user` is the full Mongoose User document, so both `req.user._id`
+ * (workout/calendar controllers) and `req.user.id` (exercise controller) work.
+ */
+
+const { validationResult } = require('express-validator');
+
+/**
+ * Invoke a controller in-process and capture its response.
+ * @returns {Promise<{statusCode:number, payload:any}>}
+ */
+async function callController(handler, { user, params = {}, query = {}, body = {} } = {}, validators = []) {
+  const req = {
+    user,
+    params,
+    query,
+    body,
+    headers: {},
+    get() { return undefined },
+    header() { return undefined }
+  };
+
+  // Run express-validator chains against the same req the handler will read,
+  // so the controller's own validationResult(req) sees the results.
+  for (const chain of validators) {
+    // eslint-disable-next-line no-await-in-loop
+    await chain.run(req);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (statusCode, payload) => {
+      if (settled) return;
+      settled = true;
+      resolve({ statusCode, payload });
+    };
+
+    const res = {
+      statusCode: 200,
+      status(code) { this.statusCode = code; return this; },
+      json(payload) { finish(this.statusCode, payload); return this; },
+      send(payload) { finish(this.statusCode, payload); return this; },
+      set() { return this; },
+      setHeader() { return this; },
+      end() { finish(this.statusCode, undefined); return this; }
+    };
+
+    Promise.resolve()
+      .then(() => handler(req, res))
+      .catch((err) => finish(500, { success: false, message: err && err.message ? err.message : 'Server error' }));
+  });
+}
+
+/**
+ * Map a captured controller response to an MCP tool result. Non-2xx or
+ * `{ success: false }` payloads become tool errors.
+ * @param {object} result - { statusCode, payload } from callController
+ * @param {(data:any)=>any} [transform] - optional shaper for the success data
+ */
+function toToolResult(result, transform) {
+  const { statusCode, payload } = result;
+  const ok = statusCode >= 200 && statusCode < 300 && !(payload && payload.success === false);
+
+  if (!ok) {
+    let msg;
+    if (payload && payload.errors) {
+      msg = payload.errors.map((e) => e.msg || e.message).filter(Boolean).join('; ') ||
+        (payload.message || 'Validation failed');
+    } else {
+      msg = (payload && payload.message) || `Request failed (${statusCode})`;
+    }
+    return { isError: true, content: [{ type: 'text', text: `Error: ${msg}` }] };
+  }
+
+  // Prefer the conventional `data` envelope; fall back to the whole payload.
+  let data = payload && Object.prototype.hasOwnProperty.call(payload, 'data') ? payload.data : payload;
+  if (typeof transform === 'function') data = transform(data);
+
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+/**
+ * Convenience: run a controller and return the MCP tool result in one call.
+ */
+async function runTool(handler, ctx, { validators = [], transform } = {}) {
+  const result = await callController(handler, ctx, validators);
+  return toToolResult(result, transform);
+}
+
+module.exports = {
+  callController,
+  toToolResult,
+  runTool,
+  validationResult
+};

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -1,0 +1,41 @@
+/**
+ * Builds a per-request MCP server instance scoped to one authenticated user.
+ *
+ * The Streamable HTTP transport runs statelessly (a fresh server + transport
+ * per POST), so we construct a new McpServer here on each request, registering
+ * the workout/calendar/exercise tools with the user and their granted scopes
+ * closed over. Tools enforce scope individually via `withScope`.
+ */
+
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+
+const workoutTools = require('./tools/workoutTools');
+const calendarTools = require('./tools/calendarTools');
+const exerciseTools = require('./tools/exerciseTools');
+
+const APP_VERSION = process.env.APP_VERSION || '1.0.0';
+
+/**
+ * @param {object} user - full Mongoose User document
+ * @param {string[]} scopes - granted OAuth scopes for this token
+ */
+function buildMcpServer(user, scopes) {
+  const server = new McpServer({
+    name: 'synergyfit',
+    version: APP_VERSION
+  }, {
+    instructions:
+      'Tools to view and modify the SynergyFit user\'s workouts and training calendar. ' +
+      'Use search_exercises to resolve exercise ids before creating workouts. All actions ' +
+      'apply to the authenticated user only.'
+  });
+
+  const ctx = { user, scopes: Array.isArray(scopes) ? scopes : [] };
+  workoutTools.register(server, ctx);
+  calendarTools.register(server, ctx);
+  exerciseTools.register(server, ctx);
+
+  return server;
+}
+
+module.exports = { buildMcpServer };

--- a/backend/src/mcp/tools/calendarTools.js
+++ b/backend/src/mcp/tools/calendarTools.js
@@ -1,0 +1,77 @@
+const { z } = require('zod');
+const calendarController = require('../../controllers/calendarController');
+const { runTool } = require('../invoke');
+const { withScope } = require('./util');
+
+const EVENT_TYPES = ['workout', 'rest', 'deload', 'event', 'milestone'];
+// Must match the CalendarEvent model enum (default 'scheduled') — NOT the
+// workout statuses.
+const EVENT_STATUSES = ['scheduled', 'in_progress', 'completed', 'skipped', 'cancelled'];
+
+/**
+ * Register calendar tools. `ctx` = { user, scopes }.
+ */
+function register(server, ctx) {
+  const { user, scopes } = ctx;
+  const READ = 'calendar:read';
+  const WRITE = 'calendar:write';
+
+  server.registerTool('list_calendar_events', {
+    title: 'List calendar events',
+    description: "List the user's training calendar events within a date range (both dates required).",
+    inputSchema: {
+      startDate: z.string().describe('ISO date, inclusive lower bound (required)'),
+      endDate: z.string().describe('ISO date, inclusive upper bound (required)'),
+      type: z.enum(EVENT_TYPES).optional(),
+      status: z.enum(EVENT_STATUSES).optional()
+    }
+  }, withScope(scopes, READ, (args) =>
+    runTool(calendarController.getEvents, { user, query: args })
+  ));
+
+  server.registerTool('create_calendar_event', {
+    title: 'Create calendar event',
+    description: 'Add an event to the training calendar (a workout, rest day, deload, etc.).',
+    inputSchema: {
+      date: z.string().describe('ISO date/datetime for the event'),
+      title: z.string().min(1),
+      type: z.enum(EVENT_TYPES),
+      status: z.enum(EVENT_STATUSES).optional(),
+      notes: z.string().optional(),
+      workoutTemplateId: z.string().length(24).optional().describe('Optional predefined-workout template id to attach')
+    }
+  }, withScope(scopes, WRITE, (args) =>
+    runTool(calendarController.createEvent, { user, body: args })
+  ));
+
+  server.registerTool('update_calendar_event', {
+    title: 'Update or reschedule calendar event',
+    description: 'Update a calendar event by id. If only the date changes, the event is rescheduled to that date.',
+    inputSchema: {
+      id: z.string().length(24),
+      date: z.string().optional().describe('New ISO date to reschedule to'),
+      title: z.string().optional(),
+      type: z.enum(EVENT_TYPES).optional(),
+      status: z.enum(EVENT_STATUSES).optional(),
+      notes: z.string().optional()
+    }
+  }, withScope(scopes, WRITE, (args) => {
+    const { id, ...changes } = args;
+    const keys = Object.keys(changes);
+    // Date-only change → use the dedicated reschedule (move) handler.
+    if (keys.length === 1 && keys[0] === 'date') {
+      return runTool(calendarController.moveEvent, { user, params: { id }, body: { newDate: changes.date } });
+    }
+    return runTool(calendarController.updateEvent, { user, params: { id }, body: changes });
+  }));
+
+  server.registerTool('delete_calendar_event', {
+    title: 'Delete calendar event',
+    description: 'Delete a calendar event by id.',
+    inputSchema: { id: z.string().length(24) }
+  }, withScope(scopes, WRITE, (args) =>
+    runTool(calendarController.deleteEvent, { user, params: { id: args.id } })
+  ));
+}
+
+module.exports = { register };

--- a/backend/src/mcp/tools/exerciseTools.js
+++ b/backend/src/mcp/tools/exerciseTools.js
@@ -1,0 +1,52 @@
+const { z } = require('zod');
+const exerciseController = require('../../controllers/exerciseController');
+const { runTool } = require('../invoke');
+const { withScope } = require('./util');
+
+// Trim exercise docs to the fields Claude needs to reference/build workouts,
+// keeping tool output token-efficient.
+function trimExercise(ex) {
+  if (!ex || typeof ex !== 'object') return ex;
+  const { _id, name, muscles, secondaryMuscles, discipline, equipment, difficulty, instructions } = ex;
+  return { _id, name, muscles, secondaryMuscles, discipline, equipment, difficulty, instructions };
+}
+
+/**
+ * Register read-only exercise tools. `ctx` = { user, scopes }.
+ */
+function register(server, ctx) {
+  const { user, scopes } = ctx;
+  const READ = 'exercises:read';
+
+  server.registerTool('search_exercises', {
+    title: 'Search exercises',
+    description: 'Search the exercise library by name, muscle group, discipline, equipment or difficulty. Returns exerciseIds usable in create_workout.',
+    inputSchema: {
+      search: z.string().optional().describe('Free-text match on exercise name'),
+      muscle: z.string().optional().describe('Comma-separated muscle groups, e.g. "chest,triceps"'),
+      discipline: z.string().optional().describe('Comma-separated disciplines'),
+      equipment: z.string().optional().describe('Comma-separated equipment, or "none" for bodyweight'),
+      difficulty: z.enum(['beginner', 'intermediate', 'advanced']).optional(),
+      page: z.number().int().min(1).optional(),
+      limit: z.number().int().min(1).max(25).optional()
+    }
+  }, withScope(scopes, READ, (args) =>
+    runTool(
+      exerciseController.getExercises,
+      { user, query: { limit: 25, ...args } },
+      { transform: (data) => (data && Array.isArray(data.exercises)
+        ? { ...data, exercises: data.exercises.map(trimExercise) }
+        : data) }
+    )
+  ));
+
+  server.registerTool('get_exercise', {
+    title: 'Get exercise',
+    description: 'Get a single exercise by id, including instructions and target muscles.',
+    inputSchema: { id: z.string().length(24) }
+  }, withScope(scopes, READ, (args) =>
+    runTool(exerciseController.getExercise, { user, params: { id: args.id } }, { transform: trimExercise })
+  ));
+}
+
+module.exports = { register };

--- a/backend/src/mcp/tools/util.js
+++ b/backend/src/mcp/tools/util.js
@@ -1,0 +1,21 @@
+/**
+ * Shared helpers for MCP tool modules.
+ */
+
+// Return an MCP tool-error result when the token lacks a required scope.
+function scopeError(scope) {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: `Error: this connector is not authorized for "${scope}".` }]
+  };
+}
+
+// Guard a tool handler behind a required scope.
+function withScope(scopes, required, handler) {
+  return async (args, extra) => {
+    if (!scopes.includes(required)) return scopeError(required);
+    return handler(args, extra);
+  };
+}
+
+module.exports = { scopeError, withScope };

--- a/backend/src/mcp/tools/workoutTools.js
+++ b/backend/src/mcp/tools/workoutTools.js
@@ -1,0 +1,116 @@
+const { z } = require('zod');
+const workoutController = require('../../controllers/workoutController');
+const { validateWorkout } = require('../../middleware/validation');
+const { runTool } = require('../invoke');
+const { withScope } = require('./util');
+
+const WORKOUT_TYPES = ['strength', 'cardio', 'hybrid', 'recovery', 'hiit', 'flexibility', 'calisthenics', 'mobility'];
+const STATUSES = ['planned', 'in_progress', 'completed', 'skipped'];
+
+const setSchema = z.object({
+  targetReps: z.number().optional(),
+  actualReps: z.number().optional(),
+  weight: z.number().optional().describe('kg'),
+  time: z.number().optional().describe('seconds'),
+  distance: z.number().optional().describe('meters'),
+  rpe: z.number().int().min(1).max(10).optional(),
+  restSeconds: z.number().optional(),
+  notes: z.string().optional(),
+  isCompleted: z.boolean().optional()
+});
+
+const exerciseSchema = z.object({
+  exerciseId: z.string().length(24).optional().describe('MongoDB ObjectId of an exercise (from search_exercises)'),
+  exerciseName: z.string().describe('Exercise name (required)'),
+  order: z.number().int().optional(),
+  sets: z.array(setSchema).optional(),
+  notes: z.string().optional()
+});
+
+/**
+ * Register workout tools. `ctx` = { user, scopes }.
+ */
+function register(server, ctx) {
+  const { user, scopes } = ctx;
+  const READ = 'workouts:read';
+  const WRITE = 'workouts:write';
+
+  server.registerTool('list_workouts', {
+    title: 'List workouts',
+    description: "List the user's workouts, most recent first. Optionally filter by date range, status, or type.",
+    inputSchema: {
+      startDate: z.string().optional().describe('ISO date, inclusive lower bound (e.g. 2026-07-01)'),
+      endDate: z.string().optional().describe('ISO date, inclusive upper bound'),
+      status: z.enum(STATUSES).optional(),
+      type: z.enum(WORKOUT_TYPES).optional(),
+      page: z.number().int().min(1).optional(),
+      limit: z.number().int().min(1).max(50).optional()
+    }
+  }, withScope(scopes, READ, (args) =>
+    runTool(workoutController.getWorkouts, { user, query: args })
+  ));
+
+  server.registerTool('get_workout', {
+    title: 'Get workout',
+    description: 'Get a single workout by its id, including exercises and sets.',
+    inputSchema: { id: z.string().length(24).describe('Workout id') }
+  }, withScope(scopes, READ, (args) =>
+    runTool(workoutController.getWorkout, { user, params: { id: args.id } })
+  ));
+
+  server.registerTool('get_workout_stats', {
+    title: 'Get workout stats',
+    description: 'Aggregate workout statistics (totals, completion, average duration) over the last N days.',
+    inputSchema: { days: z.number().int().min(1).max(365).optional().describe('Look-back window, default 30') }
+  }, withScope(scopes, READ, (args) =>
+    runTool(workoutController.getWorkoutStats, { user, query: args })
+  ));
+
+  server.registerTool('create_workout', {
+    title: 'Create workout',
+    description: 'Create a new workout for the user. Use search_exercises to find exerciseIds; exerciseName is required per exercise.',
+    inputSchema: {
+      title: z.string().min(2).max(100),
+      date: z.string().describe('ISO date/datetime for the workout'),
+      type: z.enum(WORKOUT_TYPES),
+      status: z.enum(STATUSES).optional(),
+      durationMinutes: z.number().optional(),
+      notes: z.string().optional(),
+      exercises: z.array(exerciseSchema).optional()
+    }
+  }, withScope(scopes, WRITE, (args) =>
+    runTool(workoutController.createWorkout, { user, body: args }, { validators: validateWorkout })
+  ));
+
+  server.registerTool('update_workout', {
+    title: 'Update workout',
+    description: 'Update an existing workout by id. Provide only the fields to change (title/date/type/status are validated).',
+    inputSchema: {
+      id: z.string().length(24),
+      title: z.string().min(2).max(100).optional(),
+      date: z.string().optional(),
+      type: z.enum(WORKOUT_TYPES).optional(),
+      status: z.enum(STATUSES).optional(),
+      durationMinutes: z.number().optional(),
+      notes: z.string().optional(),
+      exercises: z.array(exerciseSchema).optional()
+    }
+  }, withScope(scopes, WRITE, (args) => {
+    // No express-validator chain here: the controller applies a partial
+    // findByIdAndUpdate with mongoose runValidators, and validateWorkout would
+    // wrongly require title/date/type on a partial update. Enum/range
+    // constraints are enforced by the zod schema above and the Mongoose schema.
+    const { id, ...body } = args;
+    return runTool(workoutController.updateWorkout, { user, params: { id }, body });
+  }));
+
+  server.registerTool('delete_workout', {
+    title: 'Delete workout',
+    description: 'Delete a workout by id.',
+    inputSchema: { id: z.string().length(24) }
+  }, withScope(scopes, WRITE, (args) =>
+    runTool(workoutController.deleteWorkout, { user, params: { id: args.id } })
+  ));
+}
+
+module.exports = { register };

--- a/backend/src/models/OAuthAuthorizationCode.js
+++ b/backend/src/models/OAuthAuthorizationCode.js
@@ -1,0 +1,63 @@
+const mongoose = require('mongoose');
+
+/**
+ * Short-lived OAuth authorization code (RFC 6749 + PKCE RFC 7636).
+ * The plaintext code is never stored — only its SHA-256 hash. Codes are
+ * single-use: `usedAt` is stamped on redemption, and any reuse revokes the
+ * tokens minted from it (token theft response).
+ */
+const oauthAuthorizationCodeSchema = new mongoose.Schema({
+  codeHash: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  clientId: {
+    type: String,
+    required: true
+  },
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  redirectUri: {
+    type: String,
+    required: true
+  },
+  // PKCE S256 challenge; verified against the code_verifier at token exchange.
+  codeChallenge: {
+    type: String,
+    required: true
+  },
+  scope: {
+    type: [String],
+    default: []
+  },
+  // RFC 8707 resource indicator, if the client sent one.
+  resource: {
+    type: String,
+    default: null
+  },
+  usedAt: {
+    type: Date,
+    default: null
+  },
+  // familyId of tokens minted from this code, so reuse can revoke them.
+  issuedTokenFamilyId: {
+    type: String,
+    default: null
+  },
+  expiresAt: {
+    type: Date,
+    required: true
+  }
+}, {
+  timestamps: true
+});
+
+// TTL index: MongoDB removes the document once `expiresAt` passes.
+oauthAuthorizationCodeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = mongoose.model('OAuthAuthorizationCode', oauthAuthorizationCodeSchema);

--- a/backend/src/models/OAuthClient.js
+++ b/backend/src/models/OAuthClient.js
@@ -1,0 +1,61 @@
+const mongoose = require('mongoose');
+
+/**
+ * OAuth client registered via Dynamic Client Registration (RFC 7591).
+ * Claude registers itself as a public client (token_endpoint_auth_method: 'none')
+ * on each fresh connection. We store the client so subsequent token/refresh
+ * requests can be validated against its redirect URIs.
+ */
+const oauthClientSchema = new mongoose.Schema({
+  clientId: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  // Only set for confidential clients. Claude connects as a public client and
+  // has no secret; we never store plaintext secrets.
+  clientSecretHash: {
+    type: String,
+    default: null
+  },
+  clientName: {
+    type: String,
+    default: null
+  },
+  redirectUris: {
+    type: [String],
+    required: true,
+    validate: {
+      validator: (uris) => Array.isArray(uris) && uris.length > 0,
+      message: 'At least one redirect URI is required'
+    }
+  },
+  grantTypes: {
+    type: [String],
+    default: ['authorization_code', 'refresh_token']
+  },
+  responseTypes: {
+    type: [String],
+    default: ['code']
+  },
+  tokenEndpointAuthMethod: {
+    type: String,
+    default: 'none'
+  },
+  scope: {
+    type: String,
+    default: null
+  },
+  clientIdIssuedAt: {
+    type: Number // epoch seconds, per RFC 7591
+  },
+  lastUsedAt: {
+    type: Date,
+    default: Date.now
+  }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('OAuthClient', oauthClientSchema);

--- a/backend/src/models/OAuthPendingAuthorization.js
+++ b/backend/src/models/OAuthPendingAuthorization.js
@@ -1,0 +1,53 @@
+const mongoose = require('mongoose');
+
+/**
+ * Bridges the Google-login hop during the OAuth authorize flow. When a user
+ * chooses "Continue with Google" on the consent page, we can't carry the
+ * authorize parameters through the Google round-trip, so we persist them here
+ * keyed by `requestId` (passed as the OAuth `state` to Google as `mcp:<id>`).
+ * After Google auth completes, the callback loads this record to render the
+ * consent page for the now-authenticated user.
+ */
+const oauthPendingAuthorizationSchema = new mongoose.Schema({
+  requestId: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  clientId: {
+    type: String,
+    required: true
+  },
+  redirectUri: {
+    type: String,
+    required: true
+  },
+  codeChallenge: {
+    type: String,
+    required: true
+  },
+  state: {
+    type: String,
+    default: null
+  },
+  scope: {
+    type: [String],
+    default: []
+  },
+  resource: {
+    type: String,
+    default: null
+  },
+  expiresAt: {
+    type: Date,
+    required: true
+  }
+}, {
+  timestamps: true
+});
+
+// TTL index: pending authorizations expire quickly (10 min).
+oauthPendingAuthorizationSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = mongoose.model('OAuthPendingAuthorization', oauthPendingAuthorizationSchema);

--- a/backend/src/models/OAuthToken.js
+++ b/backend/src/models/OAuthToken.js
@@ -1,0 +1,66 @@
+const mongoose = require('mongoose');
+
+/**
+ * MCP access and refresh tokens for the OAuth flow. Stored hashed (SHA-256),
+ * never plaintext. These are deliberately distinct from the app's login JWTs:
+ * an MCP token is an opaque random string that can never validate as a JWT
+ * (and vice versa), and it is scope-limited and independently revocable.
+ *
+ * Refresh tokens are rotated on use. All tokens minted from a single
+ * authorization code share a `familyId`; detecting reuse of a rotated refresh
+ * token revokes the entire family.
+ */
+const oauthTokenSchema = new mongoose.Schema({
+  tokenHash: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  kind: {
+    type: String,
+    enum: ['access', 'refresh'],
+    required: true
+  },
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  clientId: {
+    type: String,
+    required: true
+  },
+  scope: {
+    type: [String],
+    default: []
+  },
+  familyId: {
+    type: String,
+    required: true,
+    index: true
+  },
+  resource: {
+    type: String,
+    default: null
+  },
+  // For refresh tokens: set when the token has been rotated (consumed). The
+  // record is kept (until its TTL removes it) so a later replay of the spent
+  // token can be detected as reuse and revoke the whole family.
+  rotatedAt: {
+    type: Date,
+    default: null
+  },
+  expiresAt: {
+    type: Date,
+    required: true
+  }
+}, {
+  timestamps: true
+});
+
+// TTL index: expired tokens are removed automatically.
+oauthTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = mongoose.model('OAuthToken', oauthTokenSchema);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -4,6 +4,7 @@ const { register, login, getProfile, updateProfile } = require('../controllers/a
 const { auth } = require('../middleware/auth');
 const { validateRegister, validateLogin } = require('../middleware/validation');
 const passport = require('../config/passport');
+const { renderGoogleConsentAfterAuth } = require('../mcp/consentController');
 
 // @route   POST /api/v1/auth/register
 // @desc    Register a new user
@@ -28,7 +29,14 @@ router.put('/profile', auth, updateProfile);
 // @route   GET /api/v1/auth/google
 // @desc    Initiate Google OAuth login
 // @access  Public
-router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+// Forwards an optional `state` param (e.g. `mcp:<requestId>` for the MCP
+// connector consent flow) through the Google round-trip.
+router.get('/google', (req, res, next) =>
+  passport.authenticate('google', {
+    scope: ['profile', 'email'],
+    state: req.query.state
+  })(req, res, next)
+);
 
 // @route   GET /api/v1/auth/google/callback
 // @desc    Google OAuth callback
@@ -43,7 +51,16 @@ router.get('/google/callback',
         console.error('No user object after Google authentication');
         return res.redirect(`${process.env.FRONTEND_URL || 'http://localhost:3000'}/auth?error=no_user`);
       }
-      
+
+      // MCP connector consent flow: if state is `mcp:<requestId>`, render the
+      // connector consent page for this now-authenticated user instead of
+      // redirecting to the SPA with a login JWT.
+      const state = req.query.state;
+      if (typeof state === 'string' && state.startsWith('mcp:')) {
+        const requestId = state.slice('mcp:'.length);
+        return await renderGoogleConsentAfterAuth(req, res, requestId);
+      }
+
       // Generate JWT token for the authenticated user
       const token = req.user.generateToken();
       console.log('JWT token generated successfully');

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -1,0 +1,84 @@
+/**
+ * The MCP endpoint: Streamable HTTP transport at POST /mcp, behind OAuth bearer
+ * auth. Run statelessly (a fresh McpServer + transport per request) so the
+ * connector survives server restarts with no session store.
+ *
+ * This router carries ONLY the JSON-RPC endpoint — the consent/OAuth routes
+ * live elsewhere (/oauth/consent, /authorize, ...) so nothing unauthenticated
+ * shares this prefix.
+ */
+
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+const { requireBearerAuth } = require('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
+
+const User = require('../models/User');
+const { provider } = require('../mcp/authProvider');
+const { buildMcpServer } = require('../mcp/server');
+const { RESOURCE_METADATA_URL } = require('../mcp/config');
+
+const router = express.Router();
+
+// Generous per-IP limit: a single Claude conversation can fire many tool calls.
+const mcpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { jsonrpc: '2.0', error: { code: -32000, message: 'Rate limit exceeded' }, id: null }
+});
+
+const bearerAuth = requireBearerAuth({
+  verifier: provider,
+  resourceMetadataUrl: RESOURCE_METADATA_URL
+});
+
+function methodNotAllowed(req, res) {
+  res.status(405).json({
+    jsonrpc: '2.0',
+    error: { code: -32000, message: 'Method not allowed. Use POST for the MCP endpoint.' },
+    id: null
+  });
+}
+
+router.post('/', mcpLimiter, bearerAuth, async (req, res) => {
+  try {
+    const userId = req.auth && req.auth.extra && req.auth.extra.userId;
+    const user = userId ? await User.findById(userId) : null;
+    if (!user) {
+      return res.status(401).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Unknown or deleted user' },
+        id: null
+      });
+    }
+
+    const server = buildMcpServer(user, req.auth.scopes || []);
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+
+    // Tear down per-request server + transport when the response closes.
+    res.on('close', () => {
+      transport.close().catch(() => {});
+      server.close().catch(() => {});
+    });
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (err) {
+    console.error('MCP request error:', err);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: { code: -32603, message: 'Internal server error' },
+        id: null
+      });
+    }
+  }
+});
+
+// Stateless server: no long-lived SSE stream or session to GET/DELETE.
+router.get('/', methodNotAllowed);
+router.delete('/', methodNotAllowed);
+
+module.exports = router;

--- a/backend/src/routes/mcpAuth.js
+++ b/backend/src/routes/mcpAuth.js
@@ -1,0 +1,62 @@
+/**
+ * OAuth authorization-server routes for the MCP connector. Mounted at the app
+ * ROOT (not under /api/v1) because OAuth discovery documents are origin-rooted
+ * (`/.well-known/*`) and Claude expects the endpoints at the issuer origin.
+ *
+ * Provides (via the SDK's mcpAuthRouter):
+ *   /.well-known/oauth-authorization-server   (RFC 8414, advertises S256)
+ *   /.well-known/oauth-protected-resource/mcp (RFC 9728)
+ *   /authorize  /token  /register  /revoke
+ * Plus a bare-path PRM alias and the /oauth/consent/* handlers.
+ */
+
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const { mcpAuthRouter } = require('@modelcontextprotocol/sdk/server/auth/router.js');
+
+const { provider, SCOPES } = require('../mcp/authProvider');
+const { MCP_BASE_URL, MCP_RESOURCE_URL } = require('../mcp/config');
+const consentController = require('../mcp/consentController');
+
+const router = express.Router();
+
+// SDK router: metadata + /authorize + /token + /register + /revoke.
+router.use(
+  mcpAuthRouter({
+    provider,
+    issuerUrl: new URL(MCP_BASE_URL),
+    resourceServerUrl: new URL(MCP_RESOURCE_URL),
+    scopesSupported: SCOPES,
+    resourceName: 'SynergyFit'
+  })
+);
+
+// Bare-path protected-resource metadata alias. Claude probes the path-suffixed
+// URL first (served by the SDK above), then this bare path; other clients may
+// only try the bare path. The `resource` value still points at `${origin}/mcp`.
+router.get('/.well-known/oauth-protected-resource', (req, res) => {
+  res.json({
+    resource: MCP_RESOURCE_URL,
+    // Must exactly match the issuer the SDK advertises (its metadata uses the
+    // normalized URL href, i.e. with a trailing slash), so Claude resolves the
+    // same authorization server whichever PRM document it reads.
+    authorization_servers: [new URL(MCP_BASE_URL).href],
+    scopes_supported: SCOPES,
+    resource_name: 'SynergyFit'
+  });
+});
+
+// Consent POSTs: modest per-IP limit (the SDK already rate-limits its own
+// /authorize, /token, /register endpoints).
+const consentLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: 'Too many requests, please try again later.'
+});
+
+router.post('/oauth/consent/approve', consentLimiter, consentController.approve);
+router.post('/oauth/consent/deny', consentLimiter, consentController.deny);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -54,6 +54,8 @@ const integrationRoutes = require('./routes/integrations');
 const webhookRoutes = require('./routes/webhooks');
 const workoutLogRoutes = require('./routes/workoutLogs');
 const trainNowRoutes = require('./routes/trainNow');
+const mcpAuthRoutes = require('./routes/mcpAuth');
+const mcpRoutes = require('./routes/mcp');
 
 // Log Strava config on startup (helps debug production issues)
 console.log('==============================================');
@@ -132,32 +134,44 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 // CORS configuration
-const allowedOrigins = process.env.ALLOWED_ORIGINS 
-  ? process.env.ALLOWED_ORIGINS.split(',') 
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',')
   : [process.env.FRONTEND_URL || 'http://localhost:5173'];
 
-app.use(cors({
-  origin: (origin, callback) => {
-    // Allow requests with no origin (mobile apps, curl, etc.)
-    if (!origin) return callback(null, true);
-    
-    if (allowedOrigins.includes(origin)) {
-      return callback(null, true);
-    }
-    
-    const msg = `CORS policy violation: Origin ${origin} not allowed`;
-    logger.warn(msg);
-    return callback(new Error(msg), false);
-  },
-  credentials: true,
-  optionsSuccessStatus: 200 // Support legacy browsers
+// MCP connector + OAuth paths are public API surfaces (Claude calls them
+// server-side; MCP Inspector and other browser clients call them cross-origin).
+// They must not go through the SPA origin allowlist.
+const MCP_PUBLIC_PREFIXES = ['/mcp', '/.well-known', '/authorize', '/token', '/register', '/revoke', '/oauth/consent'];
+const isMcpPublicPath = (path) =>
+  MCP_PUBLIC_PREFIXES.some((p) => path === p || path.startsWith(p + '/'));
+
+app.use(cors((req, callback) => {
+  // Permissive CORS for MCP/OAuth endpoints; expose WWW-Authenticate so browser
+  // clients can read the 401 challenge.
+  if (isMcpPublicPath(req.path)) {
+    return callback(null, {
+      origin: true,
+      credentials: false,
+      exposedHeaders: ['WWW-Authenticate'],
+      optionsSuccessStatus: 200
+    });
+  }
+
+  // Existing SPA behaviour for all other paths.
+  const origin = req.header('Origin');
+  if (!origin || allowedOrigins.includes(origin)) {
+    return callback(null, { origin: true, credentials: true, optionsSuccessStatus: 200 });
+  }
+  const msg = `CORS policy violation: Origin ${origin} not allowed`;
+  logger.warn(msg);
+  return callback(new Error(msg), { credentials: true, optionsSuccessStatus: 200 });
 }));
 
 // Compression middleware - skip for SSE streaming endpoints
 app.use(compression({
   filter: (req, res) => {
-    // Don't compress SSE/streaming responses
-    if (req.path === '/api/v1/ai/stream' || req.headers['x-no-compression']) {
+    // Don't compress SSE/streaming responses (AI stream + MCP Streamable HTTP)
+    if (req.path === '/api/v1/ai/stream' || req.path === '/mcp' || req.headers['x-no-compression']) {
       return false;
     }
     return compression.filter(req, res);
@@ -265,6 +279,11 @@ app.use('/api/v1/integrations', integrationRoutes);
 app.use('/api/v1/webhooks', webhookRoutes);
 app.use('/api/v1/workout-logs', workoutLogRoutes);
 app.use('/api/v1/train-now', trainNowRoutes);
+
+// MCP connector: OAuth authorization-server routes (mounted at root — the
+// `.well-known` discovery documents are origin-rooted) and the /mcp endpoint.
+app.use(mcpAuthRoutes);
+app.use('/mcp', mcpRoutes);
 
 // Error handling middleware
 app.use((err, req, res, next) => {

--- a/backend/src/utils/ensureIndexes.js
+++ b/backend/src/utils/ensureIndexes.js
@@ -14,6 +14,10 @@ const Workout = require('../models/Workout');
 const Plan = require('../models/Plan');
 const Goal = require('../models/Goal');
 const User = require('../models/User');
+const OAuthClient = require('../models/OAuthClient');
+const OAuthAuthorizationCode = require('../models/OAuthAuthorizationCode');
+const OAuthToken = require('../models/OAuthToken');
+const OAuthPendingAuthorization = require('../models/OAuthPendingAuthorization');
 
 /**
  * Ensure all collection indexes are created
@@ -32,7 +36,11 @@ async function ensureIndexes(logger) {
       { name: 'Workout', model: Workout },
       { name: 'Plan', model: Plan },
       { name: 'Goal', model: Goal },
-      { name: 'User', model: User }
+      { name: 'User', model: User },
+      { name: 'OAuthClient', model: OAuthClient },
+      { name: 'OAuthAuthorizationCode', model: OAuthAuthorizationCode },
+      { name: 'OAuthToken', model: OAuthToken },
+      { name: 'OAuthPendingAuthorization', model: OAuthPendingAuthorization }
     ];
 
     const results = [];

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Camera, Moon, Sun, Loader2, Brain, Link, Unlink, RefreshCw, CheckCircle, AlertCircle, Trash2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Camera, Moon, Sun, Loader2, Brain, Link, Unlink, RefreshCw, CheckCircle, AlertCircle, Trash2, Copy, Sparkles } from 'lucide-react';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Switch } from '@/components/ui/switch';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -678,6 +678,37 @@ export default function Settings() {
                       Connect
                     </button>
                   )}
+                </div>
+              </div>
+            </div>
+
+            {/* Claude Connector (MCP) */}
+            <div className="py-4 border-b border-gray-100 dark:border-gray-800">
+              <div className="flex items-start gap-3">
+                <div className="p-2 rounded-lg bg-primary-100 dark:bg-primary-900/30">
+                  <Sparkles className="w-5 h-5 text-primary-500 dark:text-primary-400" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-bold text-gray-500 dark:text-gray-400 tracking-wide">
+                    Claude (Model Context Protocol)
+                  </p>
+                  <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+                    Manage your workouts from Claude on any device. In Claude, open
+                    Settings → Connectors → Add custom connector, then paste this URL
+                    and sign in with your SynergyFit account:
+                  </p>
+                  <div className="mt-3 flex items-center gap-2">
+                    <code className="flex-1 px-3 py-2 text-xs bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-900 dark:text-white overflow-x-auto whitespace-nowrap">
+                      {`${import.meta.env.VITE_API_URL || 'http://localhost:5001'}/mcp`}
+                    </code>
+                    <button
+                      onClick={() => navigator.clipboard?.writeText(`${import.meta.env.VITE_API_URL || 'http://localhost:5001'}/mcp`)}
+                      className="p-2 text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-900/50 transition-colors"
+                      title="Copy connector URL"
+                    >
+                      <Copy className="w-4 h-4" />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/render.yaml
+++ b/render.yaml
@@ -48,8 +48,24 @@ services:
         value: true
       - key: APP_VERSION
         value: 1.0.0
+      # MCP connector (Claude custom connector). MCP_BASE_URL must equal this
+      # service's public origin; the connector URL users add is ${MCP_BASE_URL}/mcp.
+      - key: MCP_BASE_URL
+        sync: false  # e.g. https://synergyfit-api.onrender.com
+      - key: MCP_CONSENT_TICKET_SECRET
+        sync: false  # distinct secret for signing consent tickets
+      - key: MCP_ACCESS_TOKEN_TTL_SECONDS
+        value: 3600
+      - key: MCP_REFRESH_TOKEN_TTL_SECONDS
+        value: 2592000
+      - key: MCP_AUTH_CODE_TTL_SECONDS
+        value: 600
+    # NOTE: the `free` plan spins down on idle; cold starts can exceed Claude's
+    # ~10s OAuth-endpoint timeout and cause intermittent connector-setup
+    # failures. Upgrade to `starter`, or keep the service warm with an external
+    # pinger hitting /api/v1/health every few minutes.
 
-  # Frontend Static Site  
+  # Frontend Static Site
   - type: static
     name: synergyfit-app
     buildCommand: npm install --prefix frontend && npm run build --prefix frontend


### PR DESCRIPTION
## What & why
Adds a remote **MCP server** inside the existing Express backend so each user can connect **Claude** (claude.ai custom connector, including the mobile app) to view and modify their own workouts, training calendar, and search exercises — usable now, ahead of the `ai-coach-service` build-out.

## How it works
- **OAuth 2.0 authorization server** via `@modelcontextprotocol/sdk` 1.29 — Dynamic Client Registration + PKCE S256, authorization-code + refresh grants. Users add the connector URL in Claude, tap Connect, and sign in with their existing SynergyFit account (email/password **or** Google) on a server-rendered consent page. No manual tokens.
- **Opaque tokens** stored hashed (SHA-256) with Mongo TTL indexes; refresh-token **rotation + family revocation on reuse**. MCP tokens are structurally distinct from app login JWTs (verified: each is rejected by the other's surface).
- **Streamable HTTP** endpoint at `POST /mcp` (stateless), behind bearer auth returning the spec-compliant 401 challenge.
- **12 tools** (workouts CRUD + stats, calendar CRUD/reschedule, read-only exercise search) that **reuse existing controllers in-process** via a validator-aware bridge — no duplicated CRUD/validation logic.

## Config needed on the Render backend service
| Var | Required | Value |
|---|---|---|
| `MCP_BASE_URL` | **Yes** | `https://synergyfit-api.onrender.com` (bare origin, no `/api/v1`) |
| `MCP_CONSENT_TICKET_SECRET` | **Yes (secret)** | new random string (falls back to `JWT_SECRET`) |
| `MCP_ACCESS_TOKEN_TTL_SECONDS` / `_REFRESH_` / `_AUTH_CODE_` | No | have defaults |

Connector URL users paste into Claude: `https://synergyfit-api.onrender.com/mcp`. No new Google OAuth app/redirect, no DB migration (collections auto-create with TTL indexes).

⚠️ Render **free** plan spins down on idle; cold starts can exceed Claude's ~10s OAuth timeout → intermittent connect failures. Consider `starter` or an external keep-alive pinger on `/api/v1/health`.

## Verification
- Jest unit tests for the controller bridge (9/9).
- Automated end-to-end against an in-memory Mongo (20/20): full DCR → authorize → consent → token exchange, stateless `tools/list` (12 tools) + `tools/call`, express-validator error mapping, token isolation from the JWT API, and refresh rotation + reuse → family revocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)