### PR TITLE
chore(backend): remove temp MCP logger, render plan → starter

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -287,29 +287,6 @@ app.use('/api/v1/webhooks', webhookRoutes);
 app.use('/api/v1/workout-logs', workoutLogRoutes);
 app.use('/api/v1/train-now', trainNowRoutes);
 
-// TEMP diagnostic: log MCP/OAuth traffic (method, status, latency, and
-// non-secret request details) so connector issues are visible in Render logs.
-app.use((req, res, next) => {
-  if (/^\/(mcp|authorize|token|register|revoke|oauth|\.well-known)/.test(req.path)) {
-    const started = Date.now();
-    const detail = { ua: req.headers['user-agent'] };
-    if (req.path === '/token') {
-      Object.assign(detail, {
-        grant_type: req.body && req.body.grant_type,
-        client_id: req.body && req.body.client_id,
-        redirect_uri: req.body && req.body.redirect_uri,
-        has_code: !!(req.body && req.body.code),
-        has_verifier: !!(req.body && req.body.code_verifier),
-        authz_header: req.headers.authorization ? 'present' : 'absent'
-      });
-    }
-    res.on('finish', () => {
-      console.log(`[MCP] ${req.method} ${req.path} -> ${res.statusCode} (${Date.now() - started}ms) ${JSON.stringify(detail)}`);
-    });
-  }
-  next();
-});
-
 // MCP connector: OAuth authorization-server routes (mounted at root — the
 // `.well-known` discovery documents are origin-rooted) and the /mcp endpoint.
 app.use(mcpAuthRoutes);

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,9 @@ services:
     name: synergyfit-api
     env: node
     region: oregon
-    plan: free
+    # 'starter' (always-on) — 'free' spins down on idle, which breaks the MCP
+    # OAuth flow (Claude's ~10s endpoint timeout exceeds cold-start time).
+    plan: starter
     buildCommand: npm install --prefix backend
     startCommand: npm start --prefix backend
     envVars:
@@ -60,10 +62,6 @@ services:
         value: 2592000
       - key: MCP_AUTH_CODE_TTL_SECONDS
         value: 600
-    # NOTE: the `free` plan spins down on idle; cold starts can exceed Claude's
-    # ~10s OAuth-endpoint timeout and cause intermittent connector-setup
-    # failures. Upgrade to `starter`, or keep the service warm with an external
-    # pinger hitting /api/v1/health every few minutes.
 
   # Frontend Static Site
   - type: static


### PR DESCRIPTION
Post-launch cleanup: remove the temporary `[MCP]` request logger (keep stdout logging), set render.yaml `plan` to `starter` to match reality. 🤖 Generated with [Claude Code](https://claude.com/claude-code)