### PR TITLE
fix(auth): unify Google & local sign-in into one account, let users choose method

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "openai": "^5.11.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
+    "validator": "^13.15.15",
     "winston": "^3.11.0",
     "zod": "^3.25.76"
   },

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -1,4 +1,5 @@
 const passport = require('passport');
+const jwt = require('jsonwebtoken');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const User = require('../models/User');
 const normalizeEmail = require('../utils/normalizeEmail');
@@ -19,12 +20,51 @@ passport.use(
       clientID: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       callbackURL: '/api/v1/auth/google/callback',
-      scope: ['profile', 'email']
+      scope: ['profile', 'email'],
+      // Needed so the verify callback can read `req.query.state` and tell an
+      // account-linking request (`link:<jwt>`) apart from a normal login.
+      passReqToCallback: true
     },
-    async (accessToken, refreshToken, profile, done) => {
+    async (req, accessToken, refreshToken, profile, done) => {
       try {
         console.log('Google OAuth callback - Profile received:', profile.id);
-        
+
+        // ---- Account-linking flow -------------------------------------------
+        // A logged-in user clicked "Connect Google" in Settings; the frontend
+        // forwards their JWT as `state=link:<token>`. Bind this Google identity
+        // to THAT user only — never match/create by email, which is what let a
+        // different Google account silently switch or spawn an account.
+        const state = req.query.state;
+        if (typeof state === 'string' && state.startsWith('link:')) {
+          const token = state.slice('link:'.length);
+          let decoded;
+          try {
+            decoded = jwt.verify(token, process.env.JWT_SECRET);
+          } catch (e) {
+            return done(null, false, { reason: 'invalid_session' });
+          }
+
+          const currentUser = await User.findById(decoded.id);
+          if (!currentUser) {
+            return done(null, false, { reason: 'invalid_session' });
+          }
+
+          // Refuse to steal a Google identity already bound to a different user.
+          const owner = await User.findOne({ googleId: profile.id });
+          if (owner && !owner._id.equals(currentUser._id)) {
+            return done(null, false, { reason: 'google_in_use' });
+          }
+
+          currentUser.googleId = profile.id;
+          if (!currentUser.profilePicture) {
+            currentUser.profilePicture = profile.photos?.[0]?.value;
+          }
+          currentUser.lastLogin = new Date();
+          await currentUser.save();
+          return done(null, currentUser);
+        }
+        // ---------------------------------------------------------------------
+
         // Check if user already exists with this Google ID
         let user = await User.findOne({ googleId: profile.id });
 

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -1,6 +1,7 @@
 const passport = require('passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const User = require('../models/User');
+const normalizeEmail = require('../utils/normalizeEmail');
 
 console.log('🔐 Initializing Google OAuth Strategy');
 console.log('Google Client ID:', process.env.GOOGLE_CLIENT_ID ? `${process.env.GOOGLE_CLIENT_ID.substring(0, 10)}...` : 'NOT SET');
@@ -34,8 +35,11 @@ passport.use(
           return done(null, user);
         }
 
-        // Check if user exists with same email
-        user = await User.findOne({ email: profile.emails[0].value });
+        // Check if user exists with same email. Normalize with the same canonical
+        // rule used by register/login so a Google login links to (rather than
+        // duplicates) an existing local account for the same address.
+        const email = normalizeEmail(profile.emails[0].value);
+        user = await User.findOne({ email });
 
         if (user) {
           // Link Google account to existing user
@@ -49,7 +53,7 @@ passport.use(
         // Create new user
         user = await User.create({
           googleId: profile.id,
-          email: profile.emails[0].value,
+          email,
           name: profile.displayName,
           profilePicture: profile.photos[0]?.value,
           isEmailVerified: true, // Google accounts are pre-verified

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -101,6 +101,7 @@ const login = async (req, res) => {
     if (!user.password && user.googleId) {
       return res.status(401).json({
         success: false,
+        code: 'google_only',
         message: 'This account uses Google sign-in. Please sign in with Google.'
       });
     }
@@ -295,6 +296,12 @@ const setPassword = async (req, res) => {
         return res.status(401).json({
           success: false,
           message: 'Current password is incorrect'
+        });
+      }
+      if (currentPassword === newPassword) {
+        return res.status(400).json({
+          success: false,
+          message: 'New password must be different from your current password'
         });
       }
     }

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -15,9 +15,17 @@ const register = async (req, res) => {
 
     const { email, password, name, timezone } = req.body;
 
-    // Check if user already exists
-    const existingUser = await User.findOne({ email });
+    // Check if user already exists. Select the password so we can tell a
+    // Google-only account (no password) apart from a local one and guide the
+    // user to the right sign-in method instead of a dead-end error.
+    const existingUser = await User.findOne({ email }).select('+password');
     if (existingUser) {
+      if (existingUser.googleId && !existingUser.password) {
+        return res.status(400).json({
+          success: false,
+          message: 'This email is already registered with Google sign-in. Please sign in with Google — you can add a password afterward in Settings.'
+        });
+      }
       return res.status(400).json({
         success: false,
         message: 'User already exists with this email'
@@ -149,6 +157,11 @@ const login = async (req, res) => {
 // Get current user profile
 const getProfile = async (req, res) => {
   try {
+    // `req.user` excludes `password` (select: false). Do a lean, single-field
+    // lookup (just `password`) to report whether the account can sign in with a
+    // password — this endpoint is hit on most app loads, so keep it cheap.
+    const withPassword = await User.findById(req.user._id).select('password').lean();
+
     res.json({
       success: true,
       data: {
@@ -161,6 +174,9 @@ const getProfile = async (req, res) => {
           address: req.user.address,
           profilePicture: req.user.profilePicture,
           authProvider: req.user.authProvider,
+          // Which sign-in methods are active on this account
+          hasPassword: !!(withPassword && withPassword.password),
+          googleLinked: !!req.user.googleId,
           role: req.user.role,
           profile: req.user.profile,
           settings: req.user.settings,
@@ -239,9 +255,70 @@ const updateProfile = async (req, res) => {
   }
 };
 
+// Set or change the account password.
+// - Google-only accounts (no password yet) can set one directly — identity is
+//   already proven by the valid JWT issued at Google login. This lets a user
+//   who signed up with Google also sign in with email/password.
+// - Accounts that already have a password must provide the correct
+//   `currentPassword` to change it.
+const setPassword = async (req, res) => {
+  try {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        success: false,
+        message: 'Validation errors',
+        errors: errors.array()
+      });
+    }
+
+    const { currentPassword, newPassword } = req.body;
+
+    const user = await User.findById(req.user._id).select('+password');
+    if (!user) {
+      return res.status(404).json({
+        success: false,
+        message: 'User not found'
+      });
+    }
+
+    // Changing an existing password requires verifying the current one.
+    if (user.password) {
+      if (!currentPassword) {
+        return res.status(400).json({
+          success: false,
+          message: 'Current password is required to change your password'
+        });
+      }
+      const isMatch = await user.comparePassword(currentPassword);
+      if (!isMatch) {
+        return res.status(401).json({
+          success: false,
+          message: 'Current password is incorrect'
+        });
+      }
+    }
+
+    user.password = newPassword; // hashed by the pre('save') hook
+    await user.save();
+
+    res.json({
+      success: true,
+      message: 'Password set successfully. You can now sign in with your email and password.'
+    });
+  } catch (error) {
+    console.error('Set password error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Server error setting password'
+    });
+  }
+};
+
 module.exports = {
   register,
   login,
   getProfile,
-  updateProfile
+  updateProfile,
+  setPassword
 };

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,11 +1,12 @@
 const { body } = require('express-validator');
+const normalizeEmail = require('../utils/normalizeEmail');
 
 // User validation
 const validateRegister = [
   body('email')
     .isEmail()
     .withMessage('Please provide a valid email')
-    .normalizeEmail(),
+    .customSanitizer(normalizeEmail),
   body('password')
     .isLength({ min: 6 })
     .withMessage('Password must be at least 6 characters long'),
@@ -19,10 +20,21 @@ const validateLogin = [
   body('email')
     .isEmail()
     .withMessage('Please provide a valid email')
-    .normalizeEmail(),
+    .customSanitizer(normalizeEmail),
   body('password')
     .notEmpty()
     .withMessage('Password is required')
+];
+
+// Set or change password (for adding a password to a Google account,
+// or changing an existing one). `currentPassword` is only required when the
+// account already has a password — enforced in the controller.
+const validateSetPassword = [
+  body('newPassword')
+    .isLength({ min: 6 })
+    .withMessage('Password must be at least 6 characters long'),
+  body('currentPassword')
+    .optional()
 ];
 
 // Exercise validation
@@ -90,6 +102,7 @@ const validateWorkout = [
 module.exports = {
   validateRegister,
   validateLogin,
+  validateSetPassword,
   validateExercise,
   validateWorkout
 };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const router = express.Router();
-const { register, login, getProfile, updateProfile } = require('../controllers/authController');
+const { register, login, getProfile, updateProfile, setPassword } = require('../controllers/authController');
 const { auth } = require('../middleware/auth');
-const { validateRegister, validateLogin } = require('../middleware/validation');
+const { validateRegister, validateLogin, validateSetPassword } = require('../middleware/validation');
 const passport = require('../config/passport');
 const { renderGoogleConsentAfterAuth } = require('../mcp/consentController');
 
@@ -25,6 +25,11 @@ router.get('/profile', auth, getProfile);
 // @desc    Update user profile
 // @access  Private
 router.put('/profile', auth, updateProfile);
+
+// @route   POST /api/v1/auth/set-password
+// @desc    Set (Google-only account) or change the account password
+// @access  Private
+router.post('/set-password', auth, validateSetPassword, setPassword);
 
 // @route   GET /api/v1/auth/google
 // @desc    Initiate Google OAuth login

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -46,43 +46,62 @@ router.get('/google', (req, res, next) =>
 // @route   GET /api/v1/auth/google/callback
 // @desc    Google OAuth callback
 // @access  Public
-router.get('/google/callback', 
-  passport.authenticate('google', { session: false, failureRedirect: '/auth?error=google_auth_failed' }),
-  async (req, res) => {
+// Uses a custom passport callback so we can route the three flows distinctly:
+//   - `link:<jwt>`  → account-linking from Settings (success/error back to Settings)
+//   - `mcp:<id>`    → MCP connector consent page
+//   - (none)        → normal login/signup (issue a fresh JWT to the SPA)
+router.get('/google/callback', (req, res, next) => {
+  passport.authenticate('google', { session: false }, async (err, user, info) => {
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+    const state = req.query.state;
+    const isLink = typeof state === 'string' && state.startsWith('link:');
+    const isMcp = typeof state === 'string' && state.startsWith('mcp:');
+
     try {
-      console.log('Google OAuth callback - User authenticated:', req.user ? 'Yes' : 'No');
-      
-      if (!req.user) {
-        console.error('No user object after Google authentication');
-        return res.redirect(`${process.env.FRONTEND_URL || 'http://localhost:3000'}/auth?error=no_user`);
+      if (err) {
+        console.error('Google auth callback error:', err);
+        return res.redirect(isLink
+          ? `${frontendUrl}/Settings?google=error&reason=server_error`
+          : `${frontendUrl}/auth?error=oauth_failed&message=${encodeURIComponent(err.message)}`);
       }
 
-      // MCP connector consent flow: if state is `mcp:<requestId>`, render the
-      // connector consent page for this now-authenticated user instead of
-      // redirecting to the SPA with a login JWT.
-      const state = req.query.state;
-      if (typeof state === 'string' && state.startsWith('mcp:')) {
+      if (!user) {
+        // Authentication/link failed. For a link attempt, surface a friendly
+        // reason on the Settings page instead of bouncing to the login screen.
+        if (isLink) {
+          const reason = (info && info.reason) || 'google_link_failed';
+          return res.redirect(`${frontendUrl}/Settings?google=error&reason=${encodeURIComponent(reason)}`);
+        }
+        return res.redirect(`${frontendUrl}/auth?error=google_auth_failed`);
+      }
+
+      // Downstream helpers (MCP consent) read the authenticated user off req.
+      req.user = user;
+
+      // MCP connector consent flow
+      if (isMcp) {
         const requestId = state.slice('mcp:'.length);
         return await renderGoogleConsentAfterAuth(req, res, requestId);
       }
 
-      // Generate JWT token for the authenticated user
-      const token = req.user.generateToken();
-      console.log('JWT token generated successfully');
-      
-      // Redirect to frontend with token
-      const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-      const redirectUrl = `${frontendUrl}/auth/callback?token=${token}`;
-      console.log('Redirecting to:', redirectUrl);
-      
-      res.redirect(redirectUrl);
+      // Account-linking succeeded: googleId is now bound to the already
+      // logged-in user (done in the verify step). Keep their existing session
+      // and return them to Settings with a confirmation.
+      if (isLink) {
+        return res.redirect(`${frontendUrl}/Settings?google=connected`);
+      }
+
+      // Normal login/signup: issue a fresh JWT for the SPA to consume.
+      const token = user.generateToken();
+      return res.redirect(`${frontendUrl}/auth/callback?token=${token}`);
     } catch (error) {
       console.error('Google auth callback error:', error);
       console.error('Error stack:', error.stack);
-      const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-      res.redirect(`${frontendUrl}/auth?error=oauth_failed&message=${encodeURIComponent(error.message)}`);
+      return res.redirect(isLink
+        ? `${frontendUrl}/Settings?google=error&reason=server_error`
+        : `${frontendUrl}/auth?error=oauth_failed&message=${encodeURIComponent(error.message)}`);
     }
-  }
-);
+  })(req, res, next);
+});
 
 module.exports = router;

--- a/backend/src/utils/normalizeEmail.js
+++ b/backend/src/utils/normalizeEmail.js
@@ -1,0 +1,37 @@
+const validator = require('validator');
+
+/**
+ * Canonical email normalization used across EVERY auth path
+ * (register, login, and Google OAuth) so the same human's address resolves to
+ * one account no matter which path created it.
+ *
+ * It delegates to `validator.normalizeEmail` with the library defaults — the
+ * SAME canonicalization express-validator's `.normalizeEmail()` applied before
+ * this refactor. That means:
+ *   - lowercases the address,
+ *   - for Gmail/Googlemail: strips dots and `+subaddress` (foo.bar+x@gmail.com
+ *     → foobar@gmail.com) — these are literally the same inbox, so this
+ *     collapses same-inbox duplicates,
+ *   - strips `+subaddress` for outlook/yahoo/icloud,
+ *   - leaves other providers' local parts untouched (dots preserved).
+ *
+ * TRADEOFF (intentional): the stored/displayed email is the *canonical* form,
+ * not necessarily the exact string the user typed (e.g. a Gmail user who typed
+ * `John.Doe@gmail.com` is stored as `johndoe@gmail.com`). We accept this
+ * because consistent canonicalization is what prevents duplicate accounts, and
+ * because it also keeps `+tag` addresses valid against the User schema's email
+ * regex (which rejects `+`). Using a lighter normalizer in only some paths is
+ * exactly what caused Google and local sign-in to create two separate accounts.
+ *
+ * NOTE: `normalizeEmail` returns `false` for input it considers invalid; in
+ * that case we fall back to a trimmed-lowercase value so downstream `isEmail`
+ * validation / schema validation produces the real error message.
+ *
+ * @param {string} email
+ * @returns {string}
+ */
+module.exports = (email) => {
+  const raw = String(email || '').trim();
+  const normalized = validator.normalizeEmail(raw);
+  return normalized === false ? raw.toLowerCase() : normalized;
+};

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -204,10 +204,38 @@ export default function Auth() {
 
           {/* Error Message */}
           {errors.general && (
-            <div className="mb-6 p-4 bg-red-50 border border-red-100 text-red-600 rounded-xl text-sm flex items-center gap-2">
-              <div className="w-1.5 h-1.5 rounded-full bg-red-500" />
-              {errors.general}
-            </div>
+            errors.general.toLowerCase().includes('google') ? (
+              // Account exists but was created via Google sign-in — guide the user
+              // straight to the Google button instead of a dead-end error.
+              <div className="mb-6 p-4 bg-amber-50 border border-amber-100 text-amber-700 rounded-xl text-sm">
+                <div className="flex items-center gap-2">
+                  <div className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                  {errors.general}
+                </div>
+                <button
+                  type="button"
+                  onClick={handleGoogleAuth}
+                  disabled={isLoading}
+                  className="mt-3 w-full flex items-center justify-center gap-3 px-6 py-2.5 border border-gray-200 rounded-xl bg-white hover:bg-gray-50 transition-all disabled:opacity-50 font-medium text-gray-700"
+                >
+                  <svg className="w-5 h-5" viewBox="0 0 24 24">
+                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+                  </svg>
+                  Continue with Google
+                </button>
+                <p className="mt-2 text-xs text-amber-600/80">
+                  Tip: after signing in with Google you can add a password from Settings → Sign-in &amp; Security.
+                </p>
+              </div>
+            ) : (
+              <div className="mb-6 p-4 bg-red-50 border border-red-100 text-red-600 rounded-xl text-sm flex items-center gap-2">
+                <div className="w-1.5 h-1.5 rounded-full bg-red-500" />
+                {errors.general}
+              </div>
+            )
           )}
 
           {/* Forms */}

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -105,7 +105,11 @@ export default function Auth() {
 
       if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.message || 'Login failed');
+        // Preserve the backend's structured code so the UI can react without
+        // brittle message-string matching.
+        const err = new Error(error.message || 'Login failed');
+        err.code = error.code;
+        throw err;
       }
 
       const data = await response.json();
@@ -123,7 +127,10 @@ export default function Auth() {
       navigate('/');
     } catch (error) {
       console.error("Sign in error:", error);
-      setErrors({ general: error.message || "Invalid email or password. Please try again." });
+      setErrors({
+        general: error.message || "Invalid email or password. Please try again.",
+        googleOnly: error.code === 'google_only'
+      });
     } finally {
       setIsLoading(false);
     }
@@ -204,7 +211,7 @@ export default function Auth() {
 
           {/* Error Message */}
           {errors.general && (
-            errors.general.toLowerCase().includes('google') ? (
+            (errors.googleOnly || errors.general.toLowerCase().includes('google')) ? (
               // Account exists but was created via Google sign-in — guide the user
               // straight to the Google button instead of a dead-end error.
               <div className="mb-6 p-4 bg-amber-50 border border-amber-100 text-amber-700 rounded-xl text-sm">

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Camera, Moon, Sun, Loader2, Brain, Link, Unlink, RefreshCw, CheckCircle, AlertCircle, Trash2, Copy, Sparkles } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Camera, Moon, Sun, Loader2, Brain, Link, Unlink, RefreshCw, CheckCircle, AlertCircle, Trash2, Copy, Sparkles, KeyRound } from 'lucide-react';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Switch } from '@/components/ui/switch';
 import { useTheme } from '@/contexts/ThemeContext';
 import { StravaIntegration } from '@/api/entities';
+import apiService from '@/services/api';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -30,6 +31,12 @@ export default function Settings() {
   const [stravaSyncing, setStravaSyncing] = useState(false);
   const [stravaMessage, setStravaMessage] = useState(null);
   const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
+
+  // Sign-in & security (set/change password) state
+  const [showPwForm, setShowPwForm] = useState(false);
+  const [pwForm, setPwForm] = useState({ currentPassword: '', newPassword: '', confirmPassword: '' });
+  const [pwSaving, setPwSaving] = useState(false);
+  const [pwMessage, setPwMessage] = useState(null);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -218,6 +225,40 @@ export default function Settings() {
       setStravaMessage({ type: 'error', text: 'Failed to disconnect Strava.' });
     } finally {
       setStravaLoading(false);
+    }
+  };
+
+  // Redirect to Google OAuth to link Google to this (already logged-in) account.
+  // The backend matches by email and adds googleId to the existing user.
+  const handleConnectGoogle = () => {
+    window.location.href = `${import.meta.env.VITE_API_URL || 'http://localhost:5001'}/api/v1/auth/google`;
+  };
+
+  // Set (Google-only account) or change the account password.
+  const handleSetPassword = async () => {
+    setPwMessage(null);
+    if (pwForm.newPassword.length < 6) {
+      setPwMessage({ type: 'error', text: 'Password must be at least 6 characters.' });
+      return;
+    }
+    if (pwForm.newPassword !== pwForm.confirmPassword) {
+      setPwMessage({ type: 'error', text: 'Passwords do not match.' });
+      return;
+    }
+    setPwSaving(true);
+    try {
+      const res = await apiService.auth.setPassword(
+        pwForm.newPassword,
+        user?.hasPassword ? pwForm.currentPassword : undefined
+      );
+      setPwMessage({ type: 'success', text: res?.message || 'Password updated successfully.' });
+      setPwForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+      setShowPwForm(false);
+      fetchUserProfile();
+    } catch (error) {
+      setPwMessage({ type: 'error', text: error.message || 'Failed to set password.' });
+    } finally {
+      setPwSaving(false);
     }
   };
 
@@ -582,6 +623,155 @@ export default function Settings() {
                   Detect
                 </button>
               </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Sign-in & Security Section */}
+        <div className="mt-8">
+          <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">Sign-in &amp; Security</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            Choose how you sign in. You can use Google, an email &amp; password, or both.
+          </p>
+
+          {pwMessage && (
+            <div className={`mb-4 p-3 rounded-lg flex items-center gap-2 ${
+              pwMessage.type === 'success'
+                ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400'
+                : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'
+            }`}>
+              {pwMessage.type === 'success' ? (
+                <CheckCircle className="w-5 h-5 flex-shrink-0" />
+              ) : (
+                <AlertCircle className="w-5 h-5 flex-shrink-0" />
+              )}
+              <span className="text-sm">{pwMessage.text}</span>
+            </div>
+          )}
+
+          <div className="space-y-1">
+            {/* Google sign-in method */}
+            <div className="py-4 border-b border-gray-100 dark:border-gray-800">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800">
+                    <svg className="w-5 h-5" viewBox="0 0 24 24">
+                      <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                      <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                      <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/>
+                      <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                    </svg>
+                  </div>
+                  <div className="text-left">
+                    <p className="text-sm font-bold text-gray-500 dark:text-gray-400 tracking-wide">
+                      Google
+                    </p>
+                    {user?.googleLinked ? (
+                      <p className="text-base font-medium text-gray-900 dark:text-white mt-1 flex items-center gap-2">
+                        <span className="w-2 h-2 rounded-full bg-green-500"></span>
+                        Connected
+                      </p>
+                    ) : (
+                      <p className="text-base font-medium text-gray-400 dark:text-gray-500 mt-1">
+                        Not connected
+                      </p>
+                    )}
+                  </div>
+                </div>
+                {!user?.googleLinked && (
+                  <button
+                    onClick={handleConnectGoogle}
+                    className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-900 dark:text-white bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                  >
+                    <Link className="w-4 h-4" />
+                    Connect
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Password sign-in method */}
+            <div className="py-4 border-b border-gray-100 dark:border-gray-800">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-primary-100 dark:bg-primary-900/30">
+                    <KeyRound className="w-5 h-5 text-primary-500 dark:text-primary-400" />
+                  </div>
+                  <div className="text-left">
+                    <p className="text-sm font-bold text-gray-500 dark:text-gray-400 tracking-wide">
+                      Email &amp; Password
+                    </p>
+                    {user?.hasPassword ? (
+                      <p className="text-base font-medium text-gray-900 dark:text-white mt-1 flex items-center gap-2">
+                        <span className="w-2 h-2 rounded-full bg-green-500"></span>
+                        Password set
+                      </p>
+                    ) : (
+                      <p className="text-base font-medium text-gray-400 dark:text-gray-500 mt-1">
+                        No password yet
+                      </p>
+                    )}
+                  </div>
+                </div>
+                {!showPwForm && (
+                  <button
+                    onClick={() => { setShowPwForm(true); setPwMessage(null); }}
+                    className="px-4 py-2 text-sm font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-900/50 transition-colors"
+                  >
+                    {user?.hasPassword ? 'Change' : 'Set password'}
+                  </button>
+                )}
+              </div>
+
+              {showPwForm && (
+                <div className="mt-4 space-y-3">
+                  {user?.hasPassword && (
+                    <input
+                      type="password"
+                      value={pwForm.currentPassword}
+                      onChange={(e) => setPwForm({ ...pwForm, currentPassword: e.target.value })}
+                      placeholder="Current password"
+                      autoComplete="current-password"
+                      className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-400/50 focus:border-primary-400"
+                    />
+                  )}
+                  <input
+                    type="password"
+                    value={pwForm.newPassword}
+                    onChange={(e) => setPwForm({ ...pwForm, newPassword: e.target.value })}
+                    placeholder="New password (min 6 characters)"
+                    autoComplete="new-password"
+                    className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-400/50 focus:border-primary-400"
+                  />
+                  <input
+                    type="password"
+                    value={pwForm.confirmPassword}
+                    onChange={(e) => setPwForm({ ...pwForm, confirmPassword: e.target.value })}
+                    placeholder="Confirm new password"
+                    autoComplete="new-password"
+                    className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-400/50 focus:border-primary-400"
+                  />
+                  <div className="flex gap-2 pt-1">
+                    <button
+                      onClick={() => {
+                        setShowPwForm(false);
+                        setPwForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+                        setPwMessage(null);
+                      }}
+                      className="flex-1 px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleSetPassword}
+                      disabled={pwSaving}
+                      className="flex-1 px-4 py-2 text-sm font-medium text-gray-900 bg-white rounded-lg hover:bg-gray-100 transition-colors disabled:opacity-50 shadow-sm border border-gray-200"
+                    >
+                      {pwSaving ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : (user?.hasPassword ? 'Update password' : 'Set password')}
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -82,6 +82,27 @@ export default function Settings() {
     }
   }, [searchParams]);
 
+  // Handle Google account-linking return (from "Connect Google")
+  useEffect(() => {
+    const google = searchParams.get('google');
+    if (!google) return;
+    if (google === 'connected') {
+      setPwMessage({ type: 'success', text: 'Google connected. You can now sign in with Google.' });
+      fetchUserProfile();
+    } else if (google === 'error') {
+      const reasons = {
+        google_in_use: 'That Google account is already linked to a different account.',
+        invalid_session: 'Your session expired. Please sign in again and retry.',
+        server_error: 'Something went wrong connecting Google. Please try again.'
+      };
+      const reason = searchParams.get('reason');
+      setPwMessage({ type: 'error', text: reasons[reason] || 'Failed to connect Google. Please try again.' });
+    }
+    searchParams.delete('google');
+    searchParams.delete('reason');
+    setSearchParams(searchParams);
+  }, [searchParams]);
+
   const fetchUserProfile = async () => {
     setIsLoading(true);
     try {
@@ -228,10 +249,14 @@ export default function Settings() {
     }
   };
 
-  // Redirect to Google OAuth to link Google to this (already logged-in) account.
-  // The backend matches by email and adds googleId to the existing user.
+  // Link Google to THIS logged-in account. We forward the current session JWT
+  // as OAuth `state=link:<token>` so the backend binds googleId to this exact
+  // user (never by email match, which could otherwise switch/spawn accounts).
   const handleConnectGoogle = () => {
-    window.location.href = `${import.meta.env.VITE_API_URL || 'http://localhost:5001'}/api/v1/auth/google`;
+    const token = localStorage.getItem('authToken');
+    if (!token) return;
+    const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:5001';
+    window.location.href = `${apiUrl}/api/v1/auth/google?state=link:${encodeURIComponent(token)}`;
   };
 
   // Set (Google-only account) or change the account password.

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -80,7 +80,13 @@ class APIService {
       this.updateToken(null);
       return Promise.resolve();
     },
-    me: () => this.request('/auth/profile')
+    me: () => this.request('/auth/profile'),
+    // Set (Google-only account) or change the account password.
+    // `currentPassword` is only needed when the account already has one.
+    setPassword: (newPassword, currentPassword) => this.request('/auth/set-password', {
+      method: 'POST',
+      body: JSON.stringify({ newPassword, ...(currentPassword ? { currentPassword } : {}) })
+    })
   };
 
   // Exercise endpoints


### PR DESCRIPTION
## Problem

Signing in with **Google** vs. **email/password** ("local") could produce **two separate user records for the same person**.

**Root cause — email normalization mismatch.** `register`/`login` ran the email through express-validator's `normalizeEmail()` (which for Gmail strips dots and `+tags`, e.g. `foo.bar@gmail.com` → `foobar@gmail.com`), while the Google OAuth flow looked up and stored Google's **raw** address. Because the same person's email was stored as *different strings*, the Google flow's email-fallback account-link missed the existing local user and created a second account.

## Fix

### Identity — one account per person
- New shared `backend/src/utils/normalizeEmail.js` delegating to `validator.normalizeEmail`, applied identically in **register, login, and the Google flow** so all three paths agree on one canonical stored/queried string.
- Chosen over a light `trim().toLowerCase()` because that alternative (a) **500s on `+tag` Gmail addresses** — the User schema email regex rejects `+`, and the failure lands inside `user.save()` as a generic 500 — and (b) reintroduces same-inbox Gmail duplicates. The canonical normalizer avoids both. **Tradeoff:** the stored email is the canonical form (Gmail dots/`+tags` collapsed); non-Gmail addresses are only lowercased.
- Declared `validator` as a direct backend dependency (was transitive via express-validator).

### Let users choose their sign-in method
- `POST /api/v1/auth/set-password` — a Google-only account can **add** a password (identity proven by the Google-issued JWT); an existing-password account can **change** it (requires current password).
- `GET /auth/profile` now reports `hasPassword` / `googleLinked` (lean single-field lookup).
- **Settings → "Sign-in & Security"**: shows which methods are active, with *Set/Change password* and *Connect Google* (linking reuses the existing Google callback — no new endpoint).
- Actionable guidance instead of dead-ends: register on a Google-only email points to Google sign-in; the login "account uses Google" error surfaces a **Continue with Google** button.

## Notes / caveats
- **No migration script** (repo owner is the sole account and will clean up any stray record). In a multi-user system, rows stored under the old normalizer could need a one-time backfill — called out explicitly, not addressed here by choice.
- `setPassword` does not invalidate existing sessions (stateless JWT) — fine for current scale.
- Unrelated in-progress `ai-coach-service/*` working-tree changes were deliberately left out of this commit.

## Verification
- Confirmed `John.Doe+promo@Gmail.com` → `johndoe@gmail.com` passes the User schema validator (previously 500'd), and that register vs. Google normalize to the **same** string.
- All backend auth modules load cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)