### PR TITLE
chore(backend): stdout logging + MCP/OAuth request diagnostics

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -25,12 +25,13 @@ const logger = winston.createLogger({
   ]
 });
 
-// Add console transport for development
-if (process.env.NODE_ENV !== 'production') {
-  logger.add(new winston.transports.Console({
-    format: winston.format.simple()
-  }));
-}
+// Console transport in ALL environments — on Render (and most container hosts)
+// stdout is the log stream, so file-only logging is effectively invisible.
+logger.add(new winston.transports.Console({
+  format: process.env.NODE_ENV === 'production'
+    ? winston.format.json()
+    : winston.format.simple()
+}));
 
 // Import routes
 const authRoutes = require('./routes/auth');
@@ -279,6 +280,29 @@ app.use('/api/v1/integrations', integrationRoutes);
 app.use('/api/v1/webhooks', webhookRoutes);
 app.use('/api/v1/workout-logs', workoutLogRoutes);
 app.use('/api/v1/train-now', trainNowRoutes);
+
+// TEMP diagnostic: log MCP/OAuth traffic (method, status, latency, and
+// non-secret request details) so connector issues are visible in Render logs.
+app.use((req, res, next) => {
+  if (/^\/(mcp|authorize|token|register|revoke|oauth|\.well-known)/.test(req.path)) {
+    const started = Date.now();
+    const detail = { ua: req.headers['user-agent'] };
+    if (req.path === '/token') {
+      Object.assign(detail, {
+        grant_type: req.body && req.body.grant_type,
+        client_id: req.body && req.body.client_id,
+        redirect_uri: req.body && req.body.redirect_uri,
+        has_code: !!(req.body && req.body.code),
+        has_verifier: !!(req.body && req.body.code_verifier),
+        authz_header: req.headers.authorization ? 'present' : 'absent'
+      });
+    }
+    res.on('finish', () => {
+      console.log(`[MCP] ${req.method} ${req.path} -> ${res.statusCode} (${Date.now() - started}ms) ${JSON.stringify(detail)}`);
+    });
+  }
+  next();
+});
 
 // MCP connector: OAuth authorization-server routes (mounted at root — the
 // `.well-known` discovery documents are origin-rooted) and the /mcp endpoint.


### PR DESCRIPTION
Temporary diagnostics to debug the Claude MCP connector token-exchange failure. Sends production logs to stdout (Render captures stdout, not files) and logs method/status/latency + non-secret `/token` details on the OAuth/MCP paths. Will be trimmed once the issue is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)