### PR TITLE
feat(chat): smooth word blur-in reveal for streamed AI responses

### DIFF
--- a/frontend/src/hooks/useStreamingChat.js
+++ b/frontend/src/hooks/useStreamingChat.js
@@ -53,6 +53,16 @@ export function useStreamingChat() {
 
     let returnedConversationId = null;
 
+    // rAF handle for coalescing token flushes (declared here so the catch/abort
+    // path can cancel a pending frame too).
+    let pendingFrame = null;
+    const cancelFlush = () => {
+      if (pendingFrame != null) {
+        cancelAnimationFrame(pendingFrame);
+        pendingFrame = null;
+      }
+    };
+
     try {
       // Call the Node.js backend which will proxy to Python AI Coach service
       const response = await fetch(`${API_BASE_URL}/api/v1/ai/stream`, {
@@ -80,6 +90,20 @@ export function useStreamingChat() {
       const decoder = new TextDecoder();
       let accumulatedMessage = '';
 
+      // Decouple network cadence from visual paint: coalesce token updates to
+      // ~1 flush per animation frame so bursty tokens reveal as an even stream
+      // (and cause far fewer markdown re-parses). Structural events (tools,
+      // revision, finalize) still flush synchronously.
+      const flush = () => {
+        pendingFrame = null;
+        setStreamingMessage(accumulatedMessage);
+      };
+      const scheduleFlush = () => {
+        if (pendingFrame == null) {
+          pendingFrame = requestAnimationFrame(flush);
+        }
+      };
+
       while (true) {
         const { done, value } = await reader.read();
 
@@ -99,7 +123,7 @@ export function useStreamingChat() {
 
                 if (event.type === 'token') {
                   accumulatedMessage += event.content || '';
-                  setStreamingMessage(accumulatedMessage);
+                  scheduleFlush();
                 } else if (event.type === 'tool_start') {
                   // If no content was streamed yet, add a friendly intro
                   if (!accumulatedMessage.trim()) {
@@ -166,8 +190,13 @@ export function useStreamingChat() {
         }
       }
 
-      // Stream finished - convert any remaining tool-executing tags to tool-complete
-      setStreamingMessage(prev => prev.replace(/<tool-executing>/g, '<tool-complete>').replace(/<\/tool-executing>/g, '</tool-complete>'));
+      // Stream finished - flush any pending frame and convert remaining
+      // tool-executing tags to tool-complete in one final synchronous update.
+      cancelFlush();
+      accumulatedMessage = accumulatedMessage
+        .replace(/<tool-executing>/g, '<tool-complete>')
+        .replace(/<\/tool-executing>/g, '</tool-complete>');
+      setStreamingMessage(accumulatedMessage);
       setIsStreaming(false);
       setActiveTools([]); // Clear active tools when complete
       abortControllerRef.current = null;
@@ -176,6 +205,7 @@ export function useStreamingChat() {
       // Handle abort gracefully (user stopped the stream)
       if (error.name === 'AbortError') {
         console.log('[useStreamingChat] Stream was stopped by user');
+        cancelFlush();
         setActiveTools([]); // Clear active tools
         return null;
       }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,21 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Streaming chat: soft "blur-in" reveal for newly streamed words.
+   Applied per-word by rehypeAnimateWords (see src/lib/rehypeAnimateWords.js),
+   only on the actively streaming assistant message. */
+@keyframes sdBlurIn {
+  from { opacity: 0; filter: blur(4px); }
+  to   { opacity: 1; filter: blur(0); }
+}
+.sd-word {
+  display: inline;
+  animation: sdBlurIn 150ms ease both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .sd-word { animation: none; }
+}
+
 
 /* :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/frontend/src/lib/rehypeAnimateWords.js
+++ b/frontend/src/lib/rehypeAnimateWords.js
@@ -1,0 +1,77 @@
+/**
+ * rehype plugin: wrap each word of streamed text in an animated <span class="sd-word">.
+ *
+ * This powers the "blur-in" reveal for streaming assistant messages (see the
+ * `sdBlurIn` keyframes in index.css). Words are wrapped individually so that,
+ * as react-markdown re-parses on each token, React reconciliation keeps already
+ * rendered spans mounted (no re-animation) and only newly appended spans fire
+ * their CSS mount animation.
+ *
+ * Zero runtime deps — operates directly on HAST node shapes.
+ *
+ * Must run AFTER rehype-raw so custom raw-HTML elements (tool-executing,
+ * video-embed, ...) already exist as HAST elements and can be skipped.
+ */
+
+// Elements whose text we must NOT fragment into per-word spans.
+const SKIP_TAGS = new Set([
+  'code',
+  'pre',
+  'svg',
+  'a',
+  'tool-executing',
+  'tool-complete',
+  'video-embed',
+]);
+
+// Matches runs of whitespace vs. non-whitespace so we can preserve spacing.
+const TOKEN_RE = /(\s+)/;
+
+function makeWordSpan(word) {
+  return {
+    type: 'element',
+    tagName: 'span',
+    properties: { className: ['sd-word'] },
+    children: [{ type: 'text', value: word }],
+  };
+}
+
+function wrapTextNode(node) {
+  // Split into alternating [nonspace, space, nonspace, ...] pieces, preserving
+  // the original whitespace as plain text so wrapping/line breaks are unaffected.
+  const pieces = node.value.split(TOKEN_RE);
+  const out = [];
+  for (const piece of pieces) {
+    if (piece === '') continue;
+    if (/^\s+$/.test(piece)) {
+      out.push({ type: 'text', value: piece });
+    } else {
+      out.push(makeWordSpan(piece));
+    }
+  }
+  return out;
+}
+
+function visit(node) {
+  if (!node.children || node.children.length === 0) return;
+  if (node.type === 'element' && SKIP_TAGS.has(node.tagName)) return;
+
+  const newChildren = [];
+  for (const child of node.children) {
+    if (child.type === 'text' && child.value.trim() !== '') {
+      newChildren.push(...wrapTextNode(child));
+    } else {
+      visit(child);
+      newChildren.push(child);
+    }
+  }
+  node.children = newChildren;
+}
+
+export function rehypeAnimateWords() {
+  return (tree) => {
+    visit(tree);
+  };
+}
+
+export default rehypeAnimateWords;

--- a/frontend/src/pages/ChatWithStreaming.jsx
+++ b/frontend/src/pages/ChatWithStreaming.jsx
@@ -7,6 +7,7 @@ import { FileUpload } from "@/components/chat/FileUpload";
 import { uploadDocument } from "@/api/documents";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
+import { rehypeAnimateWords } from "@/lib/rehypeAnimateWords";
 import { useStreamingChat } from "@/hooks/useStreamingChat";
 import { ToolExecutionMarker } from "@/components/ToolExecutionMarker";
 import { ConversationSidebar } from "@/components/chat/ConversationSidebar";
@@ -635,7 +636,11 @@ export default function ChatWithStreaming() {
                                   prose-a:text-primary-600 prose-a:font-medium prose-a:no-underline hover:prose-a:underline
                                 ">
                                 <ReactMarkdown
-                                  rehypePlugins={[rehypeRaw]}
+                                  rehypePlugins={
+                                    msg.isStreaming && isLastMessage
+                                      ? [rehypeRaw, rehypeAnimateWords()]
+                                      : [rehypeRaw]
+                                  }
                                   components={{
                                     'tool-executing': ({ children }) => (
                                       <ToolExecutionMarker isComplete={false}>{children}</ToolExecutionMarker>


### PR DESCRIPTION
## What & why

The AI coach chat printed streamed tokens with a hard, jumpy "sharp" feel — one React state update + full markdown re-parse per network token, with no fade, cursor, or pacing. Text just snapped in, in network-timed bursts.

This swaps that for the modern ChatGPT/Claude convention: a soft **word blur-in** reveal (blur→sharp + opacity, ~150ms), with token flushes decoupled from network cadence.

## Changes

- **New `frontend/src/lib/rehypeAnimateWords.js`** — rehype plugin that wraps each streamed word in a `.sd-word` span. Skips `code`/`pre`/`svg`/`a` and the custom `tool-executing`/`tool-complete`/`video-embed` tags so markup and embeds are never fragmented. Runs *after* `rehype-raw`.
- **`ChatWithStreaming.jsx`** — plugin is added to `rehypePlugins` **only for the actively streaming last message**, so completed messages and history never re-animate on re-render/scroll. Relies on React reconciliation so only newly-arrived words animate.
- **`index.css`** — `@keyframes sdBlurIn` (opacity + blur, 150ms `ease`) + a `prefers-reduced-motion` off switch.
- **`useStreamingChat.js`** — coalesce token state flushes to ~1 per `requestAnimationFrame` (smoother reveal, far fewer markdown re-parses). Structural events (tool start/complete, revision, finalize) still flush synchronously; pending frame is cancelled on finalize and on abort.

No new dependencies (Streamdown was evaluated and rejected — it can't carry the custom raw-HTML tags and bundles heavy Shiki/KaTeX; its technique was reused in-house).

## Verification

- `npm run build` passes (2898 modules; import resolves).
- Isolated unit test of the HAST transform confirms: words wrapped, whitespace preserved exactly, and `code`/`a`/`tool-executing` subtrees left untouched.
- Not exercised against a live stream (needs the Python AI backend + auth + MongoDB stack, not stood up here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)