### PR TITLE
fix(backend): allow Claude callback origins in CSP form-action (MCP connector root cause)

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -106,7 +106,13 @@ app.use(helmet({
       fontSrc: ["'self'"],
       objectSrc: ["'none'"],
       mediaSrc: ["'self'"],
-      frameSrc: ["'none'"]
+      frameSrc: ["'none'"],
+      // The MCP OAuth consent pages POST to /oauth/consent/approve, which 302s
+      // to the connector's redirect_uri (claude.ai for hosted Claude, loopback
+      // for Claude Code). Chrome enforces form-action across that redirect, so
+      // 'self' alone silently blocks the navigation and the code never reaches
+      // Claude. Allow the Claude callback origins.
+      formAction: ["'self'", "https://claude.ai", "http://localhost:*", "http://127.0.0.1:*"]
     }
   },
   crossOriginEmbedderPolicy: false,


### PR DESCRIPTION
**The** root cause of the connector failure. Consent form POSTs to /oauth/consent/approve → 302 to claude.ai. Chrome enforces CSP `form-action` across the redirect, and ours was `'self'` only, so the browser blocked the navigation to claude.ai — the code never reached Claude, so /token was never called. curl tests passed because curl ignores CSP. Fix: add https://claude.ai + loopback to form-action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)