### PR TITLE
feat(ai-coach): skill registry infra + schedule_plan_to_calendar; disable over-firing reflection

### DIFF
--- a/ai-coach-service/app/api/v1/chat.py
+++ b/ai-coach-service/app/api/v1/chat.py
@@ -49,7 +49,7 @@ async def chat(
             action=result.get("action"),
             confidence=result.get("confidence", 0.8),
             suggestions=result.get("data", {}).get("suggestion", []) if isinstance(result.get("data", {}).get("suggestion"), list) else None,
-            disclaimer="Remember to consult with a healthcare professional before starting any new fitness program."
+            disclaimer=None,
         )
         
         # Add pending change information if this is a CRUD proposal

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -27,6 +27,12 @@ from app.core.agents.services import (
     SearchService,
     MemoryService,
 )
+# Importing the skills package registers every skill via the @skill decorator.
+from app.core.agents.skills import (
+    SkillContext,
+    get_skill_definitions,
+    get_skill_handler,
+)
 
 logger = structlog.get_logger()
 
@@ -52,8 +58,21 @@ class AgentOrchestrator:
         self.search_service = SearchService(self.settings.tavily_api_key)
         self.memory_service = MemoryService(db)
 
+        # Shared context handed to every registered skill handler.
+        self.skill_context = SkillContext(
+            db=self.db,
+            settings=self.settings,
+            exercise_service=self.exercise_service,
+            workout_service=self.workout_service,
+            plan_service=self.plan_service,
+            goal_service=self.goal_service,
+            calendar_service=self.calendar_service,
+            search_service=self.search_service,
+            memory_service=self.memory_service,
+        )
+
         # Log configuration
-        tools = get_all_tools()
+        tools = self.get_tools()
         logger.info(
             "AgentOrchestrator initialized",
             model=self.settings.openai_model,
@@ -71,8 +90,18 @@ class AgentOrchestrator:
         )
         
     def get_tools(self) -> List[Dict[str, Any]]:
-        """Define available tools for the LLM - comprehensive fitness management"""
-        return get_all_tools()
+        """Available tools for the LLM: legacy tool_definitions + registered skills.
+
+        Skills take precedence: if a skill shares a name with a legacy tool, the
+        legacy definition is dropped so the tool isn't listed twice.
+        """
+        skill_definitions = get_skill_definitions()
+        skill_names = {d["function"]["name"] for d in skill_definitions}
+        legacy_tools = [
+            t for t in get_all_tools()
+            if t["function"]["name"] not in skill_names
+        ]
+        return legacy_tools + skill_definitions
 
 
     async def process_request(
@@ -865,6 +894,12 @@ USER DATA:
 
     async def _execute_tool(self, user_id: str, function_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Route tool calls to appropriate service handlers"""
+        # Registered skills take precedence over legacy tools.
+        skill_handler = get_skill_handler(function_name)
+        if skill_handler:
+            logger.info("Executing skill", skill=function_name)
+            return await skill_handler(self.skill_context, user_id, args)
+
         tool_handlers = {
             # Exercise tools
             "add_exercise": self.exercise_service.add_exercise,

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -45,7 +45,8 @@ WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I 
 - `list_goals`: View user's goals.
 
 **Calendar** (Scheduling workouts):
-- `schedule_to_calendar`: Schedule a workout or event to a specific date. Use this when user wants to add a workout to their calendar. Supports 'today', 'tomorrow', or ISO dates.
+- `schedule_to_calendar`: Schedule a SINGLE workout or event to a specific date. Use this for one-off scheduling. Supports 'today', 'tomorrow', or ISO dates.
+- `schedule_plan_to_calendar`: Schedule an ENTIRE multi-week plan (or several weeks of it) in ONE call. Whenever the user wants a whole plan put on the calendar, use this — never place plan workouts day-by-day with repeated `schedule_to_calendar` calls. It defaults to a dry-run PREVIEW that writes nothing; show the user the preview, and only after they confirm, call it again with `dry_run=false` to actually write the events.
 - `get_calendar_events`: Check what's already scheduled on the user's calendar.
 
 **Web Search & Research** (External resources):

--- a/ai-coach-service/app/core/agents/reflection_config.py
+++ b/ai-coach-service/app/core/agents/reflection_config.py
@@ -4,8 +4,11 @@ All reflection-related constants are centralized here.
 """
 
 REFLECTION_CONFIG = {
-    # Feature flag - set to False for initial deployment
-    "enabled": True,
+    # Feature flag - disabled: the reflection pass was replacing good answers
+    # with generic "provide your equipment info" messages (over-triggering on
+    # content patterns like "reps"/"warm-up"). Re-enable only after the trigger
+    # and revision logic are reworked.
+    "enabled": False,
 
     # Model selection (cheaper model for reflection to reduce cost)
     "model": "gpt-4o-mini",

--- a/ai-coach-service/app/core/agents/skills/README.md
+++ b/ai-coach-service/app/core/agents/skills/README.md
@@ -1,0 +1,59 @@
+# AI Coach Skills
+
+A **skill** is a self-contained tool for the AI coach: its OpenAI function
+definition and its async handler live in one file and register themselves.
+
+This replaces the legacy three-step process (schema dict in
+`tool_definitions/*.py` + handler method on a service + routing entry in
+`orchestrator._execute_tool`). Skills registered here are picked up
+automatically — the orchestrator merges them into `get_tools()` and routes
+execution to them in `_execute_tool` (registry takes precedence over legacy
+tools with the same name).
+
+## How to add a skill (one file)
+
+1. Copy `example_skill.py` to `your_skill.py`.
+2. Set `name`, `description`, and a JSON-Schema `parameters` object in the
+   `@skill(...)` decorator.
+3. Implement the async handler:
+
+   ```python
+   from app.core.agents.skills.registry import SkillContext, skill
+
+   @skill(
+       name="my_skill",
+       description="What it does and when to use it.",
+       parameters={
+           "type": "object",
+           "properties": {"foo": {"type": "string"}},
+           "required": ["foo"],
+       },
+   )
+   async def my_skill(ctx: SkillContext, user_id: str, args: dict) -> dict:
+       # ctx.db, ctx.settings, and every service (ctx.plan_service,
+       # ctx.calendar_service, ctx.goal_service, ...) are available.
+       return {"success": True, "message": "done"}
+   ```
+
+4. Add the import to the "Register skill modules" block in `__init__.py`:
+
+   ```python
+   from app.core.agents.skills import my_skill  # noqa: F401,E402
+   ```
+
+That's it — no orchestrator changes needed.
+
+## Handler contract
+
+- Signature: `async def handler(ctx: SkillContext, user_id: str, args: dict) -> dict`
+- Return a dict; convention is `{"success": bool, "message": str, ...}` so the
+  model can report the outcome (matches the legacy tool handlers).
+- `ctx` (`SkillContext`) exposes `db`, `settings`, and all existing services, so a
+  skill can hit Mongo directly or delegate to a service (see `example_skill.py`).
+
+## Notes
+
+- Skill names must be unique within the registry; registering a duplicate raises
+  at import time.
+- A skill whose name matches a legacy tool overrides it (the legacy definition is
+  deduped out of `get_tools()` and execution routes to the skill).

--- a/ai-coach-service/app/core/agents/skills/__init__.py
+++ b/ai-coach-service/app/core/agents/skills/__init__.py
@@ -1,0 +1,32 @@
+"""
+Skills package for the AI coach.
+
+Importing this package registers every skill module (each import triggers the
+@skill decorator side-effect). To add a skill: create a module here and add its
+import to the "Register skill modules" block below.
+"""
+
+from app.core.agents.skills.registry import (  # noqa: F401
+    SkillContext,
+    SkillRegistry,
+    get_skill_definitions,
+    get_skill_handler,
+    get_skill_names,
+    registry,
+    skill,
+)
+
+# ---- Register skill modules (import for decorator side-effects) ----
+# Add one import line per new skill file.
+from app.core.agents.skills import example_skill  # noqa: F401,E402
+from app.core.agents.skills import schedule_plan_skill  # noqa: F401,E402
+
+__all__ = [
+    "SkillContext",
+    "SkillRegistry",
+    "get_skill_definitions",
+    "get_skill_handler",
+    "get_skill_names",
+    "registry",
+    "skill",
+]

--- a/ai-coach-service/app/core/agents/skills/example_skill.py
+++ b/ai-coach-service/app/core/agents/skills/example_skill.py
@@ -1,0 +1,50 @@
+"""
+Example skill — worked reference for the skill registry.
+
+This ports the existing `get_calendar_events` tool to the @skill pattern to prove
+the infrastructure end-to-end and serve as the copy-paste template for new
+skills. It reuses the existing CalendarService via `ctx`, showing that a skill
+can delegate to a service rather than reimplementing logic.
+
+Because this registers the name `get_calendar_events`, the orchestrator treats
+the skill as the source of truth for that tool (it dedupes the legacy definition
+and routes execution to this handler first). Delete this file's import in
+__init__.py to fall back to the legacy tool.
+
+To create a new skill, copy this file, change the name/description/parameters,
+and write the handler body (hit `ctx.db` directly or call a `ctx.*_service`).
+"""
+
+from typing import Any, Dict
+
+from app.core.agents.skills.registry import SkillContext, skill
+
+
+@skill(
+    name="get_calendar_events",
+    description=(
+        "Get the user's scheduled calendar events for a date range. "
+        "Use this to check what workouts are already planned."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "startDate": {
+                "type": "string",
+                "description": "Start date in ISO format (YYYY-MM-DD). Default: today",
+            },
+            "endDate": {
+                "type": "string",
+                "description": "End date in ISO format (YYYY-MM-DD). Default: 7 days from start",
+            },
+            "type": {
+                "type": "string",
+                "enum": ["workout", "rest", "deload", "event"],
+                "description": "Filter by event type",
+            },
+        },
+    },
+)
+async def get_calendar_events(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Delegate to the existing calendar service implementation."""
+    return await ctx.calendar_service.get_calendar_events(user_id, args)

--- a/ai-coach-service/app/core/agents/skills/registry.py
+++ b/ai-coach-service/app/core/agents/skills/registry.py
@@ -1,0 +1,133 @@
+"""
+Skill registry for the AI coach.
+
+A "skill" is a self-contained tool: its OpenAI function definition and its async
+handler live together in one file and register themselves via the @skill
+decorator. This removes the three-places-to-edit friction of the legacy tool
+system (schema dict in tool_definitions/*.py + service method + routing entry in
+orchestrator._execute_tool).
+
+To add a skill: create a module under app/core/agents/skills/, decorate an async
+handler with @skill(...), and import that module in skills/__init__.py. Nothing
+else needs to change - the orchestrator picks it up automatically.
+
+Handler contract:
+    @skill(name="my_skill", description="...", parameters={...json-schema...})
+    async def my_skill(ctx: SkillContext, user_id: str, args: dict) -> dict:
+        ...
+        return {"success": True, "message": "...", ...}
+
+`ctx` gives handlers access to shared resources (db, settings, and the existing
+services) so a skill can either hit Mongo directly or reuse a service method.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:  # avoid import cycles at runtime
+    from motor.motor_asyncio import AsyncIOMotorDatabase
+    from app.config import Settings
+    from app.core.agents.services import (
+        ExerciseService,
+        WorkoutService,
+        PlanService,
+        GoalService,
+        CalendarService,
+        SearchService,
+        MemoryService,
+    )
+
+logger = structlog.get_logger()
+
+# A skill handler: (context, user_id, args) -> result dict
+SkillHandler = Callable[["SkillContext", str, Dict[str, Any]], Awaitable[Dict[str, Any]]]
+
+
+@dataclass
+class SkillContext:
+    """Shared resources handed to every skill handler.
+
+    Lets a skill reach the database, settings, and existing services without
+    re-wiring anything in the orchestrator.
+    """
+
+    db: "AsyncIOMotorDatabase"
+    settings: "Settings"
+    exercise_service: "ExerciseService"
+    workout_service: "WorkoutService"
+    plan_service: "PlanService"
+    goal_service: "GoalService"
+    calendar_service: "CalendarService"
+    search_service: "SearchService"
+    memory_service: "MemoryService"
+
+
+class SkillRegistry:
+    """Holds registered skills: name -> {definition, handler}."""
+
+    def __init__(self) -> None:
+        self._definitions: Dict[str, Dict[str, Any]] = {}
+        self._handlers: Dict[str, SkillHandler] = {}
+
+    def register(
+        self,
+        name: str,
+        description: str,
+        parameters: Dict[str, Any],
+        handler: SkillHandler,
+    ) -> None:
+        if name in self._handlers:
+            raise ValueError(f"Skill '{name}' is already registered")
+
+        self._definitions[name] = {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": parameters,
+            },
+        }
+        self._handlers[name] = handler
+        logger.info("Registered skill", skill=name)
+
+    def get_definitions(self) -> List[Dict[str, Any]]:
+        """OpenAI tool-definition dicts for all registered skills."""
+        return list(self._definitions.values())
+
+    def get_handler(self, name: str) -> Optional[SkillHandler]:
+        return self._handlers.get(name)
+
+    def names(self) -> List[str]:
+        return list(self._handlers.keys())
+
+
+# Module-level singleton - shared across the process.
+registry = SkillRegistry()
+
+
+def skill(name: str, description: str, parameters: Dict[str, Any]) -> Callable[[SkillHandler], SkillHandler]:
+    """Decorator that registers an async handler as a skill.
+
+    The decorated function is returned unchanged so it can still be called or
+    unit-tested directly.
+    """
+
+    def decorator(handler: SkillHandler) -> SkillHandler:
+        registry.register(name, description, parameters, handler)
+        return handler
+
+    return decorator
+
+
+def get_skill_definitions() -> List[Dict[str, Any]]:
+    return registry.get_definitions()
+
+
+def get_skill_handler(name: str) -> Optional[SkillHandler]:
+    return registry.get_handler(name)
+
+
+def get_skill_names() -> List[str]:
+    return registry.names()

--- a/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
@@ -1,0 +1,410 @@
+"""
+Skill: schedule_plan_to_calendar
+
+Expands a whole training plan into calendar events and bulk-inserts them in one
+tool call. This replaces the fragile "one schedule_to_calendar call per event"
+loop that ran out of tool-call budget on multi-week plans.
+
+Safety: dry-run by default. The first call returns a preview and writes nothing;
+after the user confirms, the model re-calls with dry_run=false to write. (The
+legacy structured pending_change flow is dead code, so confirmation is
+conversational — same as every other tool here.)
+
+Idempotency: each event records planId/planWeek/planDay, so re-runs dedup against
+already-scheduled slots instead of duplicating.
+
+Pure helpers (_compute_event_date, _build_events, _parse_volume, ...) take no DB
+and are unit-tested directly.
+"""
+
+import re
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no DB — unit-testable)
+# ---------------------------------------------------------------------------
+
+def _midnight(dt: datetime) -> datetime:
+    """Strip tz + time so all dates compare cleanly at UTC midnight."""
+    if dt.tzinfo is not None:
+        dt = dt.replace(tzinfo=None)
+    return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _parse_start_date(value: Any) -> Optional[datetime]:
+    """Parse a start date. Accepts a datetime, 'today'/'tomorrow', ISO, or
+    YYYY-MM-DD. Returns a naive UTC-midnight datetime, or None if unparseable."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _midnight(value)
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip().lower()
+    if text == "today":
+        return _midnight(datetime.utcnow())
+    if text == "tomorrow":
+        return _midnight(datetime.utcnow() + timedelta(days=1))
+    try:
+        return _midnight(datetime.fromisoformat(value.replace("Z", "+00:00")))
+    except Exception:
+        try:
+            return _midnight(datetime.strptime(value, "%Y-%m-%d"))
+        except Exception:
+            return None
+
+
+def _sunday0(dt: datetime) -> int:
+    """Weekday with Sunday=0..Saturday=6 (matches the plan's dayOfWeek)."""
+    return (dt.weekday() + 1) % 7
+
+
+def _compute_event_date(start_date: datetime, week_number: int, day_of_week: int) -> datetime:
+    """Map (weekNumber, dayOfWeek 0=Sun) onto a concrete date.
+
+    The first occurrence of day_of_week falls on or after start_date, then whole
+    weeks are added. Never produces a date before start_date.
+    """
+    offset = (day_of_week - _sunday0(start_date) + 7) % 7
+    return start_date + timedelta(days=offset + 7 * (week_number - 1))
+
+
+def _parse_volume(volume: Any) -> tuple[int, int]:
+    """Parse a PredefinedWorkout volume string like '3x10' / '3 x 8-12' into
+    (sets, reps). Falls back to (3, 10)."""
+    m = re.match(r"\s*(\d+)\s*[xX]\s*(\d+)", str(volume or ""))
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    return 3, 10
+
+
+def _resolve_workout_content(workout: Dict[str, Any], template_map: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve a plan workout (predefined or custom) into title + workoutDetails
+    fields. `template_map` maps str(predefinedWorkoutId) -> template document."""
+    if workout.get("workoutType") == "predefined":
+        tmpl = template_map.get(str(workout.get("predefinedWorkoutId")))
+        if tmpl:
+            exercises = []
+            for block in tmpl.get("blocks", []) or []:
+                for ex in block.get("exercises", []) or []:
+                    sets, reps = _parse_volume(ex.get("volume"))
+                    exercises.append({
+                        "exerciseId": ex.get("exercise_id"),
+                        "exerciseName": ex.get("exercise_name", ""),
+                        "targetSets": sets,
+                        "targetReps": reps,
+                        "notes": ex.get("notes", ""),
+                    })
+            return {
+                "title": tmpl.get("name", "Workout"),
+                "type": "strength",
+                "duration": tmpl.get("estimated_duration", 45),
+                "exercises": exercises,
+                "template_id": workout.get("predefinedWorkoutId"),
+            }
+        # Referenced template is missing — degrade gracefully.
+        return {"title": "Workout", "type": "strength", "duration": 45, "exercises": [], "template_id": None}
+
+    # Custom inline workout
+    custom = workout.get("customWorkout") or {}
+    exercises = []
+    for ex in custom.get("exercises", []) or []:
+        sets_arr = ex.get("sets", []) or []
+        first = sets_arr[0] if sets_arr and isinstance(sets_arr[0], dict) else {}
+        exercises.append({
+            "exerciseName": ex.get("exerciseName", ""),
+            "targetSets": len(sets_arr) or 3,
+            "targetReps": first.get("reps") or 10,
+            "notes": "",
+        })
+    return {
+        "title": custom.get("title") or "Workout",
+        "type": custom.get("type", "strength"),
+        "duration": custom.get("durationMinutes", 45),
+        "exercises": exercises,
+        "template_id": None,
+    }
+
+
+def _build_events(
+    plan: Dict[str, Any],
+    start_date: datetime,
+    weeks_cap: Optional[int],
+    template_map: Dict[str, Any],
+    user_oid: Any,
+    plan_oid: Any,
+    now: datetime,
+) -> List[Dict[str, Any]]:
+    """Expand a plan into calendar-event documents (ready for insert_many).
+
+    Emits workout events (type 'deload' for deload weeks, else 'workout') plus a
+    'rest' event for each restDays entry. Each event carries planId/planWeek/
+    planDay for back-linking and idempotency.
+    """
+    events: List[Dict[str, Any]] = []
+    weeks = sorted(plan.get("weeks", []) or [], key=lambda w: w.get("weekNumber", 0))
+    if weeks_cap:
+        weeks = [w for w in weeks if w.get("weekNumber", 0) <= weeks_cap]
+
+    for week in weeks:
+        week_number = week.get("weekNumber", 1)
+        is_deload = bool(week.get("deloadWeek", False))
+
+        for workout in week.get("workouts", []) or []:
+            day = workout.get("dayOfWeek", 1)
+            date = _compute_event_date(start_date, week_number, day)
+            content = _resolve_workout_content(workout, template_map)
+            event = {
+                "userId": user_oid,
+                "planId": plan_oid,
+                "planWeek": week_number,
+                "planDay": day,
+                "date": date,
+                "title": f"{content['title']} ({date.strftime('%b %d')})",
+                "type": "deload" if is_deload else "workout",
+                "status": "scheduled",
+                "notes": workout.get("notes") or "",
+                "workoutDetails": {
+                    "type": content["type"],
+                    "estimatedDuration": content["duration"],
+                    "exercises": content["exercises"],
+                },
+                "createdAt": now,
+                "updatedAt": now,
+            }
+            if content.get("template_id"):
+                event["workoutTemplateId"] = content["template_id"]
+            events.append(event)
+
+        for rest_day in week.get("restDays", []) or []:
+            date = _compute_event_date(start_date, week_number, rest_day)
+            events.append({
+                "userId": user_oid,
+                "planId": plan_oid,
+                "planWeek": week_number,
+                "planDay": rest_day,
+                "date": date,
+                "title": f"Rest Day ({date.strftime('%b %d')})",
+                "type": "rest",
+                "status": "scheduled",
+                "notes": "",
+                "createdAt": now,
+                "updatedAt": now,
+            })
+
+    events.sort(key=lambda e: e["date"])
+    return events
+
+
+def _serialize_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """JSON-safe view of a proposed event for a dry-run preview (no ObjectId /
+    datetime — the orchestrator json.dumps() tool results)."""
+    return {
+        "date": event["date"].strftime("%Y-%m-%d"),
+        "dayName": event["date"].strftime("%A"),
+        "week": event["planWeek"],
+        "title": event["title"],
+        "type": event["type"],
+        "exerciseCount": len(event.get("workoutDetails", {}).get("exercises", [])),
+    }
+
+
+def _format_preview(
+    plan: Dict[str, Any],
+    proposed: List[Dict[str, Any]],
+    already_scheduled: List[Dict[str, Any]],
+    conflicts: List[Dict[str, Any]],
+    start_date: datetime,
+) -> str:
+    workouts = [e for e in proposed if e["type"] in ("workout", "deload")]
+    rests = [e for e in proposed if e["type"] == "rest"]
+    first, last = proposed[0]["date"], proposed[-1]["date"]
+    lines = [
+        f"Here's the schedule for **{plan.get('name', 'your plan')}**, "
+        f"starting **{start_date.strftime('%A, %B %d, %Y')}**:",
+        "",
+        f"- **{len(workouts)}** workout/deload session(s)"
+        + (f" and **{len(rests)}** rest day(s)" if rests else ""),
+        f"- From **{first.strftime('%b %d')}** to **{last.strftime('%b %d, %Y')}**",
+    ]
+    if already_scheduled:
+        lines.append(f"- {len(already_scheduled)} session(s) already on your calendar (will be skipped)")
+    if conflicts:
+        lines.append(f"- ⚠️ {len(conflicts)} date(s) overlap existing events — I won't double-book")
+    lines += ["", "Want me to add these to your calendar?"]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Skill
+# ---------------------------------------------------------------------------
+
+@skill(
+    name="schedule_plan_to_calendar",
+    description=(
+        "Schedule an ENTIRE multi-week training plan onto the user's calendar in one call. "
+        "Use this instead of scheduling workouts day-by-day whenever the user wants a whole "
+        "plan (or several weeks of it) put on the calendar. Defaults to a dry-run PREVIEW "
+        "that writes nothing; present the preview, and only after the user confirms, call "
+        "again with dry_run=false to actually write the events."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "plan_id": {
+                "type": "string",
+                "description": "The ID of the training plan to schedule.",
+            },
+            "start_date": {
+                "type": "string",
+                "description": (
+                    "Date the plan should start: ISO 'YYYY-MM-DD', or 'today'/'tomorrow'. "
+                    "If omitted, the plan's existing startDate is used."
+                ),
+            },
+            "weeks": {
+                "type": "integer",
+                "description": "How many weeks to schedule (default: all weeks in the plan).",
+                "minimum": 1,
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "Preview only, no writes. Default true. Set false ONLY after the user confirms.",
+            },
+            "overwrite": {
+                "type": "boolean",
+                "description": "Replace this plan's existing calendar events in the date range. Default false.",
+            },
+        },
+        "required": ["plan_id"],
+    },
+)
+async def schedule_plan_to_calendar(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    plan_id = args.get("plan_id")
+    if not plan_id:
+        return {"success": False, "message": "plan_id is required."}
+    try:
+        plan_oid = ObjectId(plan_id)
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid plan_id."}
+
+    plan = await ctx.db.plans.find_one({"_id": plan_oid, "userId": user_oid})
+    if not plan:
+        return {"success": False, "message": "Plan not found."}
+
+    start_date = _parse_start_date(args.get("start_date")) or _parse_start_date(plan.get("startDate"))
+    if not start_date:
+        return {
+            "success": True,
+            "needs_input": "start_date",
+            "message": "What date should the plan start on? Give me a date like 2026-07-12 (or say 'today').",
+        }
+
+    weeks_cap = args.get("weeks")
+    dry_run = args.get("dry_run", True)
+    overwrite = bool(args.get("overwrite", False))
+
+    # Batch-fetch referenced predefined templates (avoid N queries).
+    predefined_ids = [
+        wk["predefinedWorkoutId"]
+        for w in (plan.get("weeks") or [])
+        for wk in (w.get("workouts") or [])
+        if wk.get("workoutType") == "predefined" and wk.get("predefinedWorkoutId")
+    ]
+    template_map: Dict[str, Any] = {}
+    if predefined_ids:
+        async for tmpl in ctx.db.predefinedworkouts.find({"_id": {"$in": predefined_ids}}):
+            template_map[str(tmpl["_id"])] = tmpl
+
+    now = datetime.utcnow()
+    proposed = _build_events(plan, start_date, weeks_cap, template_map, user_oid, plan_oid, now)
+    if not proposed:
+        return {"success": False, "message": "This plan has no workouts to schedule yet."}
+
+    # Fetch existing events in range for dedup + conflict detection.
+    min_d = proposed[0]["date"]
+    max_d = proposed[-1]["date"]
+    existing = await ctx.db.calendarevents.find({
+        "userId": user_oid,
+        "date": {"$gte": min_d, "$lte": max_d},
+        "status": {"$ne": "cancelled"},
+    }).to_list(None)
+
+    existing_plan_slots = {
+        (e.get("planWeek"), e.get("planDay"))
+        for e in existing
+        if e.get("planId") == plan_oid
+    }
+    other_by_date: Dict[Any, List[str]] = {}
+    for e in existing:
+        if e.get("planId") != plan_oid and e.get("date"):
+            other_by_date.setdefault(e["date"].date(), []).append(e.get("title", "event"))
+
+    already_scheduled = [e for e in proposed if (e["planWeek"], e["planDay"]) in existing_plan_slots]
+    to_insert = [e for e in proposed if (e["planWeek"], e["planDay"]) not in existing_plan_slots]
+    conflicts = [
+        {"date": e["date"].strftime("%Y-%m-%d"), "title": e["title"], "existing": other_by_date[e["date"].date()]}
+        for e in proposed
+        if e["date"].date() in other_by_date
+    ]
+
+    if dry_run:
+        return {
+            "success": True,
+            "dry_run": True,
+            "message": _format_preview(plan, proposed, already_scheduled, conflicts, start_date),
+            "proposed_count": len(proposed),
+            "proposed_events": [_serialize_event(e) for e in proposed],
+            "already_scheduled_count": len(already_scheduled),
+            "conflicts": conflicts,
+        }
+
+    # --- Confirmed write ---
+    if overwrite:
+        await ctx.db.calendarevents.delete_many({
+            "userId": user_oid,
+            "planId": plan_oid,
+            "date": {"$gte": min_d, "$lte": max_d},
+        })
+        insert_list = proposed
+    else:
+        insert_list = to_insert
+
+    inserted_count = 0
+    if insert_list:
+        result = await ctx.db.calendarevents.insert_many(insert_list)
+        inserted_count = len(result.inserted_ids)
+
+    # Activate the plan (mirrors Plan.startPlan()).
+    weeks_total = (plan.get("schedule") or {}).get("weeksTotal") or len(plan.get("weeks") or [])
+    total_workouts = sum(len(w.get("workouts", []) or []) for w in (plan.get("weeks") or []))
+    await ctx.db.plans.update_one(
+        {"_id": plan_oid, "userId": user_oid},
+        {"$set": {
+            "startDate": start_date,
+            "status": "active",
+            "endDate": start_date + timedelta(days=weeks_total * 7),
+            "progress.totalWorkouts": total_workouts,
+            "updatedAt": now,
+        }},
+    )
+
+    skipped_msg = f" ({len(already_scheduled)} already scheduled, skipped)" if already_scheduled and not overwrite else ""
+    return {
+        "success": True,
+        "dry_run": False,
+        "written": True,
+        "events_created": inserted_count,
+        "message": (
+            f"Scheduled **{inserted_count}** session(s) for **{plan.get('name', 'your plan')}** "
+            f"starting {start_date.strftime('%A, %B %d')}{skipped_msg}. Your plan is now active!"
+        ),
+    }

--- a/ai-coach-service/tests/test_reflection.py
+++ b/ai-coach-service/tests/test_reflection.py
@@ -20,6 +20,14 @@ from app.core.agents.reflection_config import REFLECTION_CONFIG
 class TestReflectionTrigger:
     """Tests for the _requires_reflection method."""
 
+    @pytest.fixture(autouse=True)
+    def enable_reflection(self):
+        """Reflection is disabled by default in deployment; force-enable it here
+        so the trigger-detection logic is still exercised. Tests that assert the
+        disabled behaviour patch it back to False internally."""
+        with patch.dict(REFLECTION_CONFIG, {"enabled": True}):
+            yield
+
     @pytest.fixture
     def orchestrator(self):
         """Create orchestrator with mocked dependencies."""
@@ -333,7 +341,9 @@ class TestReflectionExecution:
         # Verify the call used config values
         call_kwargs = orchestrator.client.chat.completions.create.call_args.kwargs
         assert call_kwargs["temperature"] == REFLECTION_CONFIG["temperature"]
-        assert call_kwargs["max_tokens"] == REFLECTION_CONFIG["max_tokens"]
+        # GPT-5 models require max_completion_tokens (see commit #69); the value
+        # still comes from the config's max_tokens entry.
+        assert call_kwargs["max_completion_tokens"] == REFLECTION_CONFIG["max_tokens"]
         assert call_kwargs["model"] == REFLECTION_CONFIG["model"]
 
     @pytest.mark.asyncio

--- a/ai-coach-service/tests/test_schedule_plan_skill.py
+++ b/ai-coach-service/tests/test_schedule_plan_skill.py
@@ -1,0 +1,280 @@
+"""
+Tests for the schedule_plan_to_calendar skill.
+
+Covers the pure date/expansion helpers and the handler (dry-run vs write,
+dedup, plan activation, error paths) with a mocked SkillContext.
+"""
+from datetime import datetime
+
+import pytest
+from bson import ObjectId
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.agents.skills.schedule_plan_skill import (
+    _build_events,
+    _compute_event_date,
+    _parse_start_date,
+    _parse_volume,
+    _resolve_workout_content,
+    schedule_plan_to_calendar,
+)
+
+NOW = datetime(2026, 1, 1)
+SUNDAY = datetime(2026, 7, 12)  # a Sunday
+
+
+# --------------------------- pure helpers ---------------------------
+
+class TestComputeEventDate:
+    def test_sunday_anchor_every_other_day(self):
+        # The real failing case: start Sunday Jul 12, days 0/2/4/6.
+        assert _compute_event_date(SUNDAY, 1, 0) == datetime(2026, 7, 12)  # Sun
+        assert _compute_event_date(SUNDAY, 1, 2) == datetime(2026, 7, 14)  # Tue
+        assert _compute_event_date(SUNDAY, 1, 4) == datetime(2026, 7, 16)  # Thu
+        assert _compute_event_date(SUNDAY, 1, 6) == datetime(2026, 7, 18)  # Sat
+
+    def test_multi_week_offset(self):
+        assert _compute_event_date(SUNDAY, 2, 0) == datetime(2026, 7, 19)
+        assert _compute_event_date(SUNDAY, 8, 0) == datetime(2026, 8, 30)
+
+    def test_midweek_start_never_before_start(self):
+        wed = datetime(2026, 7, 15)  # Wednesday (dayOfWeek 3)
+        # A Sunday (0) workout should land on the NEXT Sunday, not the prior one.
+        d = _compute_event_date(wed, 1, 0)
+        assert d >= wed
+        assert d == datetime(2026, 7, 19)
+        # Same-day (Wed=3) lands on the start date itself.
+        assert _compute_event_date(wed, 1, 3) == wed
+
+
+class TestParseVolume:
+    @pytest.mark.parametrize("value,expected", [
+        ("3x10", (3, 10)),
+        ("3 x 8", (3, 8)),
+        ("4X12", (4, 12)),
+        ("3x8-12", (3, 8)),
+        ("AMRAP", (3, 10)),
+        (None, (3, 10)),
+        ("", (3, 10)),
+    ])
+    def test_parse(self, value, expected):
+        assert _parse_volume(value) == expected
+
+
+class TestParseStartDate:
+    def test_iso_and_ymd(self):
+        assert _parse_start_date("2026-07-12") == datetime(2026, 7, 12)
+
+    def test_datetime_passthrough_midnight(self):
+        assert _parse_start_date(datetime(2026, 7, 12, 9, 30)) == datetime(2026, 7, 12)
+
+    def test_bad_returns_none(self):
+        assert _parse_start_date("not-a-date") is None
+        assert _parse_start_date(None) is None
+
+
+class TestResolveWorkoutContent:
+    def test_custom_workout(self):
+        workout = {
+            "workoutType": "custom",
+            "customWorkout": {
+                "title": "Strength",
+                "type": "strength",
+                "durationMinutes": 50,
+                "exercises": [{"exerciseName": "Squat", "sets": [{"reps": 5}, {"reps": 5}, {"reps": 5}]}],
+            },
+        }
+        c = _resolve_workout_content(workout, {})
+        assert c["title"] == "Strength"
+        assert c["duration"] == 50
+        assert c["template_id"] is None
+        assert c["exercises"][0] == {"exerciseName": "Squat", "targetSets": 3, "targetReps": 5, "notes": ""}
+
+    def test_predefined_resolution_parses_volume(self):
+        tid = ObjectId()
+        template_map = {
+            str(tid): {
+                "_id": tid,
+                "name": "Push Day",
+                "estimated_duration": 40,
+                "blocks": [{"exercises": [
+                    {"exercise_id": ObjectId(), "exercise_name": "Bench", "volume": "4x8"},
+                ]}],
+            }
+        }
+        workout = {"workoutType": "predefined", "predefinedWorkoutId": tid}
+        c = _resolve_workout_content(workout, template_map)
+        assert c["title"] == "Push Day"
+        assert c["duration"] == 40
+        assert c["template_id"] == tid
+        assert c["exercises"][0]["exerciseName"] == "Bench"
+        assert c["exercises"][0]["targetSets"] == 4
+        assert c["exercises"][0]["targetReps"] == 8
+
+    def test_missing_template_degrades(self):
+        workout = {"workoutType": "predefined", "predefinedWorkoutId": ObjectId()}
+        c = _resolve_workout_content(workout, {})
+        assert c["title"] == "Workout"
+        assert c["exercises"] == []
+
+
+def _sample_plan():
+    return {
+        "_id": ObjectId(),
+        "userId": ObjectId(),
+        "name": "Test Plan",
+        "schedule": {"weeksTotal": 2},
+        "weeks": [
+            {
+                "weekNumber": 1, "deloadWeek": False, "restDays": [6],
+                "workouts": [
+                    {"dayOfWeek": 0, "workoutType": "custom",
+                     "customWorkout": {"title": "S&C", "type": "strength", "exercises": []}},
+                    {"dayOfWeek": 2, "workoutType": "custom",
+                     "customWorkout": {"title": "Endurance", "type": "cardio", "exercises": []}},
+                ],
+            },
+            {
+                "weekNumber": 2, "deloadWeek": True, "restDays": [],
+                "workouts": [
+                    {"dayOfWeek": 0, "workoutType": "custom",
+                     "customWorkout": {"title": "Deload", "type": "strength", "exercises": []}},
+                ],
+            },
+        ],
+    }
+
+
+class TestBuildEvents:
+    def test_expands_workouts_rests_and_deload(self):
+        plan = _sample_plan()
+        events = _build_events(plan, SUNDAY, None, {}, plan["userId"], plan["_id"], NOW)
+
+        # 3 workouts (2 week-1 + 1 deload) + 1 rest day = 4
+        assert len(events) == 4
+        by_title = {e["title"].split(" (")[0]: e for e in events}
+
+        assert by_title["S&C"]["date"] == datetime(2026, 7, 12)
+        assert by_title["S&C"]["type"] == "workout"
+        assert by_title["S&C"]["planWeek"] == 1
+        assert by_title["S&C"]["planDay"] == 0
+
+        assert by_title["Deload"]["type"] == "deload"
+        assert by_title["Deload"]["date"] == datetime(2026, 7, 19)
+
+        rest = [e for e in events if e["type"] == "rest"][0]
+        assert rest["date"] == datetime(2026, 7, 18)
+        assert rest["planWeek"] == 1 and rest["planDay"] == 6
+
+        # sorted chronologically
+        assert events == sorted(events, key=lambda e: e["date"])
+
+    def test_weeks_cap(self):
+        plan = _sample_plan()
+        events = _build_events(plan, SUNDAY, 1, {}, plan["userId"], plan["_id"], NOW)
+        assert all(e["planWeek"] == 1 for e in events)
+
+
+# --------------------------- handler ---------------------------
+
+def _make_ctx(plan, existing_events=None, templates=None):
+    """Build a SkillContext-like mock with an async Mongo db."""
+    existing_events = existing_events or []
+    templates = templates or []
+
+    async def _template_iter():
+        for t in templates:
+            yield t
+
+    db = MagicMock()
+    db.plans.find_one = AsyncMock(return_value=plan)
+    db.plans.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
+    db.predefinedworkouts.find = MagicMock(return_value=_template_iter())
+
+    find_result = MagicMock()
+    find_result.to_list = AsyncMock(return_value=existing_events)
+    db.calendarevents.find = MagicMock(return_value=find_result)
+
+    async def _insert_many(docs, *a, **k):
+        # inserted_ids must reflect the actual number of docs inserted.
+        return MagicMock(inserted_ids=[ObjectId() for _ in docs])
+
+    db.calendarevents.insert_many = AsyncMock(side_effect=_insert_many)
+    db.calendarevents.delete_many = AsyncMock()
+
+    ctx = MagicMock()
+    ctx.db = db
+    return ctx
+
+
+class TestHandler:
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_nothing(self):
+        plan = _sample_plan()
+        ctx = _make_ctx(plan)
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]), {"plan_id": str(plan["_id"]), "start_date": "2026-07-12"}
+        )
+        assert result["dry_run"] is True
+        assert result["proposed_count"] == 4
+        assert len(result["proposed_events"]) == 4
+        ctx.db.calendarevents.insert_many.assert_not_called()
+        ctx.db.plans.update_one.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_confirmed_write_inserts_and_activates(self):
+        plan = _sample_plan()
+        ctx = _make_ctx(plan)
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False},
+        )
+        assert result["written"] is True
+        assert result["events_created"] == 4
+        ctx.db.calendarevents.insert_many.assert_awaited_once()
+        inserted = ctx.db.calendarevents.insert_many.call_args.args[0]
+        assert len(inserted) == 4
+        # plan activated
+        ctx.db.plans.update_one.assert_awaited_once()
+        set_doc = ctx.db.plans.update_one.call_args.args[1]["$set"]
+        assert set_doc["status"] == "active"
+        assert set_doc["startDate"] == datetime(2026, 7, 12)
+        assert set_doc["progress.totalWorkouts"] == 3
+
+    @pytest.mark.asyncio
+    async def test_dedup_skips_already_scheduled_slots(self):
+        plan = _sample_plan()
+        # An event already exists for plan week 1 / day 0.
+        existing = [{
+            "planId": plan["_id"], "planWeek": 1, "planDay": 0,
+            "date": datetime(2026, 7, 12), "title": "S&C (Jul 12)", "status": "scheduled",
+        }]
+        ctx = _make_ctx(plan, existing_events=existing)
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False},
+        )
+        # 4 proposed - 1 already scheduled = 3 inserted
+        inserted = ctx.db.calendarevents.insert_many.call_args.args[0]
+        assert len(inserted) == 3
+        assert result["events_created"] == 3
+
+    @pytest.mark.asyncio
+    async def test_unknown_plan_returns_error(self):
+        ctx = _make_ctx(plan=None)
+        result = await schedule_plan_to_calendar(
+            ctx, str(ObjectId()), {"plan_id": str(ObjectId())}
+        )
+        assert result["success"] is False
+        assert "not found" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_start_date_asks(self):
+        plan = _sample_plan()
+        plan.pop("startDate", None)
+        ctx = _make_ctx(plan)
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]), {"plan_id": str(plan["_id"])}
+        )
+        assert result.get("needs_input") == "start_date"
+        ctx.db.calendarevents.insert_many.assert_not_called()


### PR DESCRIPTION
## Why
Grounded in real user conversations (`chatConversations`) where the AI coach:
1. **Replaced good answers** with a generic *"To ensure safety and quality, please provide your equipment info…"* (user thumbs-downed it) — traced to the **self-reflection** feature over-firing on content patterns like `reps`/`warm-up`.
2. **Gave up after Week 1** when asked to schedule a whole plan — the loop budget can't sustain ~28 one-event `schedule_to_calendar` calls.

These are harness/tooling gaps, not model-capability gaps.

## What

### Skill registry infrastructure (`app/core/agents/skills/`)
- `@skill` decorator + `SkillRegistry` + `SkillContext` → a new skill is **one self-contained file** (schema + handler + db/service access), auto-wired into the orchestrator's tool list and `_execute_tool` routing (registry takes precedence, deduped by name).
- Existing 25 tools untouched; `get_calendar_events` migrated as a worked template. Docs in `skills/README.md`.

### First composite skill: `schedule_plan_to_calendar`
- Expands an entire multi-week plan into calendar events and **bulk-inserts in one call** with deterministic date math — fixes the "only Week 1" failure.
- **Dry-run by default** with conversational confirm (the legacy `pending_change` flow is dead code).
- Idempotent via `planId`/`planWeek`/`planDay`; creates rest-day events, tags deload weeks, activates the plan on write.

### Annoyance fixes
- Disable self-reflection (re-enable after trigger logic is reworked).
- Remove the hardcoded healthcare disclaimer on the non-streaming `/chat` path.

## Testing
- **84 passing** (61 existing + 23 new): pure date/expansion helper tests + mocked-DB handler tests (dry-run writes nothing, confirmed write inserts + activates, dedup prevents duplicates). Also fixes a stale `max_completion_tokens` assertion and decouples reflection trigger tests from the deployment flag.
- Verified under Python 3.13; registry smoke-tested (`schedule_plan_to_calendar` appears once; 26 tools total).

## Scope
Only touches `ai-coach-service/`. Concrete skills beyond this one (screening/Tier-0 gate, generate_plan, etc.) are deferred per the skills design spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)