### PR TITLE
fix(chat): repair streaming crash + soft per-word fade

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,13 +5,14 @@
 /* Streaming chat: soft "blur-in" reveal for newly streamed words.
    Applied per-word by rehypeAnimateWords (see src/lib/rehypeAnimateWords.js),
    only on the actively streaming assistant message. */
-@keyframes sdBlurIn {
-  from { opacity: 0; filter: blur(4px); }
-  to   { opacity: 1; filter: blur(0); }
+@keyframes sdFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 .sd-word {
+  /* inline keeps normal text flow (no layout shift); pure opacity fade */
   display: inline;
-  animation: sdBlurIn 150ms ease both;
+  animation: sdFadeIn 500ms ease-out both;
 }
 @media (prefers-reduced-motion: reduce) {
   .sd-word { animation: none; }

--- a/frontend/src/lib/rehypeAnimateWords.js
+++ b/frontend/src/lib/rehypeAnimateWords.js
@@ -9,6 +9,11 @@
  *
  * Zero runtime deps — operates directly on HAST node shapes.
  *
+ * Usage: this is a unified plugin *attacher*. Pass it to `rehypePlugins`
+ * WITHOUT calling it — e.g. `rehypePlugins={[rehypeRaw, rehypeAnimateWords]}`.
+ * (Passing `rehypeAnimateWords()` would hand unified the transformer as the
+ * attacher and crash at freeze time with `undefined.children`.)
+ *
  * Must run AFTER rehype-raw so custom raw-HTML elements (tool-executing,
  * video-embed, ...) already exist as HAST elements and can be skipped.
  */
@@ -53,7 +58,7 @@ function wrapTextNode(node) {
 }
 
 function visit(node) {
-  if (!node.children || node.children.length === 0) return;
+  if (!node || !node.children || node.children.length === 0) return;
   if (node.type === 'element' && SKIP_TAGS.has(node.tagName)) return;
 
   const newChildren = [];

--- a/frontend/src/pages/ChatWithStreaming.jsx
+++ b/frontend/src/pages/ChatWithStreaming.jsx
@@ -638,7 +638,7 @@ export default function ChatWithStreaming() {
                                 <ReactMarkdown
                                   rehypePlugins={
                                     msg.isStreaming && isLastMessage
-                                      ? [rehypeRaw, rehypeAnimateWords()]
+                                      ? [rehypeRaw, rehypeAnimateWords]
                                       : [rehypeRaw]
                                   }
                                   components={{


### PR DESCRIPTION
Follow-up to #82, which shipped the word-reveal but had a crash and a look the user didn't want.

## Fixes
- **Crash (was live on `main`):** `rehypeAnimateWords` was passed to `rehypePlugins` **pre-invoked** (`rehypeAnimateWords()`). unified then treated the returned transformer as the plugin *attacher* and ran it at `.freeze()` with `tree = undefined` → `Cannot read properties of undefined (reading 'children')`, which broke the chat render. Now passed as the attacher (no parens), plus a null guard and a usage note so it can't recur.
- **Feel:** the blur + downward-drop reveal read as "sharp" and janked on bullet lists. Replaced with a **gentle opacity-only fade** (`display: inline`, 500 ms `ease-out`) — no blur, no motion, no layout shift.

## Verification
- Reproduced the exact crash and confirmed it's gone by rendering through the **real** react-markdown + rehype-raw + rehypeAnimateWords pipeline (`react-dom/server`): words wrap in `.sd-word` spans; `code`, links, and `<tool-executing>` markers stay intact.
- Clean `npm run build`.

## Known follow-up (not in this PR)
In-app "text speed" follows the model's stream rate, not a fixed cadence. If we want the steady ~11 words/sec feel from the preview, a reveal pacer in `useStreamingChat` (decouple network from display) is the next step. Also, per-word animation can still re-trigger on markdown blocks that restructure mid-stream (e.g. lists); a block-memoization pass would make it bulletproof. Opacity-only keeps this unobtrusive in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)