### PR TITLE
feat(ai-coach): coaching skills — generate/validate/schedule plans, exercise suggest/substitute, live management

### DIFF
--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -69,6 +69,7 @@ class AgentOrchestrator:
             calendar_service=self.calendar_service,
             search_service=self.search_service,
             memory_service=self.memory_service,
+            openai_client=self.client,
         )
 
         # Log configuration

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -19,6 +19,8 @@ TOOL USAGE GUIDELINES:
 **Grep Tools** (Pattern-matching search for specific exercise names):
 - `grep_exercises`: Use this when searching for SPECIFIC exercise names (e.g., "toes to bar", "muscle up"). Good for checking if an exercise exists before adding.
 - `grep_workouts`: Search workout templates by name/goal patterns.
+- `suggest_exercises`: Recommend exercises for a muscle group / movement pattern that fit the user's equipment and avoid injured areas. Use when the user asks "what should I do for X?".
+- `substitute_exercise`: Swap an exercise for a similar-stimulus one that fits available equipment (e.g. "I don't have a cable machine"). If the reason is pain/injury it will route to a safety caution instead of swapping — respect that.
 
 WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I have?", "show me back exercises", "hamstring exercises"):
 → Use `list_exercises` with the `muscle` parameter, NOT grep_exercises!
@@ -34,10 +36,12 @@ WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I 
 - `get_workout_history`: View past workouts to analyze progress.
 
 **Training Plans** (Multi-week programs):
-- `create_plan`: Create structured training plans with weekly schedules. Plans can use workout templates or define custom workouts inline.
+- `generate_plan`: PREFERRED for building a new multi-week plan for a goal — it tailors workouts to the user's level/equipment/health caveats, validates the result, and saves a DRAFT (no calendar changes). Use this instead of hand-building with create_plan/add_plan_workout. After the user reviews the draft, put it on the calendar with `schedule_plan_to_calendar`.
+- `validate_plan`: Check an existing/draft plan for quality issues (volume, frequency, rest, deload, ramp, goal fit) before scheduling or after edits. Read-only.
+- `create_plan`: Low-level — create a plan from explicit structure. Prefer `generate_plan` for goal-driven plans.
 - `list_plans`: View user's existing plans.
 - `update_plan`: Modify plan details or status.
-- `add_plan_workout` / `remove_plan_workout`: Manage workouts within plan weeks.
+- `add_plan_workout` / `remove_plan_workout`: Manage individual workouts within plan weeks.
 
 **Goals**:
 - `create_goal`: Set fitness goals with target metrics.
@@ -48,6 +52,9 @@ WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I 
 - `schedule_to_calendar`: Schedule a SINGLE workout or event to a specific date. Use this for one-off scheduling. Supports 'today', 'tomorrow', or ISO dates.
 - `schedule_plan_to_calendar`: Schedule an ENTIRE multi-week plan (or several weeks of it) in ONE call. Whenever the user wants a whole plan put on the calendar, use this — never place plan workouts day-by-day with repeated `schedule_to_calendar` calls. It defaults to a dry-run PREVIEW that writes nothing; show the user the preview, and only after they confirm, call it again with `dry_run=false` to actually write the events.
 - `get_calendar_events`: Check what's already scheduled on the user's calendar.
+- `reschedule_session`: Move or skip ONE session the user missed or wants to change. Previews first, writes on confirm.
+- `review_progress`: Report adherence/progress over a recent window (from the calendar) for "how am I doing?" check-ins. Read-only.
+- `adjust_plan`: Change a live plan's volume/frequency or add a deload mid-cycle. Previews + re-validates; big volume jumps need override.
 
 **Web Search & Research** (External resources):
 

--- a/ai-coach-service/app/core/agents/skills/__init__.py
+++ b/ai-coach-service/app/core/agents/skills/__init__.py
@@ -20,6 +20,13 @@ from app.core.agents.skills.registry import (  # noqa: F401
 # Add one import line per new skill file.
 from app.core.agents.skills import example_skill  # noqa: F401,E402
 from app.core.agents.skills import schedule_plan_skill  # noqa: F401,E402
+from app.core.agents.skills import validate_plan_skill  # noqa: F401,E402
+from app.core.agents.skills import generate_plan_skill  # noqa: F401,E402
+from app.core.agents.skills import substitute_exercise_skill  # noqa: F401,E402
+from app.core.agents.skills import suggest_exercises_skill  # noqa: F401,E402
+from app.core.agents.skills import review_progress_skill  # noqa: F401,E402
+from app.core.agents.skills import reschedule_session_skill  # noqa: F401,E402
+from app.core.agents.skills import adjust_plan_skill  # noqa: F401,E402
 
 __all__ = [
     "SkillContext",

--- a/ai-coach-service/app/core/agents/skills/adjust_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/adjust_plan_skill.py
@@ -1,0 +1,182 @@
+"""
+Skill: adjust_plan
+
+Modify a live plan mid-cycle — volume, frequency, or insert a deload — then
+re-validate. Dry-run by default with conversational confirm. Won't push volume
+past the ramp cap without an explicit override + caution (spec).
+
+`apply_adjustment` is a pure transform (unit-tested); the handler validates,
+guards the cap, and persists.
+"""
+
+import copy
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+from app.core.agents.skills.knowledge import training_knowledge as tk
+from app.core.agents.skills.validate_plan_skill import validate_plan_doc, _week_metrics
+
+
+def _avg_weekly_sets(weeks: List[Dict[str, Any]]) -> float:
+    per = [_week_metrics(w) for w in weeks]
+    training = [m for m in per if m[0] > 0]
+    return (sum(m[1] for m in training) / len(training)) if training else 0.0
+
+
+def apply_adjustment(
+    weeks: List[Dict[str, Any]],
+    change_type: str,
+    direction: str,
+    magnitude: int,
+) -> Tuple[List[Dict[str, Any]], str]:
+    """Pure transform. Returns (new_weeks, human description)."""
+    weeks = copy.deepcopy(weeks or [])
+    change_type = (change_type or "").lower()
+    direction = (direction or "increase").lower()
+    magnitude = max(1, int(magnitude or 1))
+    desc = ""
+
+    if change_type == "volume":
+        delta = magnitude if direction == "increase" else -magnitude
+        for w in weeks:
+            for wo in w.get("workouts", []) or []:
+                cw = wo.get("customWorkout")
+                if not cw:
+                    continue
+                for ex in cw.get("exercises", []) or []:
+                    sets = ex.get("sets", []) or []
+                    if delta > 0:
+                        template = dict(sets[-1]) if sets else {"reps": 10}
+                        sets = sets + [dict(template) for _ in range(delta)]
+                    else:
+                        for _ in range(-delta):
+                            if len(sets) > 1:
+                                sets = sets[:-1]
+                    ex["sets"] = sets
+        desc = f"{direction}d volume by {magnitude} set(s) per exercise"
+
+    elif change_type == "deload":
+        for w in weeks:
+            if (w.get("workouts") or []) and not w.get("deloadWeek"):
+                w["deloadWeek"] = True
+                for wo in w["workouts"]:
+                    cw = wo.get("customWorkout")
+                    if cw:
+                        for ex in cw.get("exercises", []) or []:
+                            sets = ex.get("sets", []) or []
+                            ex["sets"] = sets[: max(1, round(len(sets) * 0.6))]
+                desc = f"added a deload at week {w.get('weekNumber')}"
+                break
+
+    elif change_type == "frequency":
+        if direction == "decrease":
+            for w in weeks:
+                if len(w.get("workouts", []) or []) > 1:
+                    w["workouts"] = w["workouts"][:-1]
+            desc = "reduced training frequency by one day/week"
+        else:
+            for w in weeks:
+                workouts = w.get("workouts", []) or []
+                if not workouts:
+                    continue
+                used = {x.get("dayOfWeek") for x in workouts}
+                off = next((d for d in range(7) if d not in used), None)
+                if off is not None:
+                    extra = copy.deepcopy(workouts[0])
+                    extra["dayOfWeek"] = off
+                    w["workouts"] = workouts + [extra]
+            desc = "added one training day/week"
+
+    return weeks, desc
+
+
+@skill(
+    name="adjust_plan",
+    description=(
+        "Adjust a live training plan mid-cycle: change volume (sets), frequency (days/week), "
+        "or insert a deload. Re-validates the result. Previews first; writes only on confirm "
+        "(dry_run=false). Won't push volume past the safe ramp without override=true."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "plan_id": {"type": "string", "description": "The plan to adjust."},
+            "change_type": {"type": "string", "enum": ["volume", "frequency", "deload"]},
+            "direction": {"type": "string", "enum": ["increase", "decrease"], "description": "For volume/frequency."},
+            "magnitude": {"type": "integer", "description": "Sets/days to change (default 1).", "minimum": 1},
+            "override": {"type": "boolean", "description": "Allow exceeding the ramp cap (with caution). Default false."},
+            "dry_run": {"type": "boolean", "description": "Preview only. Default true."},
+        },
+        "required": ["plan_id", "change_type"],
+    },
+)
+async def adjust_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    plan_id = args.get("plan_id")
+    change_type = args.get("change_type")
+    if not plan_id or not change_type:
+        return {"success": False, "message": "plan_id and change_type are required."}
+    try:
+        plan_oid = ObjectId(plan_id)
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid plan_id."}
+
+    plan = await ctx.db.plans.find_one({"_id": plan_oid, "userId": user_oid})
+    if not plan:
+        return {"success": False, "message": "Plan not found."}
+
+    direction = args.get("direction", "increase")
+    magnitude = int(args.get("magnitude") or 1)
+    override = bool(args.get("override", False))
+
+    old_avg = _avg_weekly_sets(plan.get("weeks", []) or [])
+    new_weeks, desc = apply_adjustment(plan.get("weeks", []) or [], change_type, direction, magnitude)
+    if not desc:
+        return {"success": False, "message": "That adjustment didn't change anything — try a different change_type/direction."}
+    new_avg = _avg_weekly_sets(new_weeks)
+
+    # Cap guard: a volume increase that jumps past the ramp cap needs override.
+    if change_type == "volume" and direction == "increase" and old_avg > 0 and not override:
+        if new_avg > old_avg * tk.WEEKLY_RAMP_HARD_FLAG:
+            return {
+                "success": True,
+                "needs_confirmation": "override",
+                "message": (
+                    f"That would raise weekly volume from ~{old_avg:.0f} to ~{new_avg:.0f} sets "
+                    f"(> the {int((tk.WEEKLY_RAMP_HARD_FLAG-1)*100)}% ramp guideline). That's a big jump — "
+                    f"confirm with override to proceed, or make a smaller increase."
+                ),
+            }
+
+    # Re-validate the modified plan.
+    goal_category = "general"
+    if plan.get("goalId"):
+        try:
+            goal = await ctx.db.goals.find_one({"_id": plan["goalId"], "userId": user_oid}, {"category": 1})
+            goal_category = (goal or {}).get("category") or "general"
+        except Exception:
+            pass
+    report = validate_plan_doc({"schedule": plan.get("schedule") or {}, "weeks": new_weeks}, goal_category)
+
+    if args.get("dry_run", True):
+        msg = f"Proposed change: {desc} (~{old_avg:.0f} → ~{new_avg:.0f} sets/wk).\n\n"
+        msg += ("Validation looks good. " if report["valid"] else
+                "Note:\n" + "\n".join(f"- {v}" for v in report["violations"]) + "\n\n")
+        msg += "Apply it?"
+        return {"success": True, "dry_run": True, "description": desc, "validation": report, "message": msg}
+
+    total_workouts = sum(len(w.get("workouts", []) or []) for w in new_weeks)
+    await ctx.db.plans.update_one(
+        {"_id": plan_oid, "userId": user_oid},
+        {"$set": {"weeks": new_weeks, "progress.totalWorkouts": total_workouts, "updatedAt": datetime.utcnow()}},
+    )
+    return {
+        "success": True,
+        "dry_run": False,
+        "description": desc,
+        "validation": report,
+        "message": f"Done — {desc}. Weekly volume is now ~{new_avg:.0f} sets.",
+    }

--- a/ai-coach-service/app/core/agents/skills/generate_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/generate_plan_skill.py
@@ -1,0 +1,290 @@
+"""
+Skill: generate_plan
+
+Builds a multi-week DRAFT training plan aligned to a goal, then validates it.
+The split follows the spec: the model chooses/justifies exercises (a set of
+weekly workout "blueprints"); deterministic code does the scaffolding — assigning
+training days, repeating blueprints across weeks, inserting deloads, and marking
+rest days. Names produced by the model are checked against the real exercise
+library.
+
+"Dry-run by default" here means NO CALENDAR WRITES: it persists a `status:"draft"`
+plan (cheap, discardable) and returns it plus a validation report. The user then
+reviews and schedules it with `schedule_plan_to_calendar` (which has its own
+dry-run/confirm).
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+from app.core.agents.skills.knowledge import training_knowledge as tk
+from app.core.agents.skills.safety import get_safety_context, format_caveats_for_prompt
+from app.core.agents.skills.validate_plan_skill import validate_plan_doc
+
+# Category inference from free-text goals (used only when no goalId is linked).
+_CATEGORY_KEYWORDS = {
+    "strength": ["strength", "stronger", "1rm", "powerlift", "deadlift", "squat", "bench"],
+    "endurance": ["endurance", "run", "5k", "10k", "marathon", "cardio", "cycling", "aerobic"],
+    "skill": ["pull-up", "pullup", "muscle-up", "handstand", "planche", "skill", "calisthenic"],
+    "weight": ["lose weight", "fat loss", "weight loss", "lean", "cut"],
+    "health": ["health", "general fitness", "feel better", "mobility", "wellness"],
+}
+
+
+def infer_category(goal_text: str) -> str:
+    low = (goal_text or "").lower()
+    for category, words in _CATEGORY_KEYWORDS.items():
+        if any(w in low for w in words):
+            return category
+    return "general"
+
+
+def pick_workout_days(days_per_week: int, preferred: Optional[List[int]]) -> List[int]:
+    """Choose dayOfWeek slots (0=Sun..6=Sat). Prefer the user's days, else spread
+    evenly to avoid clustering (which keeps rest gaps between sessions)."""
+    days_per_week = max(1, min(7, int(days_per_week)))
+    if preferred:
+        picked = sorted(set(int(d) for d in preferred if 0 <= int(d) <= 6))[:days_per_week]
+        if len(picked) == days_per_week:
+            return picked
+    # Even spread across the week.
+    step = 7 / days_per_week
+    return sorted({int(round(i * step)) % 7 for i in range(days_per_week)})
+
+
+def _scale_sets(base_sets: int, is_deload: bool) -> int:
+    """Deload weeks cut volume ~40%; otherwise keep the blueprint volume."""
+    if is_deload:
+        return max(1, round(base_sets * 0.6))
+    return max(1, base_sets)
+
+
+def build_plan_weeks(
+    blueprints: List[Dict[str, Any]],
+    workout_days: List[int],
+    weeks: int,
+) -> List[Dict[str, Any]]:
+    """Pure: expand weekly blueprints across N weeks with deloads + rest days."""
+    out: List[Dict[str, Any]] = []
+
+    for wn in range(1, weeks + 1):
+        # Deload every DELOAD_EVERY_WEEKS_MAX weeks (e.g. week 6, 12) for long plans.
+        is_deload = tk.expects_deload(weeks) and wn % tk.DELOAD_EVERY_WEEKS_MAX == 0
+        workouts = []
+        for i, day in enumerate(workout_days):
+            bp = blueprints[i % len(blueprints)]
+            exercises = []
+            for ex in bp.get("exercises", []) or []:
+                base_sets = int(ex.get("sets", 3) or 3)
+                reps = int(ex.get("reps", 10) or 10)
+                # Distinct dict per set (avoid aliasing the same object N times).
+                exercises.append({
+                    "exerciseName": ex.get("exerciseName", ""),
+                    "sets": [{"reps": reps} for _ in range(_scale_sets(base_sets, is_deload))],
+                })
+            workouts.append({
+                "dayOfWeek": day,
+                "workoutType": "custom",
+                "customWorkout": {
+                    "title": bp.get("title", "Workout"),
+                    "type": bp.get("type", "strength"),
+                    "durationMinutes": int(bp.get("durationMinutes", 45) or 45),
+                    "exercises": exercises,
+                },
+            })
+        out.append({
+            "weekNumber": wn,
+            "focus": "Deload" if is_deload else "",
+            "deloadWeek": is_deload,
+            # Off-days are implicit — we don't materialize a calendar event for
+            # every rest day (that would flood the calendar). Explicit rest/deload
+            # events remain available via the plan's restDays when deliberately set.
+            "restDays": [],
+            "workouts": workouts,
+        })
+    return out
+
+
+_SYSTEM_PROMPT = (
+    "You are a strength & conditioning coach. Design a weekly set of workout "
+    "'blueprints' (one per training day) for the user's goal. Output JSON only."
+)
+
+
+def _build_llm_prompt(goal_name, category, fitness_level, equipment, duration, days_per_week, caveats) -> str:
+    return f"""Design {days_per_week} distinct workout blueprints for one training week.
+
+Goal: {goal_name} (category: {category})
+Fitness level: {fitness_level}
+Available equipment: {', '.join(equipment) if equipment else 'bodyweight only'}
+Target session length: ~{duration} min
+Health caveats (work AROUND these, never program into injured areas):
+{caveats}
+
+Return JSON exactly:
+{{"workouts": [
+  {{"title": "...", "type": "strength|cardio|hybrid|recovery|hiit", "durationMinutes": {duration},
+    "focus": "short phrase",
+    "exercises": [{{"exerciseName": "real common exercise name", "sets": 3, "reps": 10}}]}}
+]}}
+Rules: {days_per_week} blueprints; 3-6 exercises each; use widely-known exercise names; match equipment and level."""
+
+
+async def _validate_exercise_names(ctx: SkillContext, user_id: str, names: List[str]) -> List[str]:
+    """Best-effort: return names not found in the exercise library (advisory)."""
+    if not names:
+        return []
+    try:
+        res = await ctx.exercise_service.grep_exercises(user_id, {"patterns": names})
+        return list(res.get("missing", []) or [])
+    except Exception:
+        return []
+
+
+@skill(
+    name="generate_plan",
+    description=(
+        "Generate a multi-week DRAFT training plan tailored to the user's goal, level, "
+        "equipment and any health caveats, then validate it. Does NOT touch the calendar — "
+        "it creates a draft plan for review; the user schedules it afterward with "
+        "schedule_plan_to_calendar."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "goal_id": {"type": "string", "description": "ID of an existing goal to build the plan around."},
+            "goal_text": {"type": "string", "description": "Free-text goal if no goal_id (e.g. 'first pull-up in 8 weeks')."},
+            "weeks": {"type": "integer", "description": "Plan length in weeks (default 8).", "minimum": 1, "maximum": 52},
+            "days_per_week": {"type": "integer", "description": "Training days/week (default: from profile, else 3).", "minimum": 1, "maximum": 7},
+            "name": {"type": "string", "description": "Optional plan name."},
+        },
+    },
+)
+async def generate_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid user."}
+
+    # --- Resolve goal ---
+    goal_name = args.get("goal_text") or ""
+    category = "general"
+    goal_id = args.get("goal_id")
+    linked_goal_oid = None
+    if goal_id:
+        try:
+            linked_goal_oid = ObjectId(goal_id)
+            goal = await ctx.db.goals.find_one({"_id": linked_goal_oid, "userId": user_oid})
+            if goal:
+                goal_name = goal.get("name", goal_name)
+                category = goal.get("category", "general")
+        except Exception:
+            linked_goal_oid = None
+    elif goal_name:
+        category = infer_category(goal_name)
+
+    if not goal_name:
+        return {
+            "success": True,
+            "needs_input": "goal",
+            "message": "What's the goal for this plan? (e.g. 'build strength', 'run a 5k', 'first pull-up')",
+        }
+
+    # --- Profile (must-have check: availability) ---
+    user = await ctx.db.users.find_one({"_id": user_oid}, {"profile": 1})
+    profile = (user or {}).get("profile") or {}
+    prefs = profile.get("preferences") or {}
+    fitness_level = profile.get("fitnessLevel", "beginner")
+    equipment = prefs.get("equipment") or []
+    duration = prefs.get("workoutDuration") or 45
+    weeks = int(args.get("weeks") or 8)
+    days_per_week = int(args.get("days_per_week") or len(prefs.get("workoutDays") or []) or 3)
+
+    # --- Safety caveats ---
+    safety = await get_safety_context(ctx, user_id)
+
+    # --- LLM: generate weekly blueprints ---
+    if ctx.openai_client is None:
+        return {"success": False, "message": "Plan generation is unavailable (no model client)."}
+    prompt = _build_llm_prompt(
+        goal_name, category, fitness_level, equipment, duration, days_per_week,
+        format_caveats_for_prompt(safety),
+    )
+    try:
+        resp = await ctx.openai_client.chat.completions.create(
+            model=ctx.settings.openai_model,
+            messages=[{"role": "system", "content": _SYSTEM_PROMPT}, {"role": "user", "content": prompt}],
+            response_format={"type": "json_object"},
+            temperature=0.7,
+            max_completion_tokens=2000,
+        )
+        blueprints = json.loads(resp.choices[0].message.content).get("workouts", [])
+    except Exception as e:
+        return {"success": False, "message": f"Couldn't generate the plan: {e}"}
+
+    if not blueprints:
+        return {"success": False, "message": "The plan came back empty — try again or refine the goal."}
+
+    # --- Deterministic scaffold ---
+    workout_days = pick_workout_days(days_per_week, prefs.get("workoutDays"))
+    plan_weeks = build_plan_weeks(blueprints, workout_days, weeks)
+
+    # --- Validate before writing ---
+    plan_name = args.get("name") or f"{weeks}-Week {goal_name} Plan"
+    plan_doc_for_validation = {
+        "schedule": {"weeksTotal": weeks, "workoutsPerWeek": len(workout_days)},
+        "weeks": plan_weeks,
+    }
+    report = validate_plan_doc(plan_doc_for_validation, category)
+
+    unverified = await _validate_exercise_names(
+        ctx, user_id,
+        [ex.get("exerciseName", "") for bp in blueprints for ex in bp.get("exercises", []) if ex.get("exerciseName")],
+    )
+
+    # --- Persist DRAFT plan (no calendar writes) ---
+    create_args = {
+        "name": plan_name,
+        "description": f"AI-generated draft for: {goal_name}",
+        "schedule": {
+            "weeksTotal": weeks,
+            "workoutsPerWeek": len(workout_days),
+            "restDays": sorted(set(range(7)) - set(workout_days)),
+            "preferredWorkoutDays": workout_days,
+        },
+        "weeks": plan_weeks,
+        "tags": ["ai-generated", "draft"],
+    }
+    if linked_goal_oid:
+        create_args["goalId"] = str(linked_goal_oid)
+
+    create_result = await ctx.plan_service.create_plan(user_id, create_args)
+    if not create_result.get("success"):
+        return {"success": False, "message": create_result.get("message", "Failed to save the draft plan.")}
+
+    msg = (
+        f"📋 Drafted **{plan_name}** — {weeks} weeks, {len(workout_days)} days/week"
+        f" ({report['metrics']['avg_weekly_sets']} sets/wk).\n\n"
+    )
+    if report["valid"]:
+        msg += "It passes the quality checks. "
+    else:
+        msg += "A few things to review:\n" + "\n".join(f"- {v}" for v in report["violations"]) + "\n\n"
+    if unverified:
+        msg += f"Note: {len(unverified)} exercise name(s) weren't found in your library and may be created on scheduling.\n\n"
+    msg += "Want me to put it on your calendar?"
+
+    return {
+        "success": True,
+        "dry_run": True,
+        "plan_id": create_result.get("plan_id"),
+        "name": plan_name,
+        "weeks": weeks,
+        "days_per_week": len(workout_days),
+        "validation": report,
+        "unverified_exercises": unverified,
+        "message": msg,
+    }

--- a/ai-coach-service/app/core/agents/skills/knowledge/__init__.py
+++ b/ai-coach-service/app/core/agents/skills/knowledge/__init__.py
@@ -1,0 +1,3 @@
+"""Training knowledge base for AI-coach skills (sourced constants + helpers)."""
+
+from app.core.agents.skills.knowledge import training_knowledge  # noqa: F401

--- a/ai-coach-service/app/core/agents/skills/knowledge/movement.py
+++ b/ai-coach-service/app/core/agents/skills/knowledge/movement.py
@@ -1,0 +1,45 @@
+"""
+Movement-pattern inference for exercises.
+
+The Exercise model has no movementPattern field (see the skills roadmap). Until
+that's added (or replaced by a vector-search KB), we infer a coarse pattern from
+the exercise name, falling back to its primary muscle. Pure functions — no DB.
+
+Patterns are the standard primal categories used for substitution matching:
+push / pull / squat / hinge / carry / core / cardio.
+"""
+
+from typing import Any, Dict, List, Optional
+
+# Name keywords -> movement pattern. Order matters: earlier patterns win.
+MOVEMENT_PATTERNS: Dict[str, List[str]] = {
+    "hinge": ["deadlift", "romanian", "rdl", "hip thrust", "good morning", "kettlebell swing", "swing", "hip hinge"],
+    "squat": ["squat", "lunge", "leg press", "step-up", "step up", "split squat", "pistol"],
+    "pull": ["pull-up", "pullup", "chin-up", "chinup", "row", "lat pulldown", "pulldown", "curl", "face pull", "muscle-up"],
+    "push": ["bench", "push-up", "pushup", "press", "dip", "overhead", "ohp", "fly", "pushdown", "extension", "handstand"],
+    "carry": ["carry", "farmer", "suitcase", "waiter"],
+    "core": ["plank", "crunch", "sit-up", "situp", "hollow", "leg raise", "knee raise", "ab wheel", "rollout", "russian twist"],
+    "cardio": ["run", "jog", "sprint", "bike", "cycl", "rowing", "erg", "burpee", "jump rope", "skip", "swim", "elliptical"],
+}
+
+# Primary muscle -> pattern fallback when the name isn't recognized.
+MUSCLE_TO_PATTERN: Dict[str, str] = {
+    "chest": "push", "shoulders": "push", "triceps": "push", "delts": "push",
+    "back": "pull", "lats": "pull", "biceps": "pull", "traps": "pull", "rhomboids": "pull",
+    "quads": "squat", "quadriceps": "squat", "calves": "squat",
+    "glutes": "hinge", "hamstrings": "hinge", "lower back": "hinge",
+    "core": "core", "abs": "core", "obliques": "core",
+}
+
+
+def infer_movement_pattern(exercise: Dict[str, Any]) -> Optional[str]:
+    """Best-effort pattern from name, then primary muscle. None if unknown."""
+    name = (exercise.get("name") or "").lower()
+    for pattern, keywords in MOVEMENT_PATTERNS.items():
+        if any(kw in name for kw in keywords):
+            return pattern
+    for muscle in exercise.get("muscles", []) or []:
+        pattern = MUSCLE_TO_PATTERN.get((muscle or "").lower())
+        if pattern:
+            return pattern
+    return None

--- a/ai-coach-service/app/core/agents/skills/knowledge/training_knowledge.py
+++ b/ai-coach-service/app/core/agents/skills/knowledge/training_knowledge.py
@@ -1,0 +1,82 @@
+"""
+Training knowledge base — sourced constants for deterministic plan checks.
+
+Follows the reflection_config.py pattern (a plain module of documented dicts, no
+class). These thresholds are population-level guidance; several are best-practice
+heuristics rather than RCT-proven constants and are tagged accordingly. Skills
+read these constants so the numbers live in one auditable place, not in prompts.
+
+Sources are noted inline: WHO 2020 physical-activity guidelines; Schoenfeld et al.
+2017 (hypertrophy volume); ACSM Guidelines; concurrent-training reviews
+(Schumann 2022). Contested metrics (ACWR, the "10% rule") are flagged so no skill
+treats them as settled.
+"""
+
+# Minimum training frequency (sessions/week) by goal category.
+# Goal categories match the ai-coach `goals` collection: strength, endurance,
+# skill, weight, performance, health, general.
+MIN_SESSIONS_PER_WEEK = {
+    "strength": 2,       # ACSM: 2+ resistance days/week
+    "endurance": 3,      # aerobic base needs frequency
+    "skill": 2,          # skill acquisition benefits from frequency
+    "weight": 3,         # combined resistance + aerobic
+    "performance": 3,
+    "health": 2,         # WHO: muscle-strengthening 2+ days/week
+    "general": 2,
+}
+
+# Minimum working sets per week (whole-body proxy; per-muscle counting is a v2
+# enhancement that needs exercise->muscle resolution). Hypertrophy anchor:
+# Schoenfeld/Ogborn/Krieger 2017 ~10 sets/muscle/week for maximizing growth.
+MIN_WEEKLY_SETS = {
+    "strength": 10,
+    "endurance": 6,
+    "skill": 8,
+    "weight": 10,
+    "performance": 10,
+    "health": 6,
+    "general": 8,
+}
+
+# WHO 2020 aerobic guidance (minutes/week of moderate activity) — used for
+# endurance/health/weight goal specificity checks.
+WHO_AEROBIC_MIN_MINUTES = 150
+WHO_AEROBIC_MAX_MINUTES = 300
+
+# Recovery / spacing (best-practice heuristics).
+MIN_HOURS_SAME_MUSCLE = 48          # >=48h between heavy same-muscle sessions
+MIN_HOURS_CONCURRENT_SEPARATION = 3  # strength+endurance same day: separate >=3h
+DELOAD_EVERY_WEEKS_MIN = 4           # deload cadence 4-6 weeks
+DELOAD_EVERY_WEEKS_MAX = 6
+
+# Week-over-week load ramp cap. NOTE: the "10% rule" is NOT an evidence-based
+# hard threshold (Buist 2008; Nielsen review) — used here only as a conservative
+# guideline default. Allow some slack before flagging.
+WEEKLY_RAMP_CAP = 1.10               # guideline
+WEEKLY_RAMP_HARD_FLAG = 1.30         # flag clearly aggressive jumps
+
+# Metrics that must never autonomously gate or predict injury (surface honestly).
+CONTESTED_METRICS = {
+    "ACWR": "Acute:chronic workload ratio — criticized for poor predictive "
+            "validity (Impellizzeri 2020). Monitoring aid only, never a gate.",
+    "ten_percent_rule": "No evidence for 10%/week as a hard threshold (Buist "
+                        "2008; Nielsen review). Guideline, not a rule.",
+    "HRV_readiness": "Noisy and individual; a soft nudge, never an autonomous "
+                     "decision driver.",
+}
+
+# Disciplines that count as aerobic/endurance stimulus (for goal-specificity).
+AEROBIC_WORKOUT_TYPES = {"cardio", "hiit", "endurance"}
+
+
+def min_sessions_for_goal(category: str) -> int:
+    return MIN_SESSIONS_PER_WEEK.get((category or "general").lower(), MIN_SESSIONS_PER_WEEK["general"])
+
+
+def min_weekly_sets_for_goal(category: str) -> int:
+    return MIN_WEEKLY_SETS.get((category or "general").lower(), MIN_WEEKLY_SETS["general"])
+
+
+def expects_deload(weeks_total: int) -> bool:
+    """Plans long enough to warrant at least one deload."""
+    return weeks_total is not None and weeks_total >= DELOAD_EVERY_WEEKS_MAX

--- a/ai-coach-service/app/core/agents/skills/registry.py
+++ b/ai-coach-service/app/core/agents/skills/registry.py
@@ -49,8 +49,8 @@ SkillHandler = Callable[["SkillContext", str, Dict[str, Any]], Awaitable[Dict[st
 class SkillContext:
     """Shared resources handed to every skill handler.
 
-    Lets a skill reach the database, settings, and existing services without
-    re-wiring anything in the orchestrator.
+    Lets a skill reach the database, settings, existing services, and the shared
+    OpenAI client without re-wiring anything in the orchestrator.
     """
 
     db: "AsyncIOMotorDatabase"
@@ -62,6 +62,10 @@ class SkillContext:
     calendar_service: "CalendarService"
     search_service: "SearchService"
     memory_service: "MemoryService"
+    # Shared AsyncOpenAI client, for skills that make their own LLM calls
+    # (generate_plan, suggest_exercises, ...). Optional so DB-only skills and
+    # tests need not provide it.
+    openai_client: Any = None
 
 
 class SkillRegistry:

--- a/ai-coach-service/app/core/agents/skills/reschedule_session_skill.py
+++ b/ai-coach-service/app/core/agents/skills/reschedule_session_skill.py
@@ -1,0 +1,105 @@
+"""
+Skill: reschedule_session
+
+Handle a single missed or moved calendar session: skip it, shift it to a new
+date, or auto-decide. Dry-run by default with conversational confirm, matching
+the other write skills.
+
+`resolve_reschedule` is a pure decision helper (unit-tested); the handler loads
+the event and applies the resolved operation.
+"""
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+from app.core.agents.skills.schedule_plan_skill import _parse_start_date, _midnight
+
+
+def resolve_reschedule(
+    event_date: Optional[datetime],
+    action: str,
+    new_date: Optional[datetime],
+    today: datetime,
+) -> Dict[str, Any]:
+    """Pure: decide the operation. Returns {op: 'skip'|'shift', to_date?}."""
+    action = (action or "auto").lower()
+    if action == "skip":
+        return {"op": "skip"}
+    if action == "shift":
+        return {"op": "shift", "to_date": new_date or (today + timedelta(days=1))}
+    # auto / compress: prefer an explicit date, else move a missed session to
+    # tomorrow, else (a future session with no target) just skip it.
+    if new_date:
+        return {"op": "shift", "to_date": new_date}
+    if event_date and event_date.date() < today.date():
+        return {"op": "shift", "to_date": today + timedelta(days=1)}
+    return {"op": "skip"}
+
+
+@skill(
+    name="reschedule_session",
+    description=(
+        "Reschedule ONE calendar session the user missed or wants to move: skip it, shift "
+        "it to another date, or let me auto-decide. Previews the change first; only writes "
+        "after the user confirms (dry_run=false)."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "event_id": {"type": "string", "description": "The calendar event to reschedule."},
+            "action": {"type": "string", "enum": ["skip", "shift", "auto"], "description": "Default 'auto'."},
+            "new_date": {"type": "string", "description": "Target date for a shift (ISO / 'today' / 'tomorrow')."},
+            "dry_run": {"type": "boolean", "description": "Preview only. Default true; set false to apply."},
+        },
+        "required": ["event_id"],
+    },
+)
+async def reschedule_session(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    event_id = args.get("event_id")
+    if not event_id:
+        return {"success": False, "message": "event_id is required."}
+    try:
+        event_oid = ObjectId(event_id)
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid event_id."}
+
+    event = await ctx.db.calendarevents.find_one({"_id": event_oid, "userId": user_oid})
+    if not event:
+        return {"success": False, "message": "I couldn't find that session on your calendar."}
+
+    today = _midnight(datetime.utcnow())
+    res = resolve_reschedule(event.get("date"), args.get("action", "auto"), _parse_start_date(args.get("new_date")), today)
+    dry_run = args.get("dry_run", True)
+    title = event.get("title", "session")
+
+    if res["op"] == "skip":
+        summary = f"Mark **{title}** as skipped."
+    else:
+        summary = f"Move **{title}** to **{res['to_date'].strftime('%A, %B %d')}**."
+
+    if dry_run:
+        return {"success": True, "dry_run": True, "op": res["op"], "message": f"{summary}\n\nConfirm?"}
+
+    now = datetime.utcnow()
+    if res["op"] == "skip":
+        await ctx.db.calendarevents.update_one(
+            {"_id": event_oid, "userId": user_oid},
+            {"$set": {"status": "skipped", "updatedAt": now}},
+        )
+        return {"success": True, "dry_run": False, "op": "skip", "message": f"Marked **{title}** as skipped."}
+
+    await ctx.db.calendarevents.update_one(
+        {"_id": event_oid, "userId": user_oid},
+        {"$set": {"date": res["to_date"], "status": "scheduled", "updatedAt": now}},
+    )
+    return {
+        "success": True,
+        "dry_run": False,
+        "op": "shift",
+        "to_date": res["to_date"].strftime("%Y-%m-%d"),
+        "message": f"Moved **{title}** to **{res['to_date'].strftime('%A, %B %d')}**.",
+    }

--- a/ai-coach-service/app/core/agents/skills/review_progress_skill.py
+++ b/ai-coach-service/app/core/agents/skills/review_progress_skill.py
@@ -1,0 +1,135 @@
+"""
+Skill: review_progress
+
+Report training adherence and progress toward a goal. Adherence is DERIVED from
+calendar events (completed / (completed + skipped + missed)), because
+Plan.progress.adherencePercentage is known-stale (not updated by calendar
+completion). "Missed" = a workout/deload event whose date has passed but is still
+`scheduled`.
+
+`compute_adherence` is pure and unit-tested; the handler fetches events and adds
+a recommendation the orchestrator can frame conversationally.
+"""
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+
+# Only these event types count toward training adherence (rest days don't).
+_TRAINING_TYPES = {"workout", "deload"}
+_ON_TRACK_THRESHOLD = 0.70
+
+
+def compute_adherence(events: List[Dict[str, Any]], today: datetime) -> Dict[str, Any]:
+    """Pure: derive adherence counts from calendar events.
+
+    completed / (completed + skipped + missed). Future 'scheduled' events are not
+    yet due and don't count against the user.
+    """
+    completed = skipped = missed = upcoming = 0
+    for e in events:
+        if e.get("type") not in _TRAINING_TYPES:
+            continue
+        status = e.get("status")
+        if status == "completed":
+            completed += 1
+        elif status == "skipped":
+            skipped += 1
+        elif status == "scheduled":
+            date = e.get("date")
+            if date and date.date() < today.date():
+                missed += 1
+            else:
+                upcoming += 1
+
+    due = completed + skipped + missed
+    adherence_pct = round(100 * completed / due) if due else None
+    return {
+        "completed": completed,
+        "skipped": skipped,
+        "missed": missed,
+        "upcoming": upcoming,
+        "due": due,
+        "adherencePct": adherence_pct,
+    }
+
+
+def _recommendation(a: Dict[str, Any]) -> str:
+    pct = a["adherencePct"]
+    if pct is None:
+        return "No sessions were due in this window yet — schedule some and check back."
+    if pct >= 90:
+        return "Great consistency — consider progressing volume or intensity in the next block."
+    if pct >= _ON_TRACK_THRESHOLD * 100:
+        return "Solid adherence. Keep the current plan; small progression is warranted."
+    if a["missed"] >= a["completed"]:
+        return "A lot of sessions are slipping — consider reducing frequency or rescheduling to fit your week."
+    return "Adherence is a bit low; let's look at what's getting in the way and adjust the plan."
+
+
+@skill(
+    name="review_progress",
+    description=(
+        "Review the user's training adherence (and progress toward a goal) over a recent "
+        "window, computed from their calendar. Use for 'how am I doing?' / progress check-ins. "
+        "Read-only."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "goal_id": {"type": "string", "description": "Optional goal to frame progress around."},
+            "window_days": {"type": "integer", "description": "Look-back window in days (default 28).", "minimum": 1},
+        },
+    },
+)
+async def review_progress(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid user."}
+
+    window_days = int(args.get("window_days") or 28)
+    now = datetime.utcnow()
+    start = now - timedelta(days=window_days)
+
+    events = await ctx.db.calendarevents.find({
+        "userId": user_oid,
+        "date": {"$gte": start, "$lte": now},
+        "status": {"$ne": "cancelled"},
+    }).to_list(None)
+
+    adherence = compute_adherence(events, now)
+    on_track = adherence["adherencePct"] is not None and adherence["adherencePct"] >= _ON_TRACK_THRESHOLD * 100
+
+    goal_name = None
+    if args.get("goal_id"):
+        try:
+            goal = await ctx.db.goals.find_one({"_id": ObjectId(args["goal_id"]), "userId": user_oid}, {"name": 1})
+            goal_name = (goal or {}).get("name")
+        except Exception:
+            goal_name = None
+
+    recommendation = _recommendation(adherence)
+    if adherence["adherencePct"] is None:
+        msg = f"No training sessions were due in the last {window_days} days."
+    else:
+        header = f"Over the last {window_days} days" + (f" toward **{goal_name}**" if goal_name else "")
+        msg = (
+            f"{header}: **{adherence['adherencePct']}%** adherence "
+            f"({adherence['completed']} done, {adherence['skipped']} skipped, {adherence['missed']} missed; "
+            f"{adherence['upcoming']} upcoming).\n\n{recommendation}"
+        )
+
+    return {
+        "success": True,
+        "goal": goal_name,
+        "window_days": window_days,
+        "onTrack": on_track,
+        "adherencePct": adherence["adherencePct"],
+        "counts": adherence,
+        "recommendation": recommendation,
+        "message": msg,
+    }

--- a/ai-coach-service/app/core/agents/skills/safety.py
+++ b/ai-coach-service/app/core/agents/skills/safety.py
@@ -1,0 +1,82 @@
+"""
+Lightweight safety context for training skills.
+
+This is NOT a medical screening gate. It surfaces caveats from data we already
+have — `health`-category memories and the user's free-text `profile.injuries[]`
+— so any skill that programs training can pass them into its LLM step and avoid
+loading injured areas. A full PAR-Q/clearance gate is deliberately out of scope.
+
+`build_safety_context` is a pure function (unit-testable); `get_safety_context`
+fetches the inputs and calls it.
+"""
+
+from typing import Any, Dict, List
+
+from bson import ObjectId
+
+# Terms in a health note that imply "work around this", surfaced to the model.
+_INJURY_HINT_TERMS = (
+    "injury", "injured", "pain", "strain", "sprain", "tear", "surgery",
+    "post-op", "hernia", "tendonitis", "tendinitis", "impingement",
+    "condition", "asthma", "diabetes", "pregnan", "cardiac", "heart",
+    "blood pressure", "hypertension",
+)
+
+
+def build_safety_context(health_memories: List[Dict[str, Any]], injuries: List[str]) -> Dict[str, Any]:
+    """Pure: turn health memories + injuries into an inline caveat bundle."""
+    caveats: List[str] = []
+    flagged_terms: List[str] = []
+
+    for mem in health_memories or []:
+        content = (mem.get("content") or "").strip()
+        if not content:
+            continue
+        caveats.append(content)
+        low = content.lower()
+        for term in _INJURY_HINT_TERMS:
+            if term in low and term not in flagged_terms:
+                flagged_terms.append(term)
+
+    for injury in injuries or []:
+        injury = (injury or "").strip()
+        if injury:
+            caveats.append(f"Reported injury/limitation: {injury}")
+            flagged_terms.append(injury.lower())
+
+    # If anything is flagged, hint the model to keep intensity conservative.
+    intensity_hint = "conservative" if caveats else "normal"
+
+    return {
+        "caveats": caveats,
+        "flagged_terms": flagged_terms,
+        "intensity_hint": intensity_hint,
+        "has_flags": bool(caveats),
+    }
+
+
+async def get_safety_context(ctx: Any, user_id: str) -> Dict[str, Any]:
+    """Fetch health memories + profile injuries and build the caveat bundle."""
+    health_memories: List[Dict[str, Any]] = []
+    try:
+        memories = await ctx.memory_service.get_user_memories(user_id)
+        health_memories = [m for m in (memories or []) if m.get("category") == "health"]
+    except Exception:
+        health_memories = []
+
+    injuries: List[str] = []
+    try:
+        user = await ctx.db.users.find_one({"_id": ObjectId(user_id)}, {"profile.injuries": 1})
+        injuries = ((user or {}).get("profile") or {}).get("injuries") or []
+    except Exception:
+        injuries = []
+
+    return build_safety_context(health_memories, injuries)
+
+
+def format_caveats_for_prompt(safety: Dict[str, Any]) -> str:
+    """Render caveats as a short prompt block, or an explicit 'none'."""
+    caveats = safety.get("caveats") or []
+    if not caveats:
+        return "None reported."
+    return "\n".join(f"- {c}" for c in caveats)

--- a/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
@@ -39,7 +39,13 @@ def _midnight(dt: datetime) -> datetime:
 
 def _parse_start_date(value: Any) -> Optional[datetime]:
     """Parse a start date. Accepts a datetime, 'today'/'tomorrow', ISO, or
-    YYYY-MM-DD. Returns a naive UTC-midnight datetime, or None if unparseable."""
+    YYYY-MM-DD. Returns a naive UTC-midnight datetime, or None if unparseable.
+
+    KNOWN v1 LIMITATION: dates are anchored to UTC midnight and 'today'/'tomorrow'
+    use UTC now — User.settings.timezone is intentionally ignored for now. A user
+    in a UTC-negative zone saying 'today' late in the evening can land a day early.
+    Revisit by threading the user's timezone through when we localize scheduling.
+    """
     if value is None:
         return None
     if isinstance(value, datetime):
@@ -220,6 +226,7 @@ def _format_preview(
     plan: Dict[str, Any],
     proposed: List[Dict[str, Any]],
     already_scheduled: List[Dict[str, Any]],
+    moved: List[Dict[str, Any]],
     conflicts: List[Dict[str, Any]],
     start_date: datetime,
 ) -> str:
@@ -235,9 +242,11 @@ def _format_preview(
         f"- From **{first.strftime('%b %d')}** to **{last.strftime('%b %d, %Y')}**",
     ]
     if already_scheduled:
-        lines.append(f"- {len(already_scheduled)} session(s) already on your calendar (will be skipped)")
+        lines.append(f"- {len(already_scheduled)} session(s) already scheduled on the same dates (will be skipped)")
+    if moved:
+        lines.append(f"- {len(moved)} session(s) are already scheduled on different dates — confirm to reschedule (replaces the old ones)")
     if conflicts:
-        lines.append(f"- ⚠️ {len(conflicts)} date(s) overlap existing events — I won't double-book")
+        lines.append(f"- Heads up: {len(conflicts)} date(s) already have another event; I'll add the workout alongside it")
     lines += ["", "Want me to add these to your calendar?"]
     return "\n".join(lines)
 
@@ -338,18 +347,30 @@ async def schedule_plan_to_calendar(ctx: SkillContext, user_id: str, args: Dict[
         "status": {"$ne": "cancelled"},
     }).to_list(None)
 
-    existing_plan_slots = {
-        (e.get("planWeek"), e.get("planDay"))
-        for e in existing
-        if e.get("planId") == plan_oid
-    }
+    # Index existing plan events by (week, day) so we can tell a true duplicate
+    # (same slot AND same date) from a move (same slot, different date — a
+    # reschedule to a new start date). Other-source events are tracked by date
+    # for a non-blocking heads-up.
+    existing_plan_by_slot: Dict[Any, Dict[str, Any]] = {}
     other_by_date: Dict[Any, List[str]] = {}
     for e in existing:
-        if e.get("planId") != plan_oid and e.get("date"):
+        if e.get("planId") == plan_oid:
+            existing_plan_by_slot[(e.get("planWeek"), e.get("planDay"))] = e
+        elif e.get("date"):
             other_by_date.setdefault(e["date"].date(), []).append(e.get("title", "event"))
 
-    already_scheduled = [e for e in proposed if (e["planWeek"], e["planDay"]) in existing_plan_slots]
-    to_insert = [e for e in proposed if (e["planWeek"], e["planDay"]) not in existing_plan_slots]
+    already_scheduled: List[Dict[str, Any]] = []  # same slot + same date -> skip
+    moved: List[Dict[str, Any]] = []              # same slot, different date -> reschedule
+    to_insert: List[Dict[str, Any]] = []
+    for e in proposed:
+        existing_e = existing_plan_by_slot.get((e["planWeek"], e["planDay"]))
+        if existing_e is None:
+            to_insert.append(e)
+        elif existing_e.get("date") and existing_e["date"].date() == e["date"].date():
+            already_scheduled.append(e)
+        else:
+            moved.append(e)
+
     conflicts = [
         {"date": e["date"].strftime("%Y-%m-%d"), "title": e["title"], "existing": other_by_date[e["date"].date()]}
         for e in proposed
@@ -360,20 +381,33 @@ async def schedule_plan_to_calendar(ctx: SkillContext, user_id: str, args: Dict[
         return {
             "success": True,
             "dry_run": True,
-            "message": _format_preview(plan, proposed, already_scheduled, conflicts, start_date),
+            "message": _format_preview(plan, proposed, already_scheduled, moved, conflicts, start_date),
             "proposed_count": len(proposed),
             "proposed_events": [_serialize_event(e) for e in proposed],
             "already_scheduled_count": len(already_scheduled),
+            "moved_count": len(moved),
             "conflicts": conflicts,
         }
 
     # --- Confirmed write ---
+    # A move (plan already scheduled at different dates) is a destructive
+    # reschedule — require an explicit overwrite rather than silently skipping
+    # (which would leave the old events in place and insert nothing).
+    if moved and not overwrite:
+        return {
+            "success": True,
+            "needs_confirmation": "reschedule",
+            "message": (
+                f"This plan is already on your calendar at different dates. To move "
+                f"{len(moved)} session(s) to start {start_date.strftime('%A, %B %d')}, "
+                f"confirm and I'll reschedule it (this replaces the existing plan events)."
+            ),
+        }
+
     if overwrite:
-        await ctx.db.calendarevents.delete_many({
-            "userId": user_oid,
-            "planId": plan_oid,
-            "date": {"$gte": min_d, "$lte": max_d},
-        })
+        # Clear ALL of this plan's events (not just the new range) so a shifted
+        # plan doesn't leave stragglers at the old dates.
+        await ctx.db.calendarevents.delete_many({"userId": user_oid, "planId": plan_oid})
         insert_list = proposed
     else:
         insert_list = to_insert

--- a/ai-coach-service/app/core/agents/skills/substitute_exercise_skill.py
+++ b/ai-coach-service/app/core/agents/skills/substitute_exercise_skill.py
@@ -1,0 +1,170 @@
+"""
+Skill: substitute_exercise
+
+Swap an exercise for one with a similar training stimulus, respecting the user's
+available equipment. Matching is deterministic: same movement pattern + primary-
+muscle overlap + strain similarity, preserving the sets/reps target.
+
+Safety: if the reason is pain/injury, this does NOT prescribe a rehab swap — it
+routes to a caution (spec: work around clinician-cleared limitations only).
+
+Pure helpers (equipment_ok, score_substitute) are unit-tested without a DB.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+from app.core.agents.skills.knowledge.movement import infer_movement_pattern
+from app.core.agents.skills.safety import _INJURY_HINT_TERMS
+
+# Equipment values that always count as "available" (bodyweight / none).
+_ALWAYS_AVAILABLE = {"", "bodyweight", "none", "body weight"}
+
+
+def equipment_ok(candidate_equipment: List[str], available: set) -> bool:
+    """True if every piece the candidate needs is available (or it's bodyweight)."""
+    needed = [e for e in (candidate_equipment or []) if (e or "").lower() not in _ALWAYS_AVAILABLE]
+    if not needed:
+        return True
+    return all((e or "").lower() in available for e in needed)
+
+
+def _muscle_overlap(a: List[str], b: List[str]) -> float:
+    sa = {m.lower() for m in (a or [])}
+    sb = {m.lower() for m in (b or [])}
+    if not sa or not sb:
+        return 0.0
+    return len(sa & sb) / len(sa | sb)
+
+
+def score_substitute(original: Dict[str, Any], candidate: Dict[str, Any]) -> float:
+    """Stimulus-match score (higher = closer). Deterministic."""
+    score = 0.0
+    # Movement pattern is the strongest signal.
+    if infer_movement_pattern(original) and infer_movement_pattern(original) == infer_movement_pattern(candidate):
+        score += 3.0
+    # Primary muscle overlap.
+    score += 4.0 * _muscle_overlap(original.get("muscles", []), candidate.get("muscles", []))
+    # Secondary muscle overlap (smaller weight).
+    score += 1.0 * _muscle_overlap(original.get("secondaryMuscles", []), candidate.get("secondaryMuscles", []))
+    # Strain similarity.
+    o_strain, c_strain = original.get("strain") or {}, candidate.get("strain") or {}
+    if o_strain.get("intensity") and o_strain.get("intensity") == c_strain.get("intensity"):
+        score += 1.0
+    if o_strain.get("load") and o_strain.get("load") == c_strain.get("load"):
+        score += 1.0
+    return round(score, 3)
+
+
+def _is_pain_reason(reason: str) -> bool:
+    low = (reason or "").lower()
+    return any(term in low for term in _INJURY_HINT_TERMS)
+
+
+async def _load_original(ctx: SkillContext, user_oid: Any, args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    ownership = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
+    ex_id = args.get("exercise_id")
+    if ex_id:
+        try:
+            return await ctx.db.exercises.find_one({"_id": ObjectId(ex_id), **ownership})
+        except Exception:
+            return None
+    name = args.get("exercise_name")
+    if name:
+        return await ctx.db.exercises.find_one({
+            "name": {"$regex": f"^{name}$", "$options": "i"}, **ownership,
+        })
+    return None
+
+
+@skill(
+    name="substitute_exercise",
+    description=(
+        "Find a replacement exercise with a similar training stimulus (same movement "
+        "pattern and muscles) that fits the user's available equipment — e.g. when they "
+        "lack a machine or want variety. If the reason is pain or injury, it will NOT "
+        "just swap the movement; it routes to a safety caution instead."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "exercise_id": {"type": "string", "description": "ID of the exercise to replace."},
+            "exercise_name": {"type": "string", "description": "Name of the exercise to replace (if no ID)."},
+            "reason": {"type": "string", "description": "Why swap (equipment, preference, pain, variety)."},
+            "equipment": {"type": "array", "items": {"type": "string"}, "description": "Override available equipment (default: profile)."},
+        },
+    },
+)
+async def substitute_exercise(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid user."}
+
+    # Pain-driven requests route to safety, not a rehab swap.
+    if _is_pain_reason(args.get("reason", "")):
+        return {
+            "success": True,
+            "routed": "safety",
+            "message": (
+                "Since this is about pain or an injury, I won't just swap in another loaded "
+                "movement. If a clinician has cleared you to train around it, tell me which area "
+                "to avoid and I'll suggest a variation. Otherwise please rest it or check with a "
+                "professional — I can't prescribe rehab."
+            ),
+        }
+
+    original = await _load_original(ctx, user_oid, args)
+    if not original:
+        return {"success": False, "message": "I couldn't find that exercise to substitute."}
+
+    # Available equipment: explicit override, else the user's profile.
+    if args.get("equipment") is not None:
+        equipment_list = args["equipment"]
+    else:
+        user = await ctx.db.users.find_one({"_id": user_oid}, {"profile.preferences.equipment": 1})
+        equipment_list = (((user or {}).get("profile") or {}).get("preferences") or {}).get("equipment") or []
+    available = {(e or "").lower() for e in equipment_list} | _ALWAYS_AVAILABLE
+
+    # Candidate pool: shares at least one primary muscle, different exercise.
+    ownership = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
+    query = {"muscles": {"$in": original.get("muscles", [])}, "_id": {"$ne": original["_id"]}, **ownership}
+    candidates = await ctx.db.exercises.find(query).to_list(100)
+
+    scored = [
+        (score_substitute(original, c), c)
+        for c in candidates
+        if equipment_ok(c.get("equipment", []), available)
+    ]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    scored = [s for s in scored if s[0] > 0]
+
+    if not scored:
+        return {
+            "success": True,
+            "message": f"I couldn't find a good substitute for **{original.get('name')}** with your available equipment.",
+            "substitute": None,
+        }
+
+    best_score, best = scored[0]
+    alternatives = [
+        {"id": str(c["_id"]), "name": c.get("name"), "score": sc}
+        for sc, c in scored[1:4]
+    ]
+    return {
+        "success": True,
+        "message": (
+            f"Swap **{original.get('name')}** → **{best.get('name')}** "
+            f"(similar {', '.join(original.get('muscles', [])) or 'stimulus'}; match {best_score})."
+        ),
+        "substitute": {
+            "id": str(best["_id"]),
+            "name": best.get("name"),
+            "stimulusMatchScore": best_score,
+            "muscles": best.get("muscles", []),
+            "equipment": best.get("equipment", []),
+        },
+        "alternatives": alternatives,
+    }

--- a/ai-coach-service/app/core/agents/skills/suggest_exercises_skill.py
+++ b/ai-coach-service/app/core/agents/skills/suggest_exercises_skill.py
@@ -1,0 +1,138 @@
+"""
+Skill: suggest_exercises
+
+Recommend exercises for a muscle group / movement pattern / skill within the
+user's equipment and health caveats. Deterministic retrieval + filtering (the
+orchestrator model does the conversational justification around the result).
+
+For a skill goal (pull-up, handstand, ...) it points at generate_plan /
+progression generation rather than a flat list.
+
+`select_exercises` is a pure ranking helper unit-tested without a DB.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+from app.core.agents.skills.knowledge.movement import infer_movement_pattern
+from app.core.agents.skills.substitute_exercise_skill import equipment_ok, _ALWAYS_AVAILABLE
+from app.core.agents.skills.safety import get_safety_context
+
+_DIFFICULTY_ORDER = {"beginner": 0, "intermediate": 1, "advanced": 2}
+
+
+def _matches_flagged(exercise: Dict[str, Any], flagged_terms: List[str]) -> bool:
+    """True if the exercise name/muscles reference a flagged (injured) area."""
+    hay = (exercise.get("name", "") + " " + " ".join(exercise.get("muscles", []) or [])).lower()
+    return any(term and term in hay for term in flagged_terms)
+
+
+def select_exercises(
+    candidates: List[Dict[str, Any]],
+    available: set,
+    movement_pattern: Optional[str],
+    flagged_terms: List[str],
+    limit: int,
+) -> List[Dict[str, Any]]:
+    """Pure: filter by equipment / pattern / safety, rank easiest-first."""
+    picked = []
+    for ex in candidates:
+        if not equipment_ok(ex.get("equipment", []), available):
+            continue
+        if movement_pattern and infer_movement_pattern(ex) != movement_pattern:
+            continue
+        if _matches_flagged(ex, flagged_terms):
+            continue
+        picked.append(ex)
+
+    picked.sort(key=lambda e: (_DIFFICULTY_ORDER.get((e.get("difficulty") or "beginner").lower(), 1), e.get("name", "")))
+    return picked[:limit]
+
+
+@skill(
+    name="suggest_exercises",
+    description=(
+        "Suggest exercises for a muscle group, movement pattern, or goal that fit the "
+        "user's available equipment and avoid any flagged/injured areas. For a skill goal "
+        "(e.g. first pull-up, handstand), recommends building a progression instead of a flat list."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "muscle_group": {"type": "string", "description": "Target muscle (e.g. 'chest', 'hamstrings')."},
+            "movement_pattern": {"type": "string", "description": "push|pull|squat|hinge|carry|core|cardio."},
+            "skill": {"type": "string", "description": "A skill goal (e.g. 'pull-up', 'handstand')."},
+            "difficulty": {"type": "string", "enum": ["beginner", "intermediate", "advanced"]},
+            "equipment": {"type": "array", "items": {"type": "string"}, "description": "Override available equipment."},
+            "limit": {"type": "integer", "description": "Max results (default 8)."},
+        },
+    },
+)
+async def suggest_exercises(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid user."}
+
+    # Skill goals want a progression, not a flat list.
+    if args.get("skill"):
+        return {
+            "success": True,
+            "is_skill": True,
+            "message": (
+                f"'{args['skill']}' is a skill best trained with a progression ladder. "
+                f"Want me to generate a plan for it (generate_plan) so you build up step by step?"
+            ),
+        }
+
+    limit = int(args.get("limit") or 8)
+    movement_pattern = (args.get("movement_pattern") or "").lower() or None
+
+    if args.get("equipment") is not None:
+        equipment_list = args["equipment"]
+    else:
+        user = await ctx.db.users.find_one({"_id": user_oid}, {"profile.preferences.equipment": 1})
+        equipment_list = (((user or {}).get("profile") or {}).get("preferences") or {}).get("equipment") or []
+    available = {(e or "").lower() for e in equipment_list} | _ALWAYS_AVAILABLE
+
+    safety = await get_safety_context(ctx, user_id)
+    flagged_terms = safety.get("flagged_terms", [])
+
+    ownership = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
+    query: Dict[str, Any] = dict(ownership)
+    if args.get("muscle_group"):
+        query["muscles"] = {"$regex": args["muscle_group"], "$options": "i"}
+    if args.get("difficulty"):
+        query["difficulty"] = args["difficulty"]
+
+    candidates = await ctx.db.exercises.find(query).to_list(150)
+    picked = select_exercises(candidates, available, movement_pattern, flagged_terms, limit)
+
+    if not picked:
+        return {
+            "success": True,
+            "exercises": [],
+            "message": "I couldn't find exercises matching that with your available equipment.",
+        }
+
+    exercises = [
+        {
+            "id": str(e["_id"]),
+            "name": e.get("name"),
+            "muscles": e.get("muscles", []),
+            "equipment": e.get("equipment", []),
+            "difficulty": e.get("difficulty"),
+            "pattern": infer_movement_pattern(e),
+        }
+        for e in picked
+    ]
+    note = ""
+    if safety.get("has_flags"):
+        note = " (filtered to avoid your noted areas)"
+    return {
+        "success": True,
+        "exercises": exercises,
+        "message": f"Found {len(exercises)} option(s){note}.",
+    }

--- a/ai-coach-service/app/core/agents/skills/validate_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/validate_plan_skill.py
@@ -1,0 +1,184 @@
+"""
+Skill: validate_plan
+
+Deterministic Tier-2 quality checks over a training plan document, using the
+sourced constants in knowledge/training_knowledge.py. No writes, no LLM — pure
+logic so it's fully testable and reused by generate_plan and adjust_plan.
+
+Checks (all computable from the Plan doc alone):
+- frequency: sessions/week vs the goal minimum
+- volume: working sets/week vs the goal minimum
+- rest: at least one rest day per training week
+- deload: a deload week exists for long-enough plans (advisory)
+- ramp: no aggressive week-over-week volume jump
+- goal specificity: endurance/health/weight goals include aerobic work
+
+Set counting: custom workouts contribute len(exercises[].sets); predefined
+workouts are counted with a fixed proxy (we don't resolve their template here).
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+from app.core.agents.skills.knowledge import training_knowledge as tk
+
+# Sets assumed per predefined workout when we can't resolve its template.
+_PREDEFINED_SET_PROXY = 12
+
+
+def _week_metrics(week: Dict[str, Any]) -> Tuple[int, int, List[Dict[str, Any]]]:
+    """Return (sessions, working_sets, workouts) for one week."""
+    workouts = week.get("workouts", []) or []
+    sets = 0
+    for w in workouts:
+        if w.get("workoutType") == "custom":
+            custom = w.get("customWorkout") or {}
+            for ex in custom.get("exercises", []) or []:
+                sets += len(ex.get("sets", []) or [])
+        else:
+            sets += _PREDEFINED_SET_PROXY
+    return len(workouts), sets, workouts
+
+
+def _has_aerobic(weeks: List[Dict[str, Any]]) -> bool:
+    for week in weeks:
+        for w in week.get("workouts", []) or []:
+            wtype = ((w.get("customWorkout") or {}).get("type") or "").lower()
+            if wtype in tk.AEROBIC_WORKOUT_TYPES:
+                return True
+    return False
+
+
+def validate_plan_doc(plan: Dict[str, Any], goal_category: str) -> Dict[str, Any]:
+    """Pure validator. Returns {valid, violations[], suggestions[], metrics}."""
+    violations: List[str] = []
+    suggestions: List[str] = []
+
+    weeks = sorted(plan.get("weeks", []) or [], key=lambda w: w.get("weekNumber", 0))
+    weeks_total = (plan.get("schedule") or {}).get("weeksTotal") or len(weeks)
+
+    if not weeks or all(not (w.get("workouts") or []) for w in weeks):
+        return {
+            "valid": False,
+            "violations": ["The plan has no workouts."],
+            "suggestions": ["Add workouts to each training week before scheduling."],
+            "metrics": {"weeks_total": weeks_total, "avg_sessions_per_week": 0, "avg_weekly_sets": 0, "has_deload": False},
+        }
+
+    per_week = [_week_metrics(w) for w in weeks]
+    sessions_list = [m[0] for m in per_week]
+    sets_list = [m[1] for m in per_week]
+    training_weeks = [m for m in per_week if m[0] > 0]
+    avg_sessions = sum(sessions_list) / len(training_weeks) if training_weeks else 0
+    avg_sets = sum(sets_list) / len(training_weeks) if training_weeks else 0
+
+    # V1 frequency
+    min_sessions = tk.min_sessions_for_goal(goal_category)
+    if avg_sessions < min_sessions:
+        violations.append(
+            f"Only ~{avg_sessions:.1f} sessions/week; a {goal_category} goal needs at least {min_sessions}."
+        )
+
+    # V2 volume
+    min_sets = tk.min_weekly_sets_for_goal(goal_category)
+    if avg_sets < min_sets:
+        violations.append(
+            f"~{avg_sets:.0f} working sets/week is below the ~{min_sets} recommended for a {goal_category} goal."
+        )
+
+    # V3 rest — each training week should leave at least one day off
+    for week, (sessions, _sets, _w) in zip(weeks, per_week):
+        rest_days = week.get("restDays", []) or []
+        if sessions >= 7 and not rest_days:
+            violations.append(f"Week {week.get('weekNumber')} schedules training every day with no rest day.")
+
+    # V4 deload (advisory)
+    has_deload = any(w.get("deloadWeek") for w in weeks)
+    if tk.expects_deload(weeks_total) and not has_deload:
+        suggestions.append(
+            f"Plans of {weeks_total} weeks benefit from a deload every {tk.DELOAD_EVERY_WEEKS_MIN}–{tk.DELOAD_EVERY_WEEKS_MAX} weeks; none is marked."
+        )
+
+    # V5 ramp — flag aggressive week-over-week volume jumps
+    for i in range(1, len(sets_list)):
+        prev, cur = sets_list[i - 1], sets_list[i]
+        if prev > 0 and cur > prev * tk.WEEKLY_RAMP_HARD_FLAG:
+            violations.append(
+                f"Week {weeks[i].get('weekNumber')} volume jumps {((cur/prev)-1)*100:.0f}% over the prior week (aggressive)."
+            )
+
+    # V6 goal specificity — aerobic-oriented goals need aerobic work
+    if goal_category.lower() in {"endurance", "health", "weight"} and not _has_aerobic(weeks):
+        suggestions.append(
+            f"A {goal_category} goal should include aerobic/cardio sessions ({tk.WHO_AEROBIC_MIN_MINUTES}–{tk.WHO_AEROBIC_MAX_MINUTES} min/week)."
+        )
+
+    return {
+        "valid": len(violations) == 0,
+        "violations": violations,
+        "suggestions": suggestions,
+        "metrics": {
+            "weeks_total": weeks_total,
+            "avg_sessions_per_week": round(avg_sessions, 1),
+            "avg_weekly_sets": round(avg_sets),
+            "has_deload": has_deload,
+        },
+    }
+
+
+async def _resolve_goal_category(ctx: SkillContext, plan: Dict[str, Any], user_oid: Any) -> str:
+    """Best-effort goal category from the plan's linked goal; default 'general'."""
+    goal_id = plan.get("goalId")
+    if not goal_id:
+        return "general"
+    try:
+        goal = await ctx.db.goals.find_one({"_id": goal_id, "userId": user_oid}, {"category": 1})
+        return (goal or {}).get("category") or "general"
+    except Exception:
+        return "general"
+
+
+@skill(
+    name="validate_plan",
+    description=(
+        "Check a training plan for quality/safety issues (volume, frequency, rest, "
+        "deload, ramp, goal fit) BEFORE scheduling it or after the user edits it. "
+        "Returns violations and suggestions; does not modify anything."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "plan_id": {"type": "string", "description": "The ID of the plan to validate."},
+        },
+        "required": ["plan_id"],
+    },
+)
+async def validate_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    plan_id = args.get("plan_id")
+    if not plan_id:
+        return {"success": False, "message": "plan_id is required."}
+    try:
+        plan_oid = ObjectId(plan_id)
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid plan_id."}
+
+    plan = await ctx.db.plans.find_one({"_id": plan_oid, "userId": user_oid})
+    if not plan:
+        return {"success": False, "message": "Plan not found."}
+
+    goal_category = await _resolve_goal_category(ctx, plan, user_oid)
+    report = validate_plan_doc(plan, goal_category)
+
+    if report["valid"]:
+        msg = f"✅ Plan looks solid ({report['metrics']['avg_sessions_per_week']} sessions/wk, ~{report['metrics']['avg_weekly_sets']} sets/wk)."
+        if report["suggestions"]:
+            msg += " A couple of optional improvements:\n" + "\n".join(f"- {s}" for s in report["suggestions"])
+    else:
+        msg = "⚠️ A few things to fix:\n" + "\n".join(f"- {v}" for v in report["violations"])
+        if report["suggestions"]:
+            msg += "\n\nOptional:\n" + "\n".join(f"- {s}" for s in report["suggestions"])
+
+    return {"success": True, "message": msg, **report}

--- a/ai-coach-service/tests/test_exercise_skills.py
+++ b/ai-coach-service/tests/test_exercise_skills.py
@@ -1,0 +1,161 @@
+"""Tests for movement inference, substitute_exercise, and suggest_exercises."""
+
+import pytest
+from bson import ObjectId
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.agents.skills.knowledge.movement import infer_movement_pattern
+from app.core.agents.skills.substitute_exercise_skill import (
+    equipment_ok,
+    score_substitute,
+    substitute_exercise,
+)
+from app.core.agents.skills.suggest_exercises_skill import select_exercises, suggest_exercises
+
+
+# ---------------------------- movement ----------------------------
+
+class TestMovementInference:
+    @pytest.mark.parametrize("name,expected", [
+        ("Barbell Bench Press", "push"),
+        ("Pull-up", "pull"),
+        ("Back Squat", "squat"),
+        ("Romanian Deadlift", "hinge"),
+        ("Farmer Carry", "carry"),
+        ("Plank", "core"),
+        ("Treadmill Run", "cardio"),
+    ])
+    def test_by_name(self, name, expected):
+        assert infer_movement_pattern({"name": name}) == expected
+
+    def test_fallback_to_muscle(self):
+        assert infer_movement_pattern({"name": "Mystery Move", "muscles": ["chest"]}) == "push"
+
+    def test_unknown(self):
+        assert infer_movement_pattern({"name": "Zzz", "muscles": []}) is None
+
+
+# ---------------------------- substitute helpers ----------------------------
+
+class TestEquipmentOk:
+    def test_bodyweight_always_ok(self):
+        assert equipment_ok([], {"barbell"}) is True
+        assert equipment_ok(["bodyweight"], set()) is True
+
+    def test_requires_all_available(self):
+        assert equipment_ok(["barbell"], {"barbell", "bench"}) is True
+        assert equipment_ok(["barbell", "cable"], {"barbell"}) is False
+
+
+class TestScoreSubstitute:
+    def test_same_pattern_and_muscle_scores_high(self):
+        original = {"name": "Barbell Bench Press", "muscles": ["chest"], "strain": {"intensity": "high", "load": "heavy"}}
+        near = {"name": "Dumbbell Bench Press", "muscles": ["chest"], "strain": {"intensity": "high", "load": "heavy"}}
+        far = {"name": "Back Squat", "muscles": ["quads"], "strain": {"intensity": "high", "load": "heavy"}}
+        assert score_substitute(original, near) > score_substitute(original, far)
+
+    def test_muscle_overlap_contributes(self):
+        original = {"name": "Row", "muscles": ["back", "biceps"]}
+        c = {"name": "Chin-up", "muscles": ["back", "biceps"]}
+        assert score_substitute(original, c) > 0
+
+
+# ---------------------------- substitute handler ----------------------------
+
+def _make_ctx(original=None, candidates=None, profile_equipment=None):
+    db = MagicMock()
+    db.exercises.find_one = AsyncMock(return_value=original)
+    find_result = MagicMock()
+    find_result.to_list = AsyncMock(return_value=candidates or [])
+    db.exercises.find = MagicMock(return_value=find_result)
+    db.users.find_one = AsyncMock(
+        return_value={"profile": {"preferences": {"equipment": profile_equipment or []}}}
+    )
+    ctx = MagicMock()
+    ctx.db = db
+    ctx.memory_service.get_user_memories = AsyncMock(return_value=[])
+    return ctx
+
+
+class TestSubstituteHandler:
+    @pytest.mark.asyncio
+    async def test_pain_reason_routes_to_safety(self):
+        ctx = _make_ctx()
+        result = await substitute_exercise(ctx, str(ObjectId()), {"exercise_name": "Bench Press", "reason": "shoulder pain"})
+        assert result["routed"] == "safety"
+        ctx.db.exercises.find_one.assert_not_called()  # never even loads the exercise
+
+    @pytest.mark.asyncio
+    async def test_finds_best_substitute(self):
+        original = {"_id": ObjectId(), "name": "Barbell Bench Press", "muscles": ["chest"],
+                    "equipment": ["barbell"], "strain": {"intensity": "high", "load": "heavy"}}
+        good = {"_id": ObjectId(), "name": "Push-up", "muscles": ["chest"], "equipment": [],
+                "strain": {"intensity": "moderate", "load": "bodyweight"}}
+        needs_gear = {"_id": ObjectId(), "name": "Cable Fly", "muscles": ["chest"], "equipment": ["cable"]}
+        ctx = _make_ctx(original=original, candidates=[good, needs_gear], profile_equipment=[])
+        result = await substitute_exercise(ctx, str(ObjectId()), {"exercise_id": str(original["_id"])})
+        assert result["success"] is True
+        assert result["substitute"]["name"] == "Push-up"  # cable filtered out (no cable)
+
+    @pytest.mark.asyncio
+    async def test_unknown_exercise(self):
+        ctx = _make_ctx(original=None)
+        result = await substitute_exercise(ctx, str(ObjectId()), {"exercise_name": "Nope"})
+        assert result["success"] is False
+
+
+# ---------------------------- suggest ----------------------------
+
+class TestSelectExercises:
+    def _pool(self):
+        return [
+            {"_id": ObjectId(), "name": "Push-up", "muscles": ["chest"], "equipment": [], "difficulty": "beginner"},
+            {"_id": ObjectId(), "name": "Bench Press", "muscles": ["chest"], "equipment": ["barbell"], "difficulty": "advanced"},
+            {"_id": ObjectId(), "name": "Squat", "muscles": ["quads"], "equipment": [], "difficulty": "intermediate"},
+        ]
+
+    def test_equipment_filter_and_easiest_first(self):
+        picked = select_exercises(self._pool(), {"bodyweight"}, None, [], 10)
+        names = [e["name"] for e in picked]
+        assert "Bench Press" not in names  # needs barbell
+        assert names[0] == "Push-up"  # beginner ranked first
+
+    def test_movement_pattern_filter(self):
+        picked = select_exercises(self._pool(), {"barbell", "bodyweight"}, "push", [], 10)
+        assert {e["name"] for e in picked} == {"Push-up", "Bench Press"}
+
+    def test_flagged_terms_excluded(self):
+        picked = select_exercises(self._pool(), {"bodyweight"}, None, ["chest"], 10)
+        assert all("chest" not in (e.get("muscles") or []) for e in picked)
+
+
+def _make_suggest_ctx(candidates, health_memories=None, profile_equipment=None):
+    db = MagicMock()
+    find_result = MagicMock()
+    find_result.to_list = AsyncMock(return_value=candidates)
+    db.exercises.find = MagicMock(return_value=find_result)
+    db.users.find_one = AsyncMock(return_value={"profile": {"preferences": {"equipment": profile_equipment or []}}})
+    ctx = MagicMock()
+    ctx.db = db
+    ctx.memory_service.get_user_memories = AsyncMock(return_value=health_memories or [])
+    return ctx
+
+
+class TestSuggestHandler:
+    @pytest.mark.asyncio
+    async def test_skill_goal_points_to_progression(self):
+        ctx = _make_suggest_ctx([])
+        result = await suggest_exercises(ctx, str(ObjectId()), {"skill": "pull-up"})
+        assert result["is_skill"] is True
+        ctx.db.exercises.find.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_filtered_exercises(self):
+        pool = [
+            {"_id": ObjectId(), "name": "Push-up", "muscles": ["chest"], "equipment": [], "difficulty": "beginner"},
+            {"_id": ObjectId(), "name": "Cable Fly", "muscles": ["chest"], "equipment": ["cable"], "difficulty": "intermediate"},
+        ]
+        ctx = _make_suggest_ctx(pool, profile_equipment=[])
+        result = await suggest_exercises(ctx, str(ObjectId()), {"muscle_group": "chest"})
+        names = [e["name"] for e in result["exercises"]]
+        assert names == ["Push-up"]  # cable filtered out

--- a/ai-coach-service/tests/test_generate_plan_skill.py
+++ b/ai-coach-service/tests/test_generate_plan_skill.py
@@ -1,0 +1,134 @@
+"""Tests for the generate_plan skill (pure builders + handler)."""
+
+import json
+
+import pytest
+from bson import ObjectId
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.agents.skills.generate_plan_skill import (
+    build_plan_weeks,
+    generate_plan,
+    infer_category,
+    pick_workout_days,
+)
+
+
+class TestPureHelpers:
+    @pytest.mark.parametrize("text,expected", [
+        ("get stronger and hit a squat PR", "strength"),
+        ("run a 5k", "endurance"),
+        ("first pull-up", "skill"),
+        ("lose weight / fat loss", "weight"),
+        ("just feel better, general fitness", "health"),
+        ("something vague", "general"),
+    ])
+    def test_infer_category(self, text, expected):
+        assert infer_category(text) == expected
+
+    def test_pick_workout_days_prefers_user_days(self):
+        assert pick_workout_days(3, [1, 3, 5]) == [1, 3, 5]
+
+    def test_pick_workout_days_even_spread(self):
+        days = pick_workout_days(3, None)
+        assert len(days) == 3
+        assert all(0 <= d <= 6 for d in days)
+
+    def test_pick_workout_days_clamps(self):
+        assert len(pick_workout_days(10, None)) == 7
+
+    def test_build_plan_weeks_structure_and_deload(self):
+        blueprints = [
+            {"title": "A", "type": "strength", "durationMinutes": 45,
+             "exercises": [{"exerciseName": "Squat", "sets": 5, "reps": 5}]},
+        ]
+        weeks = build_plan_weeks(blueprints, [1, 3, 5], 8)
+        assert len(weeks) == 8
+        # 3 workouts/week on the chosen days
+        assert [w["dayOfWeek"] for w in weeks[0]["workouts"]] == [1, 3, 5]
+        # off-days are NOT materialized as rest events (avoid calendar flood)
+        assert weeks[0]["restDays"] == []
+        # week 6 is a deload for an 8-week plan (every 6 weeks) -> reduced volume
+        deload_week = weeks[5]
+        assert deload_week["deloadWeek"] is True
+        deload_sets = len(deload_week["workouts"][0]["customWorkout"]["exercises"][0]["sets"])
+        normal_sets = len(weeks[0]["workouts"][0]["customWorkout"]["exercises"][0]["sets"])
+        assert deload_sets < normal_sets
+
+
+def _llm_response(workouts):
+    msg = MagicMock()
+    msg.content = json.dumps({"workouts": workouts})
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+def _make_ctx(profile=None, goal=None, create_ok=True, missing=None, workouts=None):
+    profile = profile if profile is not None else {"fitnessLevel": "intermediate", "preferences": {"equipment": ["barbell"], "workoutDays": [1, 3, 5]}}
+    workouts = workouts or [
+        {"title": "Full Body A", "type": "strength", "durationMinutes": 45,
+         "exercises": [{"exerciseName": "Squat", "sets": 4, "reps": 6},
+                       {"exerciseName": "Bench Press", "sets": 4, "reps": 6},
+                       {"exerciseName": "Row", "sets": 3, "reps": 10}]},
+    ]
+
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value={"profile": profile})
+    db.goals.find_one = AsyncMock(return_value=goal)
+
+    ctx = MagicMock()
+    ctx.db = db
+    ctx.settings.openai_model = "gpt-test"
+    ctx.openai_client.chat.completions.create = AsyncMock(return_value=_llm_response(workouts))
+    ctx.memory_service.get_user_memories = AsyncMock(return_value=[])
+    ctx.exercise_service.grep_exercises = AsyncMock(return_value={"missing": missing or []})
+    ctx.plan_service.create_plan = AsyncMock(
+        return_value={"success": create_ok, "plan_id": str(ObjectId()) if create_ok else None,
+                      "message": "" if create_ok else "fail"}
+    )
+    return ctx
+
+
+class TestHandler:
+    @pytest.mark.asyncio
+    async def test_generates_and_persists_draft(self):
+        ctx = _make_ctx()
+        result = await generate_plan(ctx, str(ObjectId()), {"goal_text": "get stronger", "weeks": 8})
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        assert result["plan_id"]
+        assert result["weeks"] == 8
+        # a draft plan was written via create_plan
+        ctx.plan_service.create_plan.assert_awaited_once()
+        create_args = ctx.plan_service.create_plan.call_args.args[1]
+        assert create_args["schedule"]["weeksTotal"] == 8
+        assert "draft" in create_args["tags"]
+
+    @pytest.mark.asyncio
+    async def test_missing_goal_asks(self):
+        ctx = _make_ctx()
+        result = await generate_plan(ctx, str(ObjectId()), {})
+        assert result.get("needs_input") == "goal"
+        ctx.plan_service.create_plan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uses_linked_goal_category(self):
+        ctx = _make_ctx(goal={"name": "Run 10k", "category": "endurance"})
+        result = await generate_plan(ctx, str(ObjectId()), {"goal_id": str(ObjectId()), "weeks": 6})
+        # strength-only blueprints on an endurance goal -> validation suggests aerobic
+        assert any("aerobic" in s.lower() or "cardio" in s.lower() for s in result["validation"]["suggestions"])
+
+    @pytest.mark.asyncio
+    async def test_unverified_exercise_names_reported(self):
+        ctx = _make_ctx(missing=["Bench Press"])
+        result = await generate_plan(ctx, str(ObjectId()), {"goal_text": "get stronger"})
+        assert "Bench Press" in result["unverified_exercises"]
+
+    @pytest.mark.asyncio
+    async def test_create_failure_surfaced(self):
+        ctx = _make_ctx(create_ok=False)
+        result = await generate_plan(ctx, str(ObjectId()), {"goal_text": "get stronger"})
+        assert result["success"] is False

--- a/ai-coach-service/tests/test_live_plan_skills.py
+++ b/ai-coach-service/tests/test_live_plan_skills.py
@@ -1,0 +1,177 @@
+"""Tests for review_progress, reschedule_session, adjust_plan."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from bson import ObjectId
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.agents.skills.review_progress_skill import compute_adherence, review_progress
+from app.core.agents.skills.reschedule_session_skill import resolve_reschedule, reschedule_session
+from app.core.agents.skills.adjust_plan_skill import apply_adjustment, adjust_plan
+
+TODAY = datetime(2026, 7, 10)
+
+
+# ------------------------- review_progress -------------------------
+
+class TestComputeAdherence:
+    def test_counts_and_pct(self):
+        events = [
+            {"type": "workout", "status": "completed", "date": TODAY - timedelta(days=5)},
+            {"type": "workout", "status": "completed", "date": TODAY - timedelta(days=3)},
+            {"type": "workout", "status": "skipped", "date": TODAY - timedelta(days=2)},
+            {"type": "workout", "status": "scheduled", "date": TODAY - timedelta(days=1)},  # missed
+            {"type": "workout", "status": "scheduled", "date": TODAY + timedelta(days=1)},  # upcoming
+            {"type": "rest", "status": "scheduled", "date": TODAY - timedelta(days=1)},     # ignored
+        ]
+        a = compute_adherence(events, TODAY)
+        assert (a["completed"], a["skipped"], a["missed"], a["upcoming"]) == (2, 1, 1, 1)
+        assert a["adherencePct"] == 50  # 2 / (2+1+1)
+
+    def test_no_due_sessions(self):
+        a = compute_adherence([{"type": "workout", "status": "scheduled", "date": TODAY + timedelta(days=2)}], TODAY)
+        assert a["adherencePct"] is None
+
+    @pytest.mark.asyncio
+    async def test_handler(self):
+        events = [{"type": "workout", "status": "completed", "date": TODAY - timedelta(days=1)}]
+        db = MagicMock()
+        fr = MagicMock(); fr.to_list = AsyncMock(return_value=events)
+        db.calendarevents.find = MagicMock(return_value=fr)
+        db.goals.find_one = AsyncMock(return_value=None)
+        ctx = MagicMock(); ctx.db = db
+        result = await review_progress(ctx, str(ObjectId()), {"window_days": 14})
+        assert result["success"] is True
+        assert result["adherencePct"] == 100
+
+
+# ------------------------- reschedule_session -------------------------
+
+class TestResolveReschedule:
+    def test_skip(self):
+        assert resolve_reschedule(TODAY, "skip", None, TODAY)["op"] == "skip"
+
+    def test_shift_defaults_to_tomorrow(self):
+        r = resolve_reschedule(TODAY, "shift", None, TODAY)
+        assert r["op"] == "shift" and r["to_date"] == TODAY + timedelta(days=1)
+
+    def test_auto_missed_shifts(self):
+        r = resolve_reschedule(TODAY - timedelta(days=2), "auto", None, TODAY)
+        assert r["op"] == "shift"
+
+    def test_auto_future_skips(self):
+        r = resolve_reschedule(TODAY + timedelta(days=2), "auto", None, TODAY)
+        assert r["op"] == "skip"
+
+
+def _resched_ctx(event):
+    db = MagicMock()
+    db.calendarevents.find_one = AsyncMock(return_value=event)
+    db.calendarevents.update_one = AsyncMock()
+    ctx = MagicMock(); ctx.db = db
+    return ctx
+
+
+class TestRescheduleHandler:
+    @pytest.mark.asyncio
+    async def test_dry_run_no_write(self):
+        ev = {"_id": ObjectId(), "userId": ObjectId(), "title": "Legs", "date": datetime(2026, 7, 5)}
+        ctx = _resched_ctx(ev)
+        r = await reschedule_session(ctx, str(ev["userId"]), {"event_id": str(ev["_id"]), "action": "skip"})
+        assert r["dry_run"] is True
+        ctx.db.calendarevents.update_one.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_confirmed_skip_writes(self):
+        ev = {"_id": ObjectId(), "userId": ObjectId(), "title": "Legs", "date": datetime(2026, 7, 5)}
+        ctx = _resched_ctx(ev)
+        r = await reschedule_session(ctx, str(ev["userId"]), {"event_id": str(ev["_id"]), "action": "skip", "dry_run": False})
+        assert r["op"] == "skip"
+        set_doc = ctx.db.calendarevents.update_one.call_args.args[1]["$set"]
+        assert set_doc["status"] == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_unknown_event(self):
+        ctx = _resched_ctx(None)
+        r = await reschedule_session(ctx, str(ObjectId()), {"event_id": str(ObjectId())})
+        assert r["success"] is False
+
+
+# ------------------------- adjust_plan -------------------------
+
+def _plan_weeks():
+    def wk(n):
+        return {"weekNumber": n, "restDays": [0, 6], "workouts": [
+            {"dayOfWeek": 1, "workoutType": "custom", "customWorkout": {"type": "strength", "exercises": [
+                {"exerciseName": "Squat", "sets": [{"reps": 5}, {"reps": 5}, {"reps": 5}]}]}},
+            {"dayOfWeek": 3, "workoutType": "custom", "customWorkout": {"type": "strength", "exercises": [
+                {"exerciseName": "Bench", "sets": [{"reps": 5}, {"reps": 5}, {"reps": 5}]}]}},
+        ]}
+    return [wk(1), wk(2)]
+
+
+class TestApplyAdjustment:
+    def test_volume_increase(self):
+        weeks, desc = apply_adjustment(_plan_weeks(), "volume", "increase", 1)
+        sets = weeks[0]["workouts"][0]["customWorkout"]["exercises"][0]["sets"]
+        assert len(sets) == 4
+        assert "increase" in desc
+
+    def test_volume_decrease_keeps_at_least_one(self):
+        weeks, _ = apply_adjustment(_plan_weeks(), "volume", "decrease", 10)
+        sets = weeks[0]["workouts"][0]["customWorkout"]["exercises"][0]["sets"]
+        assert len(sets) == 1
+
+    def test_deload_marks_first_week(self):
+        weeks, desc = apply_adjustment(_plan_weeks(), "deload", "", 1)
+        assert weeks[0]["deloadWeek"] is True
+        assert "deload" in desc
+
+    def test_frequency_decrease(self):
+        weeks, _ = apply_adjustment(_plan_weeks(), "frequency", "decrease", 1)
+        assert len(weeks[0]["workouts"]) == 1
+
+    def test_original_not_mutated(self):
+        original = _plan_weeks()
+        apply_adjustment(original, "volume", "increase", 5)
+        assert len(original[0]["workouts"][0]["customWorkout"]["exercises"][0]["sets"]) == 3
+
+
+def _adjust_ctx(plan):
+    db = MagicMock()
+    db.plans.find_one = AsyncMock(return_value=plan)
+    db.plans.update_one = AsyncMock()
+    db.goals.find_one = AsyncMock(return_value=None)
+    ctx = MagicMock(); ctx.db = db
+    return ctx
+
+
+class TestAdjustHandler:
+    @pytest.mark.asyncio
+    async def test_big_volume_jump_requires_override(self):
+        plan = {"_id": ObjectId(), "userId": ObjectId(), "schedule": {"weeksTotal": 2}, "weeks": _plan_weeks()}
+        ctx = _adjust_ctx(plan)
+        r = await adjust_plan(ctx, str(plan["userId"]),
+                              {"plan_id": str(plan["_id"]), "change_type": "volume", "direction": "increase",
+                               "magnitude": 5, "dry_run": False})
+        assert r.get("needs_confirmation") == "override"
+        ctx.db.plans.update_one.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_override_applies_write(self):
+        plan = {"_id": ObjectId(), "userId": ObjectId(), "schedule": {"weeksTotal": 2}, "weeks": _plan_weeks()}
+        ctx = _adjust_ctx(plan)
+        r = await adjust_plan(ctx, str(plan["userId"]),
+                              {"plan_id": str(plan["_id"]), "change_type": "volume", "direction": "increase",
+                               "magnitude": 5, "override": True, "dry_run": False})
+        assert r["success"] is True and r["dry_run"] is False
+        ctx.db.plans.update_one.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_no_write(self):
+        plan = {"_id": ObjectId(), "userId": ObjectId(), "schedule": {"weeksTotal": 2}, "weeks": _plan_weeks()}
+        ctx = _adjust_ctx(plan)
+        r = await adjust_plan(ctx, str(plan["userId"]), {"plan_id": str(plan["_id"]), "change_type": "deload"})
+        assert r["dry_run"] is True
+        ctx.db.plans.update_one.assert_not_called()

--- a/ai-coach-service/tests/test_schedule_plan_skill.py
+++ b/ai-coach-service/tests/test_schedule_plan_skill.py
@@ -260,6 +260,51 @@ class TestHandler:
         assert result["events_created"] == 3
 
     @pytest.mark.asyncio
+    async def test_conflict_with_other_event_warns_but_still_inserts(self):
+        plan = _sample_plan()
+        # An unrelated event (no planId) sits on the same day as week-1/day-0.
+        existing = [{
+            "date": datetime(2026, 7, 12), "title": "Doctor appt", "status": "scheduled",
+        }]
+        ctx = _make_ctx(plan, existing_events=existing)
+        preview = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12"},
+        )
+        assert len(preview["conflicts"]) == 1
+        assert "alongside" in preview["message"]
+        # On write, the conflict is NOT dropped — all 4 events are inserted.
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False},
+        )
+        assert result["events_created"] == 4
+
+    @pytest.mark.asyncio
+    async def test_reschedule_to_new_date_requires_overwrite(self):
+        plan = _sample_plan()
+        # Plan already scheduled: same slot (wk1/day0) but an OLD date.
+        existing = [{
+            "planId": plan["_id"], "planWeek": 1, "planDay": 0,
+            "date": datetime(2026, 7, 5), "title": "S&C (Jul 05)", "status": "scheduled",
+        }]
+        ctx = _make_ctx(plan, existing_events=existing)
+        # Moving to a new start date without overwrite -> guarded, no silent no-op.
+        guarded = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False},
+        )
+        assert guarded.get("needs_confirmation") == "reschedule"
+        ctx.db.calendarevents.insert_many.assert_not_called()
+        # With overwrite -> clears all plan events, inserts the full new set.
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False, "overwrite": True},
+        )
+        ctx.db.calendarevents.delete_many.assert_awaited_once()
+        assert result["events_created"] == 4
+
+    @pytest.mark.asyncio
     async def test_unknown_plan_returns_error(self):
         ctx = _make_ctx(plan=None)
         result = await schedule_plan_to_calendar(

--- a/ai-coach-service/tests/test_validate_plan_skill.py
+++ b/ai-coach-service/tests/test_validate_plan_skill.py
@@ -1,0 +1,115 @@
+"""Tests for the validate_plan skill (pure validator + handler)."""
+
+import pytest
+from bson import ObjectId
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.agents.skills.validate_plan_skill import validate_plan, validate_plan_doc
+
+
+def _custom_workout(day, wtype="strength", n_ex=4, sets_per=3):
+    return {
+        "dayOfWeek": day,
+        "workoutType": "custom",
+        "customWorkout": {
+            "title": f"{wtype} day",
+            "type": wtype,
+            "exercises": [
+                {"exerciseName": f"ex{i}", "sets": [{"reps": 8}] * sets_per}
+                for i in range(n_ex)
+            ],
+        },
+    }
+
+
+def _good_strength_plan():
+    # 4 weeks, 3 sessions/wk, ~12 sets/wk, rest days, a deload marked.
+    weeks = []
+    for wn in range(1, 5):
+        weeks.append({
+            "weekNumber": wn,
+            "deloadWeek": wn == 4,
+            "restDays": [0, 6],
+            "workouts": [_custom_workout(1), _custom_workout(3), _custom_workout(5)],
+        })
+    return {"schedule": {"weeksTotal": 4}, "weeks": weeks}
+
+
+class TestValidatePlanDoc:
+    def test_valid_strength_plan(self):
+        report = validate_plan_doc(_good_strength_plan(), "strength")
+        assert report["valid"] is True
+        assert report["violations"] == []
+        assert report["metrics"]["avg_sessions_per_week"] == 3.0
+
+    def test_empty_plan_invalid(self):
+        report = validate_plan_doc({"schedule": {"weeksTotal": 4}, "weeks": []}, "strength")
+        assert report["valid"] is False
+        assert any("no workouts" in v.lower() for v in report["violations"])
+
+    def test_underdosed_frequency_and_volume(self):
+        weeks = [{"weekNumber": 1, "restDays": [0], "workouts": [_custom_workout(1, n_ex=1, sets_per=1)]}]
+        report = validate_plan_doc({"schedule": {"weeksTotal": 1}, "weeks": weeks}, "strength")
+        assert report["valid"] is False
+        assert any("sessions/week" in v for v in report["violations"])
+        assert any("working sets" in v for v in report["violations"])
+
+    def test_aggressive_ramp_flagged(self):
+        weeks = [
+            {"weekNumber": 1, "restDays": [0], "workouts": [_custom_workout(1, n_ex=2, sets_per=3)]},
+            {"weekNumber": 2, "restDays": [0], "workouts": [_custom_workout(1, n_ex=10, sets_per=5)]},
+        ]
+        report = validate_plan_doc({"schedule": {"weeksTotal": 2}, "weeks": weeks}, "strength")
+        assert any("jumps" in v for v in report["violations"])
+
+    def test_long_plan_without_deload_suggested(self):
+        weeks = [
+            {"weekNumber": wn, "deloadWeek": False, "restDays": [0, 6],
+             "workouts": [_custom_workout(1), _custom_workout(3), _custom_workout(5)]}
+            for wn in range(1, 9)
+        ]
+        report = validate_plan_doc({"schedule": {"weeksTotal": 8}, "weeks": weeks}, "strength")
+        assert any("deload" in s.lower() for s in report["suggestions"])
+
+    def test_endurance_goal_without_cardio_suggests_aerobic(self):
+        report = validate_plan_doc(_good_strength_plan(), "endurance")
+        assert any("aerobic" in s.lower() or "cardio" in s.lower() for s in report["suggestions"])
+
+
+def _make_ctx(plan, goal=None):
+    db = MagicMock()
+    db.plans.find_one = AsyncMock(return_value=plan)
+    db.goals.find_one = AsyncMock(return_value=goal)
+    ctx = MagicMock()
+    ctx.db = db
+    return ctx
+
+
+class TestHandler:
+    @pytest.mark.asyncio
+    async def test_valid_plan_handler(self):
+        plan = _good_strength_plan()
+        plan["_id"] = ObjectId()
+        plan["userId"] = ObjectId()
+        ctx = _make_ctx(plan)
+        result = await validate_plan(ctx, str(plan["userId"]), {"plan_id": str(plan["_id"])})
+        assert result["success"] is True
+        assert result["valid"] is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_plan(self):
+        ctx = _make_ctx(plan=None)
+        result = await validate_plan(ctx, str(ObjectId()), {"plan_id": str(ObjectId())})
+        assert result["success"] is False
+        assert "not found" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_goal_category_from_linked_goal(self):
+        plan = _good_strength_plan()
+        plan["_id"] = ObjectId()
+        plan["userId"] = ObjectId()
+        plan["goalId"] = ObjectId()
+        ctx = _make_ctx(plan, goal={"category": "endurance"})
+        result = await validate_plan(ctx, str(plan["userId"]), {"plan_id": str(plan["_id"])})
+        # endurance goal on a strength-only plan -> aerobic suggestion present
+        assert any("aerobic" in s.lower() or "cardio" in s.lower() for s in result["suggestions"])


### PR DESCRIPTION
Builds out the AI-coach **skill layer** on the registry from #71 — 8 new skills + shared deterministic infra, each a self-contained file auto-wired via `@skill`.

## Shared infrastructure
- `knowledge/training_knowledge.py` — sourced threshold constants (volume/frequency minimums, spacing, deload cadence, ramp cap) with contested-metric flags. **Code, not RAG** — validators stay deterministic/testable. (Exercise-KB RAG is a documented future enhancement.)
- `knowledge/movement.py` — movement-pattern inference (the Exercise model has no such field).
- `safety.py` — inline caveats from `health` memories + `profile.injuries` (lightweight, not a screening gate).
- `SkillContext` now carries the shared OpenAI client for LLM-backed skills.

## Skills
**Plan core loop**
- `validate_plan` — deterministic Tier-2 checks (volume/frequency/rest/deload/ramp/goal-fit).
- `generate_plan` — LLM designs weekly workout blueprints; code scaffolds them across weeks (deloads, rest), validates, saves a **draft** (no calendar writes). User schedules with `schedule_plan_to_calendar`.

**Exercise intelligence**
- `suggest_exercises` — equipment/safety-filtered retrieval; skill goals redirect to a progression.
- `substitute_exercise` — movement+muscle+equipment+strain matching; **pain/injury → safety caution**, never a rehab swap.

**Live plan management**
- `review_progress` — adherence **derived from calendar events** (not the stale `Plan.progress`).
- `reschedule_session` — skip/shift/auto one session, dry-run + confirm.
- `adjust_plan` — volume/frequency/deload changes; re-validates; **ramp-cap guard** needs `override` for big jumps; dry-run + confirm.

## Review fixes to `schedule_plan_to_calendar` (from #71 follow-up)
- Preview no longer claims "won't double-book" — it **warns** and inserts alongside.
- Reschedule to a new start date is no longer a **silent no-op** (distinguishes duplicate vs move; requires `overwrite`).
- `generate_plan` no longer floods the calendar with a rest event per off-day.

## Testing
**149 passing** (pure-helper unit tests + mocked-DB handler tests per skill: dry-run writes nothing, confirmed writes persist, refusal/safety paths). Verified under Python 3.13; all 9 skills register once (**33 tools**).

## Deferred (documented)
- `monitor_load` — data-blocked (RPE rarely logged, two divergent log stores, stale adherence); needs backend session-RPE capture.
- Full PAR-Q screening — lightweight safety used instead.
- `validate_plan` predefined-template resolution — v2 (template-based plans misfire on volume/aerobic checks until then).
- **Live verification** not yet run — all tests are unit/mocked.

Scope: only `ai-coach-service/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)