### PR TITLE
feat(ai-coach): curated, quality-ranked exercise demo videos (YouTube Data API)

### DIFF
--- a/ai-coach-service/.env.example
+++ b/ai-coach-service/.env.example
@@ -6,6 +6,8 @@ MONGODB_DATABASE=ripped-potato
 OPENAI_API_KEY=your-openai-api-key-here
 OPENAI_MODEL=gpt-5.4-mini
 OPENAI_MODEL_FAST=gpt-5.4-mini
+# Optional: stronger model for plan generation only (falls back to OPENAI_MODEL)
+# OPENAI_MODEL_PLANNER=gpt-5.4
 
 # Security (must match Node.js backend)
 JWT_SECRET_KEY=your-jwt-secret-key-here
@@ -14,6 +16,11 @@ JWT_ALGORITHM=HS256
 # CORS Settings
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5001
 
-# Tavily Web Search API (optional - for exercise tutorials and fitness content)
+# Tavily Web Search API (optional - for written guides, articles, research)
 # Get your free API key at https://tavily.com
 TAVILY_API_KEY=your-tavily-api-key-here
+
+# YouTube Data API v3 (optional - for quality-ranked exercise DEMO videos)
+# Free: 10k units/day. Console -> enable "YouTube Data API v3" -> create API key.
+# Without it, video search falls back to Tavily.
+YOUTUBE_API_KEY=your-youtube-api-key-here

--- a/ai-coach-service/app/config.py
+++ b/ai-coach-service/app/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     openai_model: str
     # Model for auxiliary calls (suggestions, train-now, reflection).
     openai_model_fast: str
+    # Optional stronger model for plan generation only (macro/periodization
+    # reasoning). None = fall back to openai_model; resolve at the call site.
+    openai_model_planner: Optional[str] = None
 
     # Security
     jwt_secret_key: str
@@ -45,17 +48,25 @@ class Settings(BaseSettings):
     # Tavily Web Search API
     tavily_api_key: Optional[str] = None
 
+    # YouTube Data API v3 — used to find and quality-rank exercise-demo videos.
+    # Env: YOUTUBE_API_KEY. Optional: without it, video search falls back to Tavily.
+    youtube_api_key: Optional[str] = None
+
     @property
     def cors_origins(self) -> List[str]:
         return [origin.strip() for origin in self.allowed_origins.split(",")]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # Try to load Tavily API key from Render secret file if not set
+        # Try to load API keys from Render secret files if not set via env
         if not self.tavily_api_key:
             secret_key = read_secret_file("TAVILY_API_KEY")
             if secret_key:
                 object.__setattr__(self, 'tavily_api_key', secret_key)
+        if not self.youtube_api_key:
+            secret_key = read_secret_file("YOUTUBE_API_KEY")
+            if secret_key:
+                object.__setattr__(self, 'youtube_api_key', secret_key)
 
 
 @lru_cache()

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -57,6 +57,19 @@ def _needs_grounding(message: str) -> bool:
     return bool(_GROUNDING_INTENT_RE.search(message or ""))
 
 
+_VIDEO_EMBED_RE = re.compile(r'<video-embed\s+videoid="([^"]+)"[^>]*/>')
+
+
+def _collect_video_tags(result: Dict[str, Any], into: Dict[str, str]) -> None:
+    """Record any <video-embed> tags a tool returned, keyed by video id, so we
+    can guarantee they render even if the model paraphrases them away."""
+    if not isinstance(result, dict):
+        return
+    msg = result.get("message") or ""
+    for m in _VIDEO_EMBED_RE.finditer(msg):
+        into.setdefault(m.group(1), m.group(0))
+
+
 class AgentOrchestrator:
     """Enhanced orchestrator with comprehensive fitness management tools"""
 
@@ -75,7 +88,11 @@ class AgentOrchestrator:
         self.plan_service = PlanService(db)
         self.goal_service = GoalService(db)
         self.calendar_service = CalendarService(db)
-        self.search_service = SearchService(self.settings.tavily_api_key)
+        self.search_service = SearchService(
+            tavily_api_key=self.settings.tavily_api_key,
+            youtube_api_key=self.settings.youtube_api_key,
+            db=db,
+        )
         self.memory_service = MemoryService(db)
 
         # Shared context handed to every registered skill handler.
@@ -339,6 +356,7 @@ USER DATA:
             # Workout template tools
             "create_workout_template": f"Creating workout template: {function_args.get('name', 'workout')}",
             "list_workout_templates": "Browsing workout templates",
+            "delete_workout_template": "Removing workout template(s)",
             # Workout log tools
             "log_workout": f"Logging workout: {function_args.get('title', 'workout')}",
             "get_workout_history": "Fetching your workout history",
@@ -356,7 +374,12 @@ USER DATA:
             "schedule_to_calendar": f"Scheduling {function_args.get('title', 'event')} for {function_args.get('date', 'your calendar')}",
             "get_calendar_events": "Checking your calendar",
             # Web search & research
-            "web_search": f"Searching the web for: {function_args.get('query', 'fitness info')}",
+            "web_search": (
+                f"Finding a demo video: {function_args.get('query', 'exercise')}"
+                if function_args.get("search_type") == "video"
+                else f"Searching the web for: {function_args.get('query', 'fitness info')}"
+            ),
+            "save_exercise_video": f"Saving demo for {function_args.get('exercise_name', 'exercise')}",
             "read_url": f"Reading content from: {function_args.get('url', 'webpage')[:50]}...",
             "research": f"Researching: {function_args.get('topic', 'fitness topic')}",
             # Memory
@@ -490,6 +513,10 @@ USER DATA:
         # Track the full response and tools used for reflection
         full_response = []
         tools_used = []
+        # Video-embed tags returned by tools this turn. The model sometimes
+        # paraphrases a video result instead of emitting the <video-embed> tag,
+        # which breaks the player. We ensure the tag(s) end up in the response.
+        turn_video_tags: Dict[str, str] = {}  # videoid -> full tag
 
         try:
             # Create streaming completion with tools. If the user referenced their
@@ -570,6 +597,7 @@ USER DATA:
 
                         # Execute tool
                         result = await self._execute_tool(user_id, function_name, function_args)
+                        _collect_video_tags(result, turn_video_tags)
 
                         logger.info(f"Tool {function_name} result: {result}")
 
@@ -690,6 +718,7 @@ USER DATA:
 
                                     # Execute tool
                                     result = await self._execute_tool(user_id, function_name, function_args)
+                                    _collect_video_tags(result, turn_video_tags)
                                     logger.info(f"Follow-up tool {function_name} result: {result}")
 
                                     follow_up_results.append({
@@ -739,6 +768,19 @@ USER DATA:
                         else:
                             # Stream finished without tool_calls finish reason
                             break
+
+            # Guarantee any video the tools returned actually renders: if the model
+            # described it in prose but dropped the <video-embed> tag, append it.
+            accumulated_content = "".join(full_response)
+            missing_tags = [
+                tag for vid, tag in turn_video_tags.items()
+                if vid not in accumulated_content
+            ]
+            if missing_tags:
+                injection = "\n\n" + "\n\n".join(missing_tags)
+                full_response.append(injection)
+                yield {"type": "token", "content": injection}
+                logger.info(f"Injected {len(missing_tags)} missing video-embed tag(s)")
 
             # === REFLECTION FOR STREAMING PATH ===
             accumulated_content = "".join(full_response)
@@ -944,9 +986,11 @@ USER DATA:
             "list_exercises": self.exercise_service.list_exercises,
             "grep_exercises": self.exercise_service.grep_exercises,
             "grep_workouts": self.exercise_service.grep_workouts,
+            "save_exercise_video": self.exercise_service.save_exercise_video,
             # Workout template tools
             "create_workout_template": self.workout_service.create_workout_template,
             "list_workout_templates": self.workout_service.list_workout_templates,
+            "delete_workout_template": self.workout_service.delete_workout_template,
             # Workout log tools
             "log_workout": self.workout_service.log_workout,
             "get_workout_history": self.workout_service.get_workout_history,

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -37,7 +37,8 @@ WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I 
 
 **Workout Templates** (Reusable workout designs):
 - `create_workout_template`: Create workout templates with blocks (Warm-up, Main Work, Finisher, etc.). These are saved to the user's library and can be reused in training plans.
-- `list_workout_templates`: Find existing workout templates.
+- `list_workout_templates`: Find existing workout templates. The result reports `total_matching` and `filter_used` — trust those over your memory of earlier calls, and if counts differ between calls, say which filter caused it.
+- `delete_workout_template`: Remove the user's OWN templates (common/public ones are protected). Previews first, deletes on confirm; `keep_only` handles "delete everything except X, Y" in one call. If the user asks for something no tool can do, say so plainly instead of re-browsing.
 
 **Workout Logging** (Training history):
 - `log_workout`: Record completed or planned workouts with actual sets, reps, weights, and RPE. This is the user's training log.
@@ -149,17 +150,12 @@ Example of what NOT to do:
 - Day 1: "User is sick..."
 - Day 5: User says "I'm okay" → DELETE memory ❌ (WRONG! You just lost valuable health history)
 
-PREFERRED FITNESS CONTENT CREATORS (include relevant names in your search query for better results):
-- **Calisthenics/Bodyweight**: Saturno Movement, Calisthenicmovement, FitnessFAQs, Chris Heria, Minus The Gym, Hybrid Calisthenics, Tom Merrick
-- **Strength Training/General**: Athlean-X (Jeff Cavaliere), Jeremy Ethier, Jeff Nippard, Renaissance Periodization, Squat University
-- **Mobility/Flexibility**: Tom Merrick, Squat University, GMB Fitness
-- **Powerlifting/Olympic**: Juggernaut Training Systems, Calgary Barbell, Zack Telander
-- **Yoga/Mind-Body**: Yoga With Adriene, Breathe and Flow
-
-When searching for exercise tutorials, include 1-2 relevant creator names in the query. Examples:
-- Calisthenics exercise → "muscle up tutorial Saturno Movement OR Calisthenicmovement"
-- Strength exercise → "deadlift form Athlean-X OR Jeff Nippard"
-- Mobility/stretching → "hip mobility routine Tom Merrick"
+EXERCISE HOW-TO — CHOOSE VIDEO vs TEXT BY CONTEXT (don't default to one):
+- Judge what the user actually wants. A quick form cue or "what muscles does X work?" is often best answered in TEXT (a couple of sentences, or `search_type="article"` for a written guide). "Show me / can I see / demo / what does it look like" wants a VIDEO (`search_type="video"`). When both would help (e.g. "how do I do a muscle up?"), you MAY call `web_search` twice IN THE SAME TURN — one `search_type="video"` and one `search_type="article"` — they run in parallel.
+- For `search_type="video"`: pass a CLEAN query — just the exercise name (e.g. "toes to bar", "muscle up"). Do NOT append creator names, "youtube", or "tutorial". The system searches YouTube and auto-ranks results from trusted fitness channels (Saturno Movement, Calisthenicmovement, FitnessFAQs, Athlean-X, Jeff Nippard, Tom Merrick, Squat University, …) by quality (channel, engagement, length), returning the best 1-2 as embedded players.
+- You never handle video ids or URLs — the system tracks the video it showed and fills in the technical details. You only express intent:
+  - User says the video is BAD / not good: call `web_search` again with `search_type="video"` and `exclude_previous=true` to get a fresh alternative (don't just repeat the search).
+  - User says a video is GOOD / perfect / "save this": call `save_exercise_video` with just the `exercise_name` (and `which="alternative"` only if they picked the second option). Confirm briefly ("Saved 👍").
 
 CALENDAR WORKFLOW:
 When user asks to add/schedule a workout for a specific date:

--- a/ai-coach-service/app/core/agents/services/exercise_service.py
+++ b/ai-coach-service/app/core/agents/services/exercise_service.py
@@ -62,6 +62,68 @@ class ExerciseService:
             logger.error(f"Error adding exercise: {e}")
             return {"success": False, "message": str(e)}
 
+    async def save_exercise_video(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Attach the video we just SHOWED the user to an exercise as its curated demo.
+
+        The coach passes only semantics — the exercise name and (optionally) which of
+        the shown options ('best' or 'alternative'). We resolve the real YouTube id
+        DETERMINISTICALLY from what we actually showed (uservideocontext); the LLM
+        never handles the id or URL, so it can't save the wrong video.
+        """
+        try:
+            name = (args.get("exercise_name") or "").strip()
+            if not name:
+                return {"success": False, "message": "exercise_name is required."}
+
+            which = (args.get("which") or "best").lower()
+
+            # Look up what we last showed this user for this exercise.
+            key = re.sub(r"[^a-z0-9]", "", name.lower())
+            ctx = await self.db["uservideocontext"].find_one({"user_id": user_id, "query": key})
+            if not ctx:
+                # fall back to this user's most recent video context (e.g. "save that one")
+                ctx = await self.db["uservideocontext"].find_one(
+                    {"user_id": user_id}, sort=[("updatedAt", -1)]
+                )
+            if not ctx:
+                return {"success": False, "message": "Search for a demo first, then tell me to save it."}
+
+            last_shown = ctx.get("last_shown") or ctx.get("shown_ids") or []
+            if which in ("alternative", "alt", "second", "other") and len(last_shown) >= 2:
+                video_id = last_shown[1]
+            else:
+                video_id = ctx.get("top_id") or (last_shown[0] if last_shown else None)
+
+            if not video_id:
+                return {"success": False, "message": "I couldn't tell which video to save — search for a demo first."}
+
+            url = f"https://www.youtube.com/watch?v={video_id}"
+
+            # Find the exercise: prefer common, then user-owned, by exact-ish name.
+            name_regex = {"$regex": f"^{re.escape(name)}$", "$options": "i"}
+            exercise = await self.db.exercises.find_one({"name": name_regex, "isCommon": True})
+            if not exercise:
+                exercise = await self.db.exercises.find_one({"name": name_regex, "createdBy": ObjectId(user_id)})
+            if not exercise:
+                exercise = await self.db.exercises.find_one({"name": name_regex})
+            if not exercise:
+                return {"success": False, "message": f"I couldn't find an exercise named '{name}' to attach the video to."}
+
+            await self.db.exercises.update_one(
+                {"_id": exercise["_id"]},
+                {"$set": {"mediaUrls.video": url, "updatedAt": datetime.utcnow()}},
+            )
+            logger.info(f"Saved curated video {video_id} for exercise '{exercise.get('name')}'")
+            return {
+                "success": True,
+                "message": f"Saved that video as the demo for **{exercise.get('name')}** 👍",
+                "exercise_id": str(exercise["_id"]),
+                "video_url": url,
+            }
+        except Exception as e:
+            logger.error(f"Error saving exercise video: {e}")
+            return {"success": False, "message": str(e)}
+
     async def list_exercises(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """List exercises from the database with optional filters"""
         try:

--- a/ai-coach-service/app/core/agents/services/plan_service.py
+++ b/ai-coach-service/app/core/agents/services/plan_service.py
@@ -34,6 +34,12 @@ class PlanService:
                     "workouts": [],
                     "restDays": []
                 }
+                # Rolling-materialization flags: only set when the caller provides
+                # them (missing = resolved, the legacy/back-compat convention).
+                if "resolved" in week_data:
+                    week["resolved"] = bool(week_data["resolved"])
+                    if week_data.get("resolvedAt"):
+                        week["resolvedAt"] = week_data["resolvedAt"]
 
                 # Process workouts for this week
                 for workout in week_data.get("workouts", []):

--- a/ai-coach-service/app/core/agents/services/search_service.py
+++ b/ai-coach-service/app/core/agents/services/search_service.py
@@ -2,147 +2,313 @@
 Search service - handles web search operations
 """
 
+import html
 import re
-from typing import Dict, Any
-from tavily import TavilyClient
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
 import structlog
+from bson import ObjectId
+from tavily import TavilyClient
+
+from app.core.agents.services.youtube_search import enrich_youtube_ids, youtube_search_videos
 
 logger = structlog.get_logger()
 
+# Mongo collection used to cache YouTube query -> ranked results (conserves the
+# 100-search/day quota). A TTL index expires entries after 30 days.
+VIDEO_CACHE_COLLECTION = "videocache"
+VIDEO_CACHE_TTL_DAYS = 30
+
+# Per-user record of the videos we most recently SHOWED for a given exercise/query.
+# The LLM can't reliably recall exact 11-char ids across turns, so save/exclude
+# resolve against this instead of trusting model-supplied ids.
+USER_VIDEO_CTX_COLLECTION = "uservideocontext"
+
+_YT_ID_RE = re.compile(r'(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/)([^&\n?#]+)')
+
+
+def norm_query(q: str) -> str:
+    """Normalize an exercise/query string to a stable key (alphanumerics only)."""
+    return re.sub(r"[^a-z0-9]", "", (q or "").lower())
+
+
+def _embed(video_id: str, title: str) -> str:
+    """Build a <video-embed> tag with a safe title: decode HTML entities (YouTube
+    returns '&amp;' etc.) and neutralize double-quotes that would break the tag."""
+    safe = html.unescape(title or "").replace('"', "'").strip()
+    return f'<video-embed videoid="{video_id}" title="{safe}" />'
+
+
+def _extract_video_id(url: str) -> Optional[str]:
+    """Pull the 11-char video id out of a YouTube URL (or return a bare id)."""
+    if not url:
+        return None
+    match = _YT_ID_RE.search(url)
+    if match:
+        return match.group(1)
+    # Allow a bare id to be stored directly in mediaUrls.video
+    if re.fullmatch(r"[A-Za-z0-9_-]{11}", url):
+        return url
+    return None
+
 
 class SearchService:
-    """Service for web search operations"""
+    """Service for web search operations.
 
-    def __init__(self, tavily_api_key: str = None):
+    Video demonstrations come from the YouTube Data API (quality-ranked, curated),
+    with Tavily as the fallback and as the engine for article/general/research text.
+    """
+
+    def __init__(self, tavily_api_key: str = None, youtube_api_key: str = None, db=None):
         self.tavily_api_key = tavily_api_key
+        self.youtube_api_key = youtube_api_key
+        self.db = db
+        self._video_cache_ready = False
+
+    # ------------------------------------------------------------------ #
+    # Video search: curated -> YouTube (ranked, cached) -> Tavily fallback
+    # ------------------------------------------------------------------ #
+
+    async def _ensure_video_cache_index(self) -> None:
+        if self.db is None or self._video_cache_ready:
+            return
+        try:
+            await self.db[VIDEO_CACHE_COLLECTION].create_index(
+                "createdAt", expireAfterSeconds=VIDEO_CACHE_TTL_DAYS * 86400
+            )
+            await self.db[VIDEO_CACHE_COLLECTION].create_index("query", unique=True)
+            self._video_cache_ready = True
+        except Exception as e:
+            logger.warning(f"Could not ensure video cache index: {e}")
+
+    async def _get_curated_video(self, query: str) -> Optional[Dict[str, Any]]:
+        """Tier 0: if the query names an exercise that already has a curated
+        video in the library, return it — no external call."""
+        if self.db is None:
+            return None
+        try:
+            q = query.lower()
+            # Pull common + user exercises that have a curated video, match by name.
+            cursor = self.db.exercises.find(
+                {"mediaUrls.video": {"$exists": True, "$nin": [None, ""]}},
+                {"name": 1, "mediaUrls": 1},
+            )
+            async for ex in cursor:
+                name = (ex.get("name") or "").lower()
+                if name and name in q:
+                    video = ex["mediaUrls"].get("video")
+                    vid = _extract_video_id(video)
+                    if vid:
+                        return {"video_id": vid, "title": ex.get("name"), "url": video, "curated": True}
+            return None
+        except Exception as e:
+            logger.warning(f"Curated video lookup failed: {e}")
+            return None
+
+    async def _youtube_search_cached(self, query: str, exclude_ids: List[str]) -> List[Dict[str, Any]]:
+        """Tier 1: YouTube search with a Mongo cache (skipped when excluding ids,
+        i.e. when the user rejected a video and wants a fresh result)."""
+        await self._ensure_video_cache_index()
+        cache_key = query.strip().lower()
+        if self.db is not None and not exclude_ids:
+            try:
+                cached = await self.db[VIDEO_CACHE_COLLECTION].find_one({"query": cache_key})
+                if cached and cached.get("results"):
+                    logger.info(f"YouTube cache hit for '{cache_key}'")
+                    return cached["results"]
+            except Exception as e:
+                logger.warning(f"Video cache read failed: {e}")
+
+        videos = await youtube_search_videos(
+            self.youtube_api_key, f"{query} tutorial how to", exclude_ids=exclude_ids
+        )
+
+        if self.db is not None and videos and not exclude_ids:
+            try:
+                await self.db[VIDEO_CACHE_COLLECTION].update_one(
+                    {"query": cache_key},
+                    {"$set": {"query": cache_key, "results": videos, "createdAt": datetime.utcnow()}},
+                    upsert=True,
+                )
+            except Exception as e:
+                logger.warning(f"Video cache write failed: {e}")
+        return videos
+
+    async def _record_shown(self, user_id: str, query: str, shown_ids: List[str], top: Dict[str, Any]) -> None:
+        """Remember which videos we showed this user for this exercise/query, so
+        'save it' / 'show another' can resolve the real id (the LLM forgets it)."""
+        if self.db is None or not shown_ids:
+            return
+        try:
+            key = norm_query(query)
+            existing = await self.db[USER_VIDEO_CTX_COLLECTION].find_one({"user_id": user_id, "query": key})
+            prior = existing.get("shown_ids", []) if existing else []
+            merged = list(dict.fromkeys(prior + shown_ids))[-12:]  # accumulated, for exclusion
+            await self.db[USER_VIDEO_CTX_COLLECTION].update_one(
+                {"user_id": user_id, "query": key},
+                {"$set": {
+                    "user_id": user_id, "query": key,
+                    "shown_ids": merged,          # everything shown (for "show another")
+                    "last_shown": shown_ids,      # THIS search's ids, in rank order (for "which")
+                    "top_id": top.get("video_id"), "top_title": top.get("title"),
+                    "updatedAt": datetime.utcnow(),
+                }},
+                upsert=True,
+            )
+        except Exception as e:
+            logger.warning(f"Could not record shown videos: {e}")
+
+    async def _prior_shown_ids(self, user_id: str, query: str) -> List[str]:
+        if self.db is None:
+            return []
+        try:
+            doc = await self.db[USER_VIDEO_CTX_COLLECTION].find_one({"user_id": user_id, "query": norm_query(query)})
+            return doc.get("shown_ids", []) if doc else []
+        except Exception:
+            return []
+
+    async def _video_search(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        query = args["query"]
+
+        # The coach only tells us SEMANTICS: "show a different one" -> exclude_previous.
+        # We deterministically fill in which ids to skip (everything already shown for
+        # this exercise) — the LLM never handles raw video ids.
+        exclude_ids: List[str] = []
+        if args.get("exclude_previous"):
+            exclude_ids = await self._prior_shown_ids(user_id, query)
+
+        # Tier 0: curated library video
+        curated = await self._get_curated_video(query)
+        if curated and curated["video_id"] not in exclude_ids:
+            message = (
+                f"Here's the demo we've saved for **{curated['title']}**:\n\n"
+                + _embed(curated['video_id'], curated['title'])
+            )
+            await self._record_shown(user_id, query, [curated["video_id"]], curated)
+            return {"success": True, "message": message, "results": [curated], "source": "curated"}
+
+        # Tier 1: YouTube Data API (quality-ranked)
+        if self.youtube_api_key:
+            videos = await self._youtube_search_cached(query, exclude_ids)
+            top = [v for v in videos if v["video_id"] not in exclude_ids][:2]
+            if top:
+                best = top[0]
+                message = f"Best demo I found for **{query}** — from **{best['channelTitle']}**:\n\n"
+                message += _embed(best['video_id'], best['title'])
+                if len(top) > 1:
+                    message += "\n\nAlternative: " + _embed(top[1]["video_id"], top[1]["title"])
+                await self._record_shown(user_id, query, [v["video_id"] for v in top], best)
+                return {"success": True, "message": message, "results": top, "source": "youtube"}
+            logger.info("YouTube returned no usable videos, falling back to Tavily")
+
+        # Tier 2: Tavily fallback (no key / quota exhausted / no results)
+        result = await self._tavily_video_fallback(user_id, query, exclude_ids)
+        if result.get("results"):
+            ids = [r["video_id"] for r in result["results"] if r.get("video_id")]
+            if ids:
+                await self._record_shown(user_id, query, ids, result["results"][0])
+        return result
+
+    async def _tavily_video_fallback(self, user_id: str, query: str, exclude_ids: Optional[List[str]] = None) -> Dict[str, Any]:
+        exclude = set(exclude_ids or [])
+        if not self.tavily_api_key:
+            return {"success": False, "message": "Video search isn't configured (no YouTube or Tavily key)."}
+        try:
+            tavily = TavilyClient(api_key=self.tavily_api_key)
+            response = tavily.search(
+                query=f"{query} tutorial", max_results=5, search_depth="basic",
+                include_domains=["youtube.com"],
+            )
+            tavily_ids = []
+            for result in response.get("results", []):
+                vid = _extract_video_id(result.get("url", ""))
+                if vid and vid not in exclude:
+                    tavily_ids.append(vid)
+
+            # If we have a YouTube key, enrich Tavily's ids through the Data API
+            # (real stats/channel/duration) and rank them — Tavily's #1 may not be
+            # the best. Returns a properly scored pick, not just "first youtube link".
+            if self.youtube_api_key and tavily_ids:
+                enriched = await enrich_youtube_ids(self.youtube_api_key, tavily_ids)
+                enriched = [v for v in enriched if v["video_id"] not in exclude]
+                if enriched:
+                    best = enriched[0]
+                    msg = f"Best demo I found for **{query}** — from **{best['channelTitle']}**:\n\n"
+                    msg += _embed(best['video_id'], best['title'])
+                    if len(enriched) > 1:
+                        msg += "\n\nAlternative: " + _embed(enriched[1]["video_id"], enriched[1]["title"])
+                    return {"success": True, "message": msg, "results": enriched[:2], "source": "tavily+youtube"}
+
+            # No YouTube key — return Tavily's first youtube video raw.
+            if tavily_ids:
+                title = next((r.get("title", "") for r in response.get("results", []) if _extract_video_id(r.get("url", "")) == tavily_ids[0]), "")
+                return {
+                    "success": True,
+                    "message": f"Here's a tutorial for **{query}**:\n\n" + _embed(tavily_ids[0], title),
+                    "results": [{"video_id": tavily_ids[0], "title": title}],
+                    "source": "tavily",
+                }
+            return {"success": True, "message": f"I couldn't find a solid video for \"{query}\". Want a written form guide instead?", "results": []}
+        except Exception as e:
+            logger.error(f"Tavily video fallback failed: {e}")
+            return {"success": False, "message": f"Video search failed: {str(e)}"}
 
     async def web_search(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Search the web for fitness-related content using Tavily"""
+        """Search for fitness content. Video demos → YouTube (ranked); text → Tavily."""
         try:
             query = args.get("query")
             if not query:
                 return {"success": False, "message": "Search query is required"}
 
             search_type = args.get("search_type", "general")
-            max_results = min(args.get("max_results", 3), 5)  # Cap at 5
 
-            # Check if Tavily API key is configured
-            if not self.tavily_api_key:
-                return {
-                    "success": False,
-                    "message": "Web search is not configured. Please add TAVILY_API_KEY to your environment."
-                }
-
-            # Initialize Tavily client
-            tavily = TavilyClient(api_key=self.tavily_api_key)
-
-            # Preferred fitness creators by category
-            PREFERRED_CREATORS = {
-                "calisthenics": ["Saturno Movement", "Calisthenicmovement", "FitnessFAQs", "Chris Heria", "Hybrid Calisthenics"],
-                "bodyweight": ["Saturno Movement", "Calisthenicmovement", "FitnessFAQs", "Hybrid Calisthenics", "Minus The Gym"],
-                "strength": ["Athlean-X", "Jeff Nippard", "Jeremy Ethier", "Renaissance Periodization"],
-                "mobility": ["Tom Merrick", "Squat University", "GMB Fitness"],
-                "flexibility": ["Tom Merrick", "GMB Fitness", "Yoga With Adriene"],
-                "powerlifting": ["Juggernaut Training Systems", "Calgary Barbell", "Squat University"],
-                "yoga": ["Yoga With Adriene", "Breathe and Flow"],
-                "meditation": ["Yoga With Adriene", "Headspace"],
-            }
-
-            # Detect category from query to boost with preferred creators
-            query_lower = query.lower()
-            creator_boost = ""
-
-            # Check for category keywords in query
-            for category, creators in PREFERRED_CREATORS.items():
-                if category in query_lower:
-                    creator_boost = f" {creators[0]} OR {creators[1]}"
-                    break
-
-            # Also check for common exercise types
-            if not creator_boost:
-                calisthenics_keywords = ["pull up", "pull-up", "muscle up", "muscle-up", "dip", "handstand", "planche", "front lever", "back lever", "l-sit", "ring"]
-                strength_keywords = ["deadlift", "squat", "bench press", "barbell", "dumbbell", "overhead press"]
-                mobility_keywords = ["mobility", "stretch", "flexibility", "warm up", "warm-up"]
-
-                if any(kw in query_lower for kw in calisthenics_keywords):
-                    creator_boost = " Saturno Movement OR Calisthenicmovement"
-                elif any(kw in query_lower for kw in strength_keywords):
-                    creator_boost = " Athlean-X OR Jeff Nippard"
-                elif any(kw in query_lower for kw in mobility_keywords):
-                    creator_boost = " Tom Merrick OR Squat University"
-
-            # Enhance query for fitness context
-            enhanced_query = query
+            # Video demonstrations use the dedicated curated/YouTube path.
             if search_type == "video":
-                enhanced_query = f"{query}{creator_boost} video tutorial youtube"
-            elif search_type == "article":
-                enhanced_query = f"{query} guide article"
-            else:
-                enhanced_query = f"{query}{creator_boost}"
+                logger.info(f"Video search for user {user_id}: {query}")
+                return await self._video_search(user_id, args)
 
-            # Perform search
+            # Text (article / general) stays on Tavily.
+            max_results = min(args.get("max_results", 3), 5)
+            if not self.tavily_api_key:
+                return {"success": False, "message": "Web search is not configured. Please add TAVILY_API_KEY to your environment."}
+
+            tavily = TavilyClient(api_key=self.tavily_api_key)
+            enhanced_query = f"{query} guide article" if search_type == "article" else query
             logger.info(f"Web search for user {user_id}: {enhanced_query}")
             response = tavily.search(
                 query=enhanced_query,
                 max_results=max_results,
                 search_depth="basic",
                 include_answer=True,
-                include_domains=["youtube.com", "bodybuilding.com", "menshealth.com",
-                                "womenshealthmag.com", "stack.com", "t-nation.com",
-                                "strengthlog.com", "exrx.net", "verywellfit.com"] if search_type != "general" else None
+                include_domains=["bodybuilding.com", "menshealth.com", "womenshealthmag.com",
+                                 "t-nation.com", "strengthlog.com", "exrx.net", "verywellfit.com"]
+                if search_type == "article" else None,
             )
 
-            # Format results
             results = []
             for result in response.get("results", []):
                 url = result.get("url", "")
-                is_video = "youtube.com" in url or "youtu.be" in url
-                video_id = None
-
-                # Extract YouTube video ID
-                if is_video:
-                    patterns = [
-                        r'(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)',
-                    ]
-                    for pattern in patterns:
-                        match = re.search(pattern, url)
-                        if match:
-                            video_id = match.group(1)
-                            break
-
+                content = result.get("content", "")
                 results.append({
                     "title": result.get("title", ""),
                     "url": url,
-                    "snippet": result.get("content", "")[:300] + "..." if len(result.get("content", "")) > 300 else result.get("content", ""),
-                    "is_video": is_video,
-                    "video_id": video_id
+                    "snippet": content[:300] + "..." if len(content) > 300 else content,
+                    "is_video": False,
+                    "video_id": None,
                 })
 
-            # Build response message
             if results:
                 message = f"Found **{len(results)} results** for \"{query}\":"
-
                 for i, r in enumerate(results, 1):
-                    if r["is_video"] and r["video_id"]:
-                        # Use video-embed tag for YouTube videos
-                        message += f"\n\n<video-embed videoid=\"{r['video_id']}\" title=\"{r['title']}\" />"
-                    else:
-                        # Regular link for articles
-                        message += f"\n\n**{i}. [{r['title']}]({r['url']})**\n{r['snippet']}"
-
-                # Include Tavily's AI answer if available
+                    message += f"\n\n**{i}. [{r['title']}]({r['url']})**\n{r['snippet']}"
                 ai_answer = response.get("answer")
                 if ai_answer:
                     message = f"**Quick Answer:** {ai_answer}\n\n---\n\n{message}"
             else:
                 message = f"No results found for \"{query}\". Try a different search term."
 
-            return {
-                "success": True,
-                "message": message,
-                "results": results,
-                "answer": response.get("answer")
-            }
+            return {"success": True, "message": message, "results": results, "answer": response.get("answer")}
 
         except Exception as e:
             logger.error(f"Error in web search: {e}")
@@ -347,7 +513,7 @@ class SearchService:
                 research_content += "### Related Videos\n"
                 for video in video_results[:2]:  # Max 2 videos
                     if video["video_id"]:
-                        research_content += f"<video-embed videoid=\"{video['video_id']}\" title=\"{video['title']}\" />\n\n"
+                        research_content += _embed(video["video_id"], video["title"]) + "\n\n"
 
             return {
                 "success": True,

--- a/ai-coach-service/app/core/agents/services/workout_service.py
+++ b/ai-coach-service/app/core/agents/services/workout_service.py
@@ -116,7 +116,12 @@ class WorkoutService:
             else:
                 query = ownership_filter
 
-            limit = args.get("limit", 10)
+            limit = args.get("limit", 50)
+
+            # Count before limiting so the model can tell a filtered/truncated
+            # view from the full library (prevents contradictory answers across
+            # calls with different filters).
+            total_matching = await self.db.predefinedworkouts.count_documents(query)
 
             workouts = await self.db.predefinedworkouts.find(
                 query,
@@ -155,11 +160,84 @@ class WorkoutService:
             return {
                 "success": True,
                 "count": len(results),
+                "total_matching": total_matching,
+                "truncated": total_matching > len(results),
+                "filter_used": {
+                    "include_common": include_common,
+                    "name": args.get("name"),
+                    "discipline": args.get("discipline"),
+                    "difficulty_level": args.get("difficulty_level"),
+                    "limit": limit,
+                },
                 "workouts": results
             }
 
         except Exception as e:
             logger.error(f"Error listing workout templates: {e}")
+            return {"success": False, "message": str(e)}
+
+    async def delete_workout_template(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Delete the user's own workout templates (never common/public ones).
+
+        Two-step: without confirm=true this only previews what would be deleted
+        (and which keep_only names matched nothing). Matching is case-insensitive.
+        """
+        try:
+            user_oid = ObjectId(user_id)
+            # Only the user's own templates are ever eligible.
+            own_filter: Dict[str, Any] = {"createdBy": user_oid, "isCommon": {"$ne": True}}
+
+            keep_only = [str(n).strip() for n in (args.get("keep_only") or []) if str(n).strip()]
+            template_id = args.get("template_id")
+            name = (args.get("name") or "").strip()
+
+            if not (keep_only or template_id or name):
+                return {"success": False,
+                        "message": "Tell me which template(s) to delete: a template_id, a name, or keep_only=[names to keep]."}
+
+            own = await self.db.predefinedworkouts.find(
+                own_filter, {"name": 1, "createdAt": 1}
+            ).to_list(None)
+
+            unmatched_keeps: List[str] = []
+            if keep_only:
+                keep_lower = {k.lower() for k in keep_only}
+                matched_keeps = {t["name"].lower() for t in own if t.get("name", "").lower() in keep_lower}
+                unmatched_keeps = [k for k in keep_only if k.lower() not in matched_keeps]
+                targets = [t for t in own if t.get("name", "").lower() not in keep_lower]
+            elif template_id:
+                try:
+                    tid = ObjectId(template_id)
+                except Exception:
+                    return {"success": False, "message": "Invalid template_id."}
+                targets = [t for t in own if t["_id"] == tid]
+            else:
+                targets = [t for t in own if t.get("name", "").lower() == name.lower()]
+
+            if not targets:
+                return {"success": True, "deleted": 0,
+                        "message": "No matching templates of yours found (common/public templates can't be deleted)."}
+
+            preview = [{"id": str(t["_id"]), "name": t.get("name", "")} for t in targets]
+
+            if not args.get("confirm", False):
+                msg = f"This would delete {len(targets)} template(s): " + ", ".join(t["name"] for t in preview) + "."
+                if unmatched_keeps:
+                    msg += (f" ⚠️ Note: keep name(s) {unmatched_keeps} matched nothing in your library — "
+                            "double-check them before confirming.")
+                msg += " Confirm to delete."
+                return {"success": True, "needs_confirmation": True, "would_delete": preview,
+                        "unmatched_keep_names": unmatched_keeps, "message": msg}
+
+            result = await self.db.predefinedworkouts.delete_many(
+                {**own_filter, "_id": {"$in": [t["_id"] for t in targets]}}
+            )
+            logger.info(f"Deleted {result.deleted_count} workout template(s) for user {user_id}")
+            return {"success": True, "deleted": result.deleted_count,
+                    "message": f"Deleted {result.deleted_count} template(s): " + ", ".join(t["name"] for t in preview) + "."}
+
+        except Exception as e:
+            logger.error(f"Error deleting workout template: {e}")
             return {"success": False, "message": str(e)}
 
     async def log_workout(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/ai-coach-service/app/core/agents/services/youtube_search.py
+++ b/ai-coach-service/app/core/agents/services/youtube_search.py
@@ -1,0 +1,243 @@
+"""
+YouTube Data API v3 helper — find and QUALITY-RANK exercise demonstration videos.
+
+Why this exists: the coach used to run a plain Tavily web search for "video", which
+had no quality signals and stapled preferred-creator names into the query string
+(over-constraining it → zero results → junk fallback). This module instead:
+  1. search.list  → candidate videos for a query (100 quota units)
+  2. videos.list  → statistics + duration for those ids (1 unit)
+  3. score_video() → rank by trusted channel, engagement, popularity, and duration fit
+
+`score_video` is a pure function so it can be unit-tested without hitting the API.
+"""
+
+import html
+import re
+from math import log10
+from typing import Any, Dict, List, Optional
+
+import httpx
+import structlog
+
+logger = structlog.get_logger()
+
+YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
+
+# Single source of truth for trusted fitness channels (was duplicated in the
+# prompt + search_service). Used ONLY for ranking now, never in the query string.
+# Include brand aliases (e.g. Chris Heria's channel is titled "THENX").
+PREFERRED_CREATORS: Dict[str, List[str]] = {
+    "calisthenics": ["Saturno Movement", "Calisthenicmovement", "FitnessFAQs", "Chris Heria", "THENX", "Hybrid Calisthenics", "Minus The Gym", "The Calisthenics Project"],
+    "strength": ["Athlean-X", "Jeff Nippard", "Jeremy Ethier", "Renaissance Periodization", "Squat University"],
+    "mobility": ["Tom Merrick", "Squat University", "GMB Fitness"],
+    "yoga": ["Yoga With Adriene", "Breathe and Flow"],
+    "powerlifting": ["Juggernaut Training Systems", "Calgary Barbell", "Zack Telander", "Squat University"],
+}
+
+
+def _norm_channel(s: str) -> str:
+    """Normalize a channel name for matching: lowercase, strip all non-alphanumerics.
+    So 'Saturno Movement', 'SaturnoMovement', and 'saturno-movement' all match."""
+    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
+
+
+# Normalized set of all trusted channel names for robust membership scoring.
+TRUSTED_CHANNELS = {_norm_channel(name) for names in PREFERRED_CREATORS.values() for name in names}
+
+
+def _parse_iso8601_duration(duration: str) -> int:
+    """Convert an ISO-8601 duration (e.g. 'PT8M32S') to total seconds. 0 on miss."""
+    if not duration:
+        return 0
+    m = re.match(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?", duration)
+    if not m:
+        return 0
+    hours, minutes, seconds = (int(g) if g else 0 for g in m.groups())
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def _duration_fit(seconds: int) -> float:
+    """A tutorial reads best at roughly 2–15 min. Score 0..1 by how well it fits."""
+    if seconds <= 0:
+        return 0.3  # unknown — don't reward or heavily punish
+    minutes = seconds / 60
+    if 2 <= minutes <= 15:
+        return 1.0
+    if minutes < 2:
+        return 0.5 + 0.25 * minutes  # very short shorts get partial credit
+    if minutes <= 30:
+        return 0.6  # long-but-usable
+    return 0.3  # 30min+ lecture — usually not what "show me how" wants
+
+
+def score_video(video: Dict[str, Any], trusted_channels: Optional[set] = None) -> float:
+    """Pure ranking score for one video enriched with statistics.
+
+    Expects a dict shaped like the merged search.list + videos.list item:
+      { channelTitle, title, viewCount, likeCount, durationSeconds }
+
+    Weighting (higher = better):
+      - trusted channel:      +5.0  (dominant signal — the whole point of curation)
+      - engagement (likes/views, log-ish): up to +2.0
+      - popularity (log10 views):           up to +2.0
+      - duration fit:                        up to +1.0
+    """
+    trusted = trusted_channels if trusted_channels is not None else TRUSTED_CHANNELS
+    channel = _norm_channel(video.get("channelTitle") or "")
+    views = max(int(video.get("viewCount") or 0), 0)
+    likes = max(int(video.get("likeCount") or 0), 0)
+    duration = int(video.get("durationSeconds") or 0)
+
+    score = 0.0
+
+    # 1. Trusted channel — normalized exact or substring match (handles spacing,
+    #    punctuation and casing: "SaturnoMovement" == "Saturno Movement", etc.)
+    if channel and (channel in trusted or any(t in channel for t in trusted)):
+        score += 5.0
+
+    # 2. Engagement: like/view ratio, scaled. Good fitness tutorials sit ~2-5%.
+    if views > 0 and likes > 0:
+        ratio = likes / views
+        score += min(ratio / 0.03, 1.0) * 2.0
+
+    # 3. Popularity: log10(views), capped. 1M views ~= full credit.
+    if views > 0:
+        score += min(log10(views) / 6.0, 1.0) * 2.0
+
+    # 4. Duration fit
+    score += _duration_fit(duration) * 1.0
+
+    return round(score, 4)
+
+
+async def enrich_youtube_ids(
+    api_key: str,
+    video_ids: List[str],
+    timeout: float = 8.0,
+) -> List[Dict[str, Any]]:
+    """Given raw YouTube video ids (e.g. ones Tavily surfaced), fetch their
+    snippet + statistics + duration and return them scored/sorted best-first.
+    Returns [] on failure. One videos.list call (1 quota unit)."""
+    ids = [v for v in dict.fromkeys(video_ids) if v]  # dedupe, keep order
+    if not ids:
+        return []
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(
+                f"{YOUTUBE_API_BASE}/videos",
+                params={
+                    "key": api_key,
+                    "id": ",".join(ids),
+                    "part": "snippet,statistics,contentDetails",
+                },
+            )
+            if resp.status_code != 200:
+                logger.warning("YouTube videos.list (enrich) failed", status=resp.status_code)
+                return []
+            items = resp.json().get("items", [])
+    except Exception as e:
+        logger.warning(f"YouTube enrich error: {e}")
+        return []
+
+    videos: List[Dict[str, Any]] = []
+    for it in items:
+        snippet = it.get("snippet", {})
+        statistics = it.get("statistics", {})
+        content = it.get("contentDetails", {})
+        vid = it.get("id")
+        video = {
+            "video_id": vid,
+            "title": html.unescape(snippet.get("title", "")),
+            "channelTitle": snippet.get("channelTitle", ""),
+            "publishedAt": snippet.get("publishedAt", ""),
+            "url": f"https://www.youtube.com/watch?v={vid}",
+            "viewCount": int(statistics.get("viewCount", 0) or 0),
+            "likeCount": int(statistics.get("likeCount", 0) or 0),
+            "durationSeconds": _parse_iso8601_duration(content.get("duration", "")),
+        }
+        video["score"] = score_video(video)
+        videos.append(video)
+
+    videos.sort(key=lambda v: v["score"], reverse=True)
+    return videos
+
+
+async def youtube_search_videos(
+    api_key: str,
+    query: str,
+    max_candidates: int = 10,
+    exclude_ids: Optional[List[str]] = None,
+    timeout: float = 8.0,
+) -> List[Dict[str, Any]]:
+    """Search YouTube and return candidate videos enriched with statistics,
+    sorted best-first by score_video(). Returns [] on any API failure.
+
+    Two API calls: search.list (100 units) then videos.list (1 unit).
+    """
+    exclude = set(exclude_ids or [])
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            search_resp = await client.get(
+                f"{YOUTUBE_API_BASE}/search",
+                params={
+                    "key": api_key,
+                    "q": query,
+                    "part": "snippet",
+                    "type": "video",
+                    "videoEmbeddable": "true",
+                    "maxResults": max_candidates,
+                    "relevanceLanguage": "en",
+                    "safeSearch": "strict",
+                },
+            )
+            if search_resp.status_code != 200:
+                logger.warning("YouTube search.list failed", status=search_resp.status_code, body=search_resp.text[:200])
+                return []
+
+            items = search_resp.json().get("items", [])
+            id_to_snippet: Dict[str, Dict[str, Any]] = {}
+            for it in items:
+                vid = (it.get("id") or {}).get("videoId")
+                if vid and vid not in exclude:
+                    id_to_snippet[vid] = it.get("snippet", {})
+            if not id_to_snippet:
+                return []
+
+            stats_resp = await client.get(
+                f"{YOUTUBE_API_BASE}/videos",
+                params={
+                    "key": api_key,
+                    "id": ",".join(id_to_snippet.keys()),
+                    "part": "statistics,contentDetails",
+                },
+            )
+            if stats_resp.status_code != 200:
+                logger.warning("YouTube videos.list failed", status=stats_resp.status_code)
+                # Fall back to snippet-only (no engagement signal) rather than nothing
+                stats_by_id = {}
+            else:
+                stats_by_id = {v["id"]: v for v in stats_resp.json().get("items", [])}
+    except Exception as e:  # network, timeout, JSON — degrade gracefully
+        logger.warning(f"YouTube API error: {e}")
+        return []
+
+    videos: List[Dict[str, Any]] = []
+    for vid, snippet in id_to_snippet.items():
+        stats = stats_by_id.get(vid, {})
+        statistics = stats.get("statistics", {})
+        content = stats.get("contentDetails", {})
+        video = {
+            "video_id": vid,
+            "title": html.unescape(snippet.get("title", "")),
+            "channelTitle": snippet.get("channelTitle", ""),
+            "publishedAt": snippet.get("publishedAt", ""),
+            "url": f"https://www.youtube.com/watch?v={vid}",
+            "viewCount": int(statistics.get("viewCount", 0) or 0),
+            "likeCount": int(statistics.get("likeCount", 0) or 0),
+            "durationSeconds": _parse_iso8601_duration(content.get("duration", "")),
+        }
+        video["score"] = score_video(video)
+        videos.append(video)
+
+    videos.sort(key=lambda v: v["score"], reverse=True)
+    return videos

--- a/ai-coach-service/app/core/agents/skills/validate_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/validate_plan_skill.py
@@ -128,6 +128,64 @@ def validate_plan_doc(plan: Dict[str, Any], goal_category: str) -> Dict[str, Any
     }
 
 
+def validate_skeleton(skeleton: Dict[str, Any], goal_category: str, weeks_total: int) -> Dict[str, Any]:
+    """Pure structural/quality checks over a plan skeleton (macro layer).
+    Complements validate_plan_doc, which only sees materialized weeks."""
+    violations: List[str] = []
+    suggestions: List[str] = []
+    phases = skeleton.get("phases") or []
+
+    if not phases:
+        return {"valid": False, "violations": ["The skeleton has no phases."], "suggestions": []}
+
+    # Coverage: contiguous phases over 1..weeks_total (normalize_skeleton should
+    # guarantee this; validating catches regressions).
+    covered = set()
+    for p in phases:
+        covered.update(range(int(p.get("startWeek", 0)), int(p.get("endWeek", -1)) + 1))
+    missing = [w for w in range(1, weeks_total + 1) if w not in covered]
+    if missing:
+        violations.append(f"Weeks not covered by any phase: {missing}.")
+
+    # Frequency: per-phase discipline sessions vs the goal minimum.
+    min_sessions = tk.min_sessions_for_goal(goal_category)
+    for p in phases:
+        total = sum(int(d.get("sessionsPerWeek", 0) or 0) for d in (p.get("disciplines") or []))
+        if total and total < min_sessions:
+            violations.append(
+                f"Phase '{p.get('name')}' plans {total} sessions/week; a {goal_category} goal needs at least {min_sessions}."
+            )
+
+    # Deload cadence for long plans.
+    if tk.expects_deload(weeks_total) and not skeleton.get("deloadWeeks"):
+        suggestions.append(
+            f"Plans of {weeks_total} weeks benefit from a deload every "
+            f"{tk.DELOAD_EVERY_WEEKS_MIN}–{tk.DELOAD_EVERY_WEEKS_MAX} weeks; none is marked."
+        )
+
+    # Ramp: week-intent multiplier jumps beyond the hard flag.
+    intents = sorted(skeleton.get("weekIntents") or [], key=lambda i: i.get("weekNumber", 0))
+    for i in range(1, len(intents)):
+        prev = float(intents[i - 1].get("volumeMultiplier", 1.0) or 1.0)
+        cur = float(intents[i].get("volumeMultiplier", 1.0) or 1.0)
+        if prev > 0 and not intents[i - 1].get("deload") and cur > prev * tk.WEEKLY_RAMP_HARD_FLAG:
+            violations.append(
+                f"Week {intents[i].get('weekNumber')} volume intent jumps "
+                f"{((cur / prev) - 1) * 100:.0f}% over the prior week (aggressive)."
+            )
+
+    # Goal specificity: aerobic-oriented goals need aerobic blueprints somewhere.
+    if goal_category.lower() in {"endurance", "health", "weight"}:
+        has_aerobic = any(
+            ((bp.get("type") or "").lower() in tk.AEROBIC_WORKOUT_TYPES)
+            for p in phases for bp in (p.get("sessionBlueprints") or [])
+        )
+        if not has_aerobic:
+            suggestions.append(f"A {goal_category} goal should include aerobic/cardio sessions.")
+
+    return {"valid": len(violations) == 0, "violations": violations, "suggestions": suggestions}
+
+
 async def _resolve_goal_category(ctx: SkillContext, plan: Dict[str, Any], user_oid: Any) -> str:
     """Best-effort goal category from the plan's linked goal; default 'general'."""
     goal_id = plan.get("goalId")
@@ -170,7 +228,25 @@ async def validate_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -
         return {"success": False, "message": "Plan not found."}
 
     goal_category = await _resolve_goal_category(ctx, plan, user_oid)
-    report = validate_plan_doc(plan, goal_category)
+
+    # Skeleton-based plans: check materialized weeks only (stubs are intent-only
+    # by design) and add the macro-layer checks.
+    skeleton = plan.get("skeleton")
+    if skeleton:
+        resolved = [w for w in (plan.get("weeks") or []) if w.get("resolved") is not False]
+        report = validate_plan_doc(
+            {"schedule": {**(plan.get("schedule") or {}), "weeksTotal": len(resolved)}, "weeks": resolved},
+            goal_category,
+        )
+        skel_report = validate_skeleton(
+            skeleton, goal_category,
+            (plan.get("schedule") or {}).get("weeksTotal") or len(plan.get("weeks") or []),
+        )
+        report["violations"] += skel_report["violations"]
+        report["suggestions"] += skel_report["suggestions"]
+        report["valid"] = report["valid"] and skel_report["valid"]
+    else:
+        report = validate_plan_doc(plan, goal_category)
 
     if report["valid"]:
         msg = f"✅ Plan looks solid ({report['metrics']['avg_sessions_per_week']} sessions/wk, ~{report['metrics']['avg_weekly_sets']} sets/wk)."

--- a/ai-coach-service/app/core/agents/tool_definitions/exercise_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/exercise_tools.py
@@ -179,4 +179,27 @@ def get_exercise_tools() -> List[Dict[str, Any]]:
                 }
             }
         },
+        # ==================== SAVE EXERCISE VIDEO (curation) ====================
+        {
+            "type": "function",
+            "function": {
+                "name": "save_exercise_video",
+                "description": "Save the demo video you JUST SHOWED as the curated demo for an exercise, so it's the instant answer next time. Call ONLY when the user approves a video ('this one is great', 'save this', 'perfect'). You do NOT pass a video id or URL — the system uses the video it showed. Just name the exercise and, if the user picked the alternative, say which.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "exercise_name": {
+                            "type": "string",
+                            "description": "Name of the exercise the video is for (e.g. 'Toes To Bar')."
+                        },
+                        "which": {
+                            "type": "string",
+                            "enum": ["best", "alternative"],
+                            "description": "Which of the shown videos the user approved: 'best' (the main one) or 'alternative' (the second option). Default: best."
+                        }
+                    },
+                    "required": ["exercise_name"]
+                }
+            }
+        },
     ]

--- a/ai-coach-service/app/core/agents/tool_definitions/search_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/search_tools.py
@@ -13,22 +13,26 @@ def get_search_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "web_search",
-                "description": "Search the web for fitness-related information, exercise tutorials, form guides, and educational content. Use this when users ask 'how to do' an exercise, want video tutorials, need form tips, or want external resources about fitness topics. Returns snippets and links - use read_url for full content.",
+                "description": "Search for fitness content. search_type='video' finds an exercise DEMO from YouTube, quality-ranked from trusted fitness channels (pass a CLEAN exercise name, e.g. 'toes to bar' — do NOT add creator names, 'youtube', or 'tutorial'). search_type='article'/'general' searches the web for written guides. Use for 'how to do X', form tips, or external resources.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "query": {
                             "type": "string",
-                            "description": "The search query. Be specific and include 'tutorial', 'how to', 'form guide', etc. for better results. Example: 'how to do muscle ups tutorial' or 'proper deadlift form guide'"
+                            "description": "The search query. For video demos, use just the exercise name (e.g. 'muscle up', 'toes to bar'). For articles, be specific (e.g. 'proper deadlift form guide')."
                         },
                         "search_type": {
                             "type": "string",
                             "enum": ["general", "video", "article"],
-                            "description": "Type of content to search for. 'video' prioritizes YouTube/video results, 'article' prioritizes written guides, 'general' returns mixed results. Default: general"
+                            "description": "'video' = quality-ranked YouTube exercise demo, 'article' = written guides, 'general' = mixed web results. Default: general"
                         },
                         "max_results": {
                             "type": "integer",
                             "description": "Maximum number of results to return (1-5). Default: 3"
+                        },
+                        "exclude_previous": {
+                            "type": "boolean",
+                            "description": "For search_type='video' only: set true when the user disliked the video you just showed and wants a DIFFERENT one. The system remembers what it showed and returns a fresh alternative — you do NOT pass video ids."
                         }
                     },
                     "required": ["query"]

--- a/ai-coach-service/app/core/agents/tool_definitions/workout_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/workout_tools.py
@@ -116,6 +116,40 @@ def get_workout_tools() -> List[Dict[str, Any]]:
                 }
             }
         },
+        {
+            "type": "function",
+            "function": {
+                "name": "delete_workout_template",
+                "description": (
+                    "Delete the user's OWN workout templates (never common/public ones). "
+                    "Use when the user asks to remove/clean up templates. Previews first; "
+                    "deletes only when called again with confirm=true. keep_only handles "
+                    "'delete everything except X, Y' in one call."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "template_id": {
+                            "type": "string",
+                            "description": "Delete one template by id."
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Delete one template by exact name (case-insensitive)."
+                        },
+                        "keep_only": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Delete ALL of the user's templates EXCEPT these names (case-insensitive)."
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": "Actually delete. Default false = preview only. Set true ONLY after the user confirms the preview."
+                        }
+                    }
+                }
+            }
+        },
         # ==================== WORKOUT LOG TOOLS ====================
         {
             "type": "function",

--- a/ai-coach-service/tests/test_reflection.py
+++ b/ai-coach-service/tests/test_reflection.py
@@ -193,6 +193,9 @@ class TestReflectionExecution:
             orch = AgentOrchestrator.__new__(AgentOrchestrator)
             orch.db = mock_db
             orch.client = AsyncMock()
+            # Reflection resolves its model from settings (REFLECTION_CONFIG["model"]
+            # falls back to settings.openai_model_fast).
+            orch.settings = MagicMock(openai_model_fast="gpt-5.4-mini")
             return orch
 
     @pytest.mark.asyncio
@@ -344,7 +347,8 @@ class TestReflectionExecution:
         # GPT-5 models require max_completion_tokens (see commit #69); the value
         # still comes from the config's max_tokens entry.
         assert call_kwargs["max_completion_tokens"] == REFLECTION_CONFIG["max_tokens"]
-        assert call_kwargs["model"] == REFLECTION_CONFIG["model"]
+        # Model comes from config if pinned, else falls back to settings.openai_model_fast.
+        assert call_kwargs["model"] == (REFLECTION_CONFIG["model"] or orchestrator.settings.openai_model_fast)
 
     @pytest.mark.asyncio
     async def test_handles_unknown_fitness_level(self, orchestrator):

--- a/ai-coach-service/tests/test_youtube_search.py
+++ b/ai-coach-service/tests/test_youtube_search.py
@@ -1,0 +1,57 @@
+"""Unit tests for the YouTube video ranker (pure functions — no network)."""
+
+from app.core.agents.services.youtube_search import (
+    _duration_fit,
+    _norm_channel,
+    _parse_iso8601_duration,
+    score_video,
+)
+
+
+def test_parse_iso8601_duration():
+    assert _parse_iso8601_duration("PT8M32S") == 512
+    assert _parse_iso8601_duration("PT1H2M3S") == 3723
+    assert _parse_iso8601_duration("PT45S") == 45
+    assert _parse_iso8601_duration("") == 0
+    assert _parse_iso8601_duration("garbage") == 0
+
+
+def test_duration_fit_prefers_tutorial_length():
+    assert _duration_fit(8 * 60) == 1.0          # 8 min — ideal
+    assert _duration_fit(3 * 60) == 1.0          # 3 min — ideal
+    assert _duration_fit(45 * 60) < 0.5          # 45 min lecture — poor
+    assert _duration_fit(20) < _duration_fit(300)  # 20s short < 5 min
+
+
+def test_norm_channel_handles_spacing_and_punct():
+    assert _norm_channel("Saturno Movement") == "saturnomovement"
+    assert _norm_channel("SaturnoMovement") == "saturnomovement"
+    assert _norm_channel("ATHLEAN-X") == "athleanx"
+    assert _norm_channel("Athlean-X") == _norm_channel("athleanx")
+
+
+def test_trusted_channel_dominates():
+    trusted = {"name": "FitnessFAQs", "channelTitle": "FitnessFAQs",
+               "viewCount": 100_000, "likeCount": 3000, "durationSeconds": 400}
+    random_viral = {"channelTitle": "RandomBro", "viewCount": 5_000_000,
+                    "likeCount": 200_000, "durationSeconds": 400}
+    assert score_video(trusted) > score_video(random_viral)
+
+
+def test_spacing_variant_still_credited():
+    spaced = {"channelTitle": "Saturno Movement", "viewCount": 100_000, "likeCount": 3000, "durationSeconds": 300}
+    joined = {"channelTitle": "SaturnoMovement", "viewCount": 100_000, "likeCount": 3000, "durationSeconds": 300}
+    # Both should get the trusted boost -> identical, high score.
+    assert score_video(spaced) == score_video(joined)
+    assert score_video(joined) >= 8.0
+
+
+def test_low_quality_scores_low():
+    bad = {"channelTitle": "SomeGuy", "viewCount": 500, "likeCount": 3, "durationSeconds": 3000}
+    assert score_video(bad) < 3.0
+
+
+def test_engagement_and_popularity_break_ties_among_untrusted():
+    strong = {"channelTitle": "NobodyA", "viewCount": 1_000_000, "likeCount": 40_000, "durationSeconds": 400}
+    weak = {"channelTitle": "NobodyB", "viewCount": 2_000, "likeCount": 20, "durationSeconds": 400}
+    assert score_video(strong) > score_video(weak)

--- a/ai-coach-service/video_coach_test.py
+++ b/ai-coach-service/video_coach_test.py
@@ -1,0 +1,125 @@
+"""
+Coach-level video behavior test (real orchestrator, real YouTube/Tavily, prod data).
+Evaluates the DECISIONS: does the coach pick video vs text by context, run both in
+parallel when useful, exclude rejected videos, and save approved ones?
+
+Write-safe: save_exercise_video's DB write is intercepted (args recorded, no write);
+web_search hits real external APIs (no DB writes). Multi-turn convos are threaded via
+conversation_history.
+
+Run: .venv/bin/python video_coach_test.py
+"""
+
+import asyncio
+import json
+import re
+
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from app.config import get_settings
+from app.core.agents.orchestrator import AgentOrchestrator
+
+USER_ID = "6a50b08cfc7515275d6e0e68"
+EMBED_RE = re.compile(r'<video-embed videoid="([^"]+)"')
+
+# Each scenario is a list of user turns; we assert on the LAST turn's behavior.
+SCENARIOS = [
+    {
+        "name": "show-me -> video",
+        "turns": ["can you show me how to do toes to bar?"],
+        "expect": "a video embed from a trusted channel",
+    },
+    {
+        "name": "what-muscles -> text (no video)",
+        "turns": ["what muscles does a romanian deadlift work?"],
+        "expect": "a short text answer, NO video embed",
+    },
+    {
+        "name": "show + explain -> may do both",
+        "turns": ["how do I do a muscle up? show me a demo and explain the key steps"],
+        "expect": "a video embed AND some text explanation",
+    },
+    {
+        "name": "reject -> exclude & re-search",
+        "turns": [
+            "show me how to do a dragon flag",
+            "that video isn't good, show me a different one",
+        ],
+        "expect": "second search excludes the first id, returns a different video",
+    },
+    {
+        "name": "approve -> save_exercise_video",
+        "turns": [
+            "show me how to do a pistol squat",
+            "that one's perfect, save it for me",
+        ],
+        "expect": "save_exercise_video called with the shown video id",
+    },
+]
+
+
+async def run_scenario(orch, scenario, recorder_holder):
+    history = []
+    last = {}
+    for turn in scenario["turns"]:
+        recorder_holder[0] = []  # fresh tool recorder per turn
+        answer_parts, embeds = [], []
+        async for ev in orch.process_request_streaming(turn, {"user_id": USER_ID}, conversation_history=history):
+            if ev["type"] == "token":
+                answer_parts.append(ev["content"])
+            elif ev["type"] == "complete":
+                answer_parts = [ev["full_response"]]
+        answer = "".join(answer_parts).strip()
+        embeds = EMBED_RE.findall(answer)
+        last = {"turn": turn, "answer": answer, "embeds": embeds, "tools": list(recorder_holder[0])}
+        history.append({"role": "human", "content": turn})
+        history.append({"role": "ai", "content": answer})
+    return last
+
+
+def install_guard(orch, recorder_holder, saved_calls):
+    orig = orch._execute_tool
+
+    async def guarded(uid, fn, args):
+        recorder_holder[0].append((fn, args))
+        if fn == "save_exercise_video":
+            saved_calls.append(args)  # record, do NOT write
+            return {"success": True, "message": f"[test] would save video for {args.get('exercise_name')}"}
+        if fn in ("web_search", "read_url", "research") or fn.startswith(("get_", "list_", "grep_")):
+            return await orig(uid, fn, args)
+        # block other writes
+        return {"success": False, "blocked": True, "message": "[test] write blocked"}
+
+    orch._execute_tool = guarded
+
+
+async def main():
+    s = get_settings()
+    client = AsyncIOMotorClient(s.mongodb_url)
+    db = client[s.mongodb_database]
+    orch = AgentOrchestrator(db)
+
+    recorder_holder = [[]]
+    saved_calls = []
+    install_guard(orch, recorder_holder, saved_calls)
+
+    for sc in SCENARIOS:
+        last = await run_scenario(orch, sc, recorder_holder)
+        tool_names = [t[0] for t in last["tools"]]
+        video_args = [t[1] for t in last["tools"] if t[0] == "web_search" and t[1].get("search_type") == "video"]
+        print(f"\n{'='*70}\nSCENARIO: {sc['name']}")
+        print(f"  expect: {sc['expect']}")
+        print(f"  final turn: {last['turn']!r}")
+        print(f"  tools: {tool_names}")
+        if video_args:
+            print(f"  video query/exclude_previous: {[(a.get('query'), a.get('exclude_previous')) for a in video_args]}")
+        print(f"  embeds returned: {last['embeds']}")
+        if saved_calls:
+            print(f"  save_exercise_video calls so far: {saved_calls}")
+        print(f"  answer: {last['answer'][:400]}")
+
+    client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ai-coach-service/video_fix_verify.py
+++ b/ai-coach-service/video_fix_verify.py
@@ -1,0 +1,73 @@
+"""
+Deterministic verification of the two id-resolution fixes, on a SCRATCH database
+(dropped at the end) — no production writes.
+
+1. save_exercise_video ignores a hallucinated model id and saves the REAL shown top.
+2. _prior_shown_ids returns what was recorded, so ret/exclude can use it.
+"""
+
+import asyncio
+
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from app.config import get_settings
+from app.core.agents.services.exercise_service import ExerciseService
+from app.core.agents.services.search_service import SearchService
+
+SCRATCH_DB = "aicoach_videotest_scratch"
+USER = "6a50b08cfc7515275d6e0e68"
+
+
+async def main():
+    s = get_settings()
+    client = AsyncIOMotorClient(s.mongodb_url)
+    db = client[SCRATCH_DB]
+    try:
+        # Seed: an exercise + the context the video search would have written.
+        await db.exercises.insert_one({"name": "Pistol Squat", "isCommon": True})
+        search = SearchService(db=db)
+        await search._record_shown(
+            USER, "pistol squat",
+            ["ZI3gB5irv5g", "vq5-vdgJc0I"],
+            {"video_id": "ZI3gB5irv5g", "title": "ANYONE Can Pistol Squat..."},
+        )
+
+        ex = ExerciseService(db)
+
+        # 1. "save it" (best) — no id from the model — resolves to the shown top.
+        await ex.save_exercise_video(USER, {"exercise_name": "Pistol Squat"})
+        saved = await db.exercises.find_one({"name": "Pistol Squat"})
+        got = (saved.get("mediaUrls") or {}).get("video", "")
+        ok1 = "ZI3gB5irv5g" in got
+        print(f"[1] save 'best' (no id from model) -> saved {got}")
+        print(f"    PASS={ok1} (deterministically used the shown top)")
+
+        # 2. "save the alternative" — resolves to the 2nd shown video, still no id.
+        await ex.save_exercise_video(USER, {"exercise_name": "Pistol Squat", "which": "alternative"})
+        saved2 = await db.exercises.find_one({"name": "Pistol Squat"})
+        got2 = (saved2.get("mediaUrls") or {}).get("video", "")
+        ok2 = "vq5-vdgJc0I" in got2
+        print(f"[2] save 'alternative' -> saved {got2}")
+        print(f"    PASS={ok2} (used the 2nd shown video)")
+
+        # 3. prior-shown ids available for exclude
+        prior = await search._prior_shown_ids(USER, "pistol squat")
+        ok3 = "ZI3gB5irv5g" in prior and "vq5-vdgJc0I" in prior
+        print(f"[3] prior_shown_ids -> {prior}")
+        print(f"    PASS={ok3} (retry/exclude can use these)")
+
+        # 4. curated tier now serves the saved (alternative) video with no search
+        curated = await search._get_curated_video("show me a pistol squat")
+        ok4 = curated is not None and curated["video_id"] == "vq5-vdgJc0I"
+        print(f"[4] curated lookup -> {curated}")
+        print(f"    PASS={ok4} (Tier 0 serves the saved demo, zero cost)")
+
+        print(f"\nALL PASS: {all([ok1, ok2, ok3, ok4])}")
+    finally:
+        await client.drop_database(SCRATCH_DB)
+        client.close()
+        print(f"(dropped scratch db {SCRATCH_DB})")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ai-coach-service/video_probe.py
+++ b/ai-coach-service/video_probe.py
@@ -1,0 +1,51 @@
+"""
+Direct YouTube-ranking probe (NO coach). Calls youtube_search_videos for a set of
+exercises and prints the ranked top results so we can eyeball whether the ranker
+surfaces genuinely good demos from trusted channels.
+
+Run: .venv/bin/python video_probe.py
+Cost: ~100 quota units per exercise (search.list) + 1 (videos.list).
+"""
+
+import asyncio
+
+from app.config import get_settings
+from app.core.agents.services.youtube_search import youtube_search_videos, TRUSTED_CHANNELS, _norm_channel
+
+EXERCISES = [
+    "toes to bar",
+    "muscle up",
+    "dragon flag",
+    "pistol squat",
+    "handstand push up",
+    "romanian deadlift",
+    "hollow body hold",
+    "front lever",
+]
+
+
+def fmt_dur(s):
+    return f"{s // 60}:{s % 60:02d}"
+
+
+async def main():
+    key = get_settings().youtube_api_key
+    if not key:
+        print("No YOUTUBE_API_KEY configured.")
+        return
+
+    for ex in EXERCISES:
+        vids = await youtube_search_videos(key, f"{ex} tutorial how to", max_candidates=10)
+        print(f"\n=== {ex!r} — {len(vids)} candidates, top 3 ===")
+        if not vids:
+            print("   (no results)")
+            continue
+        for v in vids[:3]:
+            cn = _norm_channel(v["channelTitle"])
+            trusted = "★" if (cn in TRUSTED_CHANNELS or any(t in cn for t in TRUSTED_CHANNELS)) else " "
+            print(f"  {trusted} score={v['score']:>5}  {v['channelTitle'][:24]:24}  "
+                  f"views={v['viewCount']:>10,}  {fmt_dur(v['durationSeconds'])}  {v['title'][:52]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Problem
The coach's "video" search was a plain Tavily web search with **no quality signal**, and it stapled preferred-creator names into the query (over-constraining → zero results → generic retry → junk video, e.g. a bad toes-to-bar tutorial the user rejected).

## What changed
Video demos now come from a dedicated, quality-ranked path. **Tavily stays for text** (guides/articles/research). Roles: the **coach decides *when*** (video vs text, contextually, may do both in one turn), **YouTube decides *which*** (ranking), and a **curated library is memory**.

- **Tiered video path:** curated (`exercises.mediaUrls.video`) → YouTube Data API (`search.list` + `videos.list`, ranked by trusted channel + engagement + popularity + duration fit) → Tavily fallback (which now also enriches any YouTube URL through the Data API and ranks it).
- **Cache** (`videocache`, 30-day TTL) to conserve the 100-search/day quota.
- **Coach passes only semantics; we fill technical details deterministically** (the LLM can't reliably recall 11-char ids):
  - reject → `web_search(search_type=video, exclude_previous=true)` (we exclude what we already showed, tracked in `uservideocontext`)
  - approve → `save_exercise_video(exercise_name, which=best|alternative)` (we resolve the real id from what we showed and store it as the curated demo)
  - orchestrator **guarantees the `<video-embed>` renders** even if the model paraphrases; titles HTML-unescaped + quote-sanitized.

## Config / deploy
New optional `YOUTUBE_API_KEY` (free tier: 10k units/day). **Set it on the Render `ai-coach` service** to enable; without it, video search falls back to Tavily (no crash).

## Also included (complete + tested)
`delete_workout_template` tool (preview→confirm, `keep_only`, protects common templates) + `list_workout_templates` filter reporting; reflection tests resolve model from `settings.openai_model_fast`.

## Verification
156 tests pass (adds `tests/test_youtube_search.py` for the pure ranker). Verified **live against production data**: ranker returns THENX / FitnessFAQs / Hybrid Calisthenics / Squat University demos for toes-to-bar, muscle-up, dragon flag, pistol squat, RDL, front lever; coach picks video/text correctly, runs both in parallel, excludes rejected videos, saves approved ones. Dev harnesses: `video_probe.py`, `video_coach_test.py`, `video_fix_verify.py`.

> Note: an unrelated in-progress plan-skill refactor (`generate_plan_skill.py` + new `plan_builder.py`) was intentionally left OUT of this PR because it's unfinished (`validate_skeleton` not yet defined) and would crash import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)