### PR TITLE
fix(ai-coach): make plan generation trust the tools, show real plans, stop stutter

### DIFF
--- a/ai-coach-service/app/api/v1/chat_stream.py
+++ b/ai-coach-service/app/api/v1/chat_stream.py
@@ -13,6 +13,7 @@ import time
 from app.models.schemas import ChatRequest
 from app.middleware.auth import get_current_user
 from app.core.agents.orchestrator import AgentOrchestrator
+from app.core.agents.text_utils import dedupe_repeated_response
 from app.services.conversation_service import ConversationService
 
 router = APIRouter()
@@ -64,8 +65,10 @@ async def generate_sse_stream(
                 yield f"data: {json.dumps(event)}\n\n"
 
             elif event_type == "complete":
-                # Build full response with tool markers
-                full_response = "".join(response_parts)
+                # Build full response with tool markers. Collapse a fully-duplicated
+                # reply (gpt-5.4-mini stutter) so the SAVED message matches what the
+                # frontend shows after the revision event. No-op on normal replies.
+                full_response = dedupe_repeated_response("".join(response_parts))
 
                 # Calculate response time
                 response_time_ms = int((time.time() - start_time) * 1000)

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -16,6 +16,7 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 from app.config import get_settings
 from app.core.agents.data_reader import DataReaderAgent
 from app.core.agents.prompts import SYSTEM_PROMPT
+from app.core.agents.text_utils import dedupe_repeated_response
 from app.core.agents.tool_definitions import get_all_tools
 from app.core.agents.reflection_config import REFLECTION_CONFIG
 from app.core.agents.reflection_prompt import REFLECTION_SYSTEM_PROMPT, REFLECTION_USER_PROMPT
@@ -308,7 +309,7 @@ USER DATA:
                         logger.info(f"Response revised. Issues fixed: {reflection_result['issues']}")
 
                 return {
-                    "message": final_content,
+                    "message": dedupe_repeated_response(final_content),
                     "type": "tool_execution",
                     "confidence": 0.95
                 }
@@ -332,7 +333,7 @@ USER DATA:
                         final_content = reflection_result["revised_response"]
 
                 return {
-                    "message": final_content,
+                    "message": dedupe_repeated_response(final_content),
                     "type": "conversation",
                     "confidence": 0.9
                 }
@@ -811,6 +812,20 @@ USER DATA:
                         "issues_fixed": reflection_result["issues"]
                     }
                     accumulated_content = reflection_result["revised_response"]
+
+            # Safety net: gpt-5.4-mini sometimes emits its whole reply twice under
+            # the large system prompt (streamed doubled). Collapse it and tell the
+            # frontend to replace what it showed. Conservative — only fires on an
+            # exact full duplication (see text_utils).
+            deduped = dedupe_repeated_response(accumulated_content)
+            if deduped != accumulated_content:
+                logger.info("Collapsed a duplicated streamed response")
+                yield {
+                    "type": "revision",
+                    "content": deduped,
+                    "issues_fixed": ["Removed a duplicated copy of the reply."],
+                }
+                accumulated_content = deduped
 
             # Yield completion event with final content
             yield {

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -5,6 +5,12 @@ System prompts for the AI fitness coach
 # System prompt used by the AI coach - shared across streaming and non-streaming endpoints
 SYSTEM_PROMPT = """You are an expert AI fitness coach helping users manage their personalized fitness journey. All data you create is personal to this specific user.
 
+🚫 PLANS COME FROM TOOLS — YOU NEVER WRITE ONE YOURSELF (highest priority rule):
+- You do NOT design multi-week plans in your head. To CREATE a training plan you MUST call `generate_plan`. To SHOW or discuss an existing plan you MUST call `show_plan` first and speak only from what it returns.
+- It is FORBIDDEN to type out a week-by-week schedule, distances, sets/reps, or "Week 1: … Week 2: …" from your own knowledge. A plan you write in prose is fake — it is not saved, not validated, and cannot be scheduled, and it misleads the user. If you feel the urge to write "Week 1:", STOP and call `generate_plan` instead.
+- Once you have the goal and the 1–2 basics you need (days/week, current level), call `generate_plan` — do not keep describing the plan in words or ask permission to "lay it out". When the user says "do it", "please do", "go", "build it", that means call `generate_plan` now.
+- When the user wants to see, review, or drill into a plan ("show me", "let's talk about the plan", "what's in week 1"), call `show_plan` — never re-summarize from memory and never call `generate_plan` to display an existing plan.
+
 CONVERSATION STYLE (applies to EVERY answer):
 - This is a CONVERSATION, not a report. Default to SHORT, direct answers: 1-4 sentences, like a real coach texting back.
 - Answer the question that was asked. Do not pad with background, "why this works" essays, weekly patterns, or restatements of the question.
@@ -45,12 +51,13 @@ WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I 
 - `get_workout_history`: View past workouts to analyze progress.
 
 **Training Plans** (Multi-week programs):
-- `generate_plan`: PREFERRED for building a new multi-week plan for a goal — it tailors workouts to the user's level/equipment/health caveats, validates the result, and saves a DRAFT (no calendar changes). Use this instead of hand-building with create_plan/add_plan_workout. After the user reviews the draft, put it on the calendar with `schedule_plan_to_calendar`.
-- Plans are SKELETON-BASED: they carry a periodized structure (phases, weekly intents, deloads, milestones), with only the next ~2 weeks written out as concrete workouts. When the user asks about later weeks, describe them from the plan's phase/intent (focus, volume direction) — do not invent concrete exercises for unresolved weeks. To write out an upcoming week, use `resolve_week` (it adapts volume to recent adherence and health notes), then offer to schedule it.
-- `resolve_week`: Materialize the next unresolved week of a skeleton plan into concrete workouts. Use when the upcoming week isn't written out, or the user asks to finalize/see next week's workouts. No-op on old fully-written plans.
+- `generate_plan`: build a NEW multi-week plan for a goal — it tailors workouts to the user's level/equipment/health caveats, validates the result, and saves a DRAFT (no calendar changes). Use this ONLY to create a brand-new plan (or to rebuild one after the user asks for changes) — NEVER to re-display a plan that already exists. Calling it again to "show" a plan creates a duplicate draft. After the user reviews the draft, put it on the calendar with `schedule_plan_to_calendar`.
+- `show_plan`: READ a plan the user already has and reveal it at the depth they asked for — `level` = overview (phases + milestones), weeks (each week's focus + workout titles), week (one week's full workouts/exercises/sets), workout (a single day). This is the tool for "show me the draft/plan", "where is it", "what's in week 3", "see the workouts". Defaults to the user's most recent plan. Read-only, no duplicates.
+- Plans are SKELETON-BASED: they carry a periodized structure (phases, weekly intents, deloads, milestones). The first ~12 weeks are written out as concrete workouts (a rolling horizon); weeks beyond that are intent-only stubs. When the user asks about a stubbed later week, describe it from the plan's phase/intent (focus, volume direction) — do not invent concrete exercises for it. To write out an upcoming stubbed week, use `resolve_week` (it adapts volume to recent adherence and health notes), then offer to schedule it.
+- `resolve_week`: Materialize the next unresolved week of a skeleton plan into concrete workouts. Use when an upcoming week is still a stub, or the user asks to finalize/see a not-yet-written week. No-op on old fully-written plans.
 - `validate_plan`: Check an existing/draft plan for quality issues (volume, frequency, rest, deload, ramp, goal fit) before scheduling or after edits. Read-only.
 - `create_plan`: Low-level — create a plan from explicit structure. Prefer `generate_plan` for goal-driven plans.
-- `list_plans`: View user's existing plans.
+- `list_plans`: View the user's existing plans (names/status/schedule only). To show a plan's CONTENTS, use `show_plan`.
 - `update_plan`: Modify plan details or status.
 - `add_plan_workout` / `remove_plan_workout`: Manage individual workouts within plan weeks.
 
@@ -174,7 +181,7 @@ IMPORTANT PRINCIPLES:
    - `get_calendar_events` → their scheduled workouts WITH the full exercise list
    - `list_workout_templates` / `grep_workouts` → their workout templates WITH exercises
    - `get_workout_history` → what they actually did
-   - `list_plans` → their training plans
+   - `list_plans` → the names/status of their training plans; `show_plan` → the CONTENTS of a plan (phases, weeks, workouts, exercises)
 
    These tools return the complete exercise-by-exercise detail. NEVER ask the user to describe, paste, or screenshot their own plan — you can see it yourself. NEVER give hypothetical advice ("if your week looks like...") about a plan you could have read. NEVER reason from exercise counts or durations alone when the exercise names are in the tool result — name the actual exercises.
 
@@ -226,6 +233,13 @@ IMPORTANT PRINCIPLES:
    **EXCEPTION**: If the user explicitly asks "can you research it?", "research this", "look it up", etc. - SKIP the questions and call the `research` tool immediately. They've told you what they want.
 
 3. **HEALTH MEMORIES TAKE PRIORITY**: If USER MEMORIES contains health-related information (injuries, illness, conditions marked with ⚠️), you MUST acknowledge and respect these BEFORE suggesting any workout. Even if the user explicitly asks to train NOW, gently remind them of their health status first. Never suggest a workout to someone who is sick, injured, or has a condition that contraindicates exercise - instead, recommend rest and ask how they're feeling.
+
+**BUILDING & SHOWING A PLAN — reveal it progressively, with the user:**
+A plan takes a goal and breaks it down goal → phases → weeks → workouts → exercises. Do NOT dump the whole thing at once, and do NOT just paraphrase counts ("16 weeks, 4 phases") — reveal it in layers and let the user drive the depth:
+- After `generate_plan`, open at the STRUCTURE level: name, length, days/week, the phase titles and what each phase is for, where the milestones land, and any real quality flags. Then invite the user to go deeper or schedule. The tool returns an `overview` (phases + each week's focus/titles) — render THAT, don't invent.
+- When the user wants to go deeper ("show me the plan/draft", "what's in week 3", "see the workouts", "where is it?") → call `show_plan` at the right `level` (overview → weeks → week → workout) and show the real content it returns. NEVER re-call `generate_plan` to display an existing plan — that creates a duplicate draft.
+- Let the user shape it before scheduling: they can adjust phases/volume (`adjust_plan`) or swap workouts. Only put it on the calendar with `schedule_plan_to_calendar` once they're happy.
+- Weeks past the written horizon are planned at the phase level; describe them from the phase intent and offer `resolve_week` to write one out.
 
 3. MUSCLE GROUP vs EXERCISE NAME: "Core", "Back", "Chest", "Hamstrings" are muscle groups - use list_exercises with muscle filter. "Plank", "Pull-up", "Deadlift" are exercise names - use grep_exercises.
 

--- a/ai-coach-service/app/core/agents/services/plan_service.py
+++ b/ai-coach-service/app/core/agents/services/plan_service.py
@@ -17,66 +17,73 @@ class PlanService:
     def __init__(self, db: AsyncIOMotorDatabase):
         self.db = db
 
+    @staticmethod
+    def _normalize_week_docs(weeks_input: list) -> list:
+        """Turn caller/plan_builder week dicts into stored week documents (assign
+        _ids, normalize workout/exercise shape). Shared by create_plan and
+        update_plan_content so a regenerated draft is stored identically to a new
+        one."""
+        weeks = []
+        for week_data in weeks_input or []:
+            week = {
+                "_id": ObjectId(),
+                "weekNumber": week_data.get("weekNumber", 1),
+                "focus": week_data.get("focus", ""),
+                "description": week_data.get("description", ""),
+                "deloadWeek": week_data.get("deloadWeek", False),
+                "workouts": [],
+                "restDays": []
+            }
+            # Rolling-materialization flags: only set when the caller provides
+            # them (missing = resolved, the legacy/back-compat convention).
+            if "resolved" in week_data:
+                week["resolved"] = bool(week_data["resolved"])
+                if week_data.get("resolvedAt"):
+                    week["resolvedAt"] = week_data["resolvedAt"]
+
+            for workout in week_data.get("workouts", []):
+                weekly_workout = {
+                    "_id": ObjectId(),
+                    "dayOfWeek": workout.get("dayOfWeek", 1),
+                    "workoutType": workout.get("workoutType", "custom"),
+                    "notes": workout.get("notes", ""),
+                    "isOptional": workout.get("isOptional", False)
+                }
+
+                if workout.get("workoutType") == "predefined" and workout.get("predefinedWorkoutId"):
+                    try:
+                        weekly_workout["predefinedWorkoutId"] = ObjectId(workout["predefinedWorkoutId"])
+                    except Exception:
+                        pass
+                elif workout.get("customWorkout"):
+                    custom = workout["customWorkout"]
+                    exercises = []
+                    for ex in custom.get("exercises", []):
+                        ex_doc = {
+                            "exerciseName": ex.get("exerciseName", ""),
+                            "sets": ex.get("sets", [])
+                        }
+                        if ex.get("notes"):
+                            ex_doc["notes"] = ex["notes"]
+                        exercises.append(ex_doc)
+                    weekly_workout["customWorkout"] = {
+                        "title": custom.get("title", ""),
+                        "type": custom.get("type", "strength"),
+                        "durationMinutes": custom.get("durationMinutes", 45),
+                        "exercises": exercises
+                    }
+
+                week["workouts"].append(weekly_workout)
+
+            weeks.append(week)
+        return weeks
+
     async def create_plan(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Create a training plan"""
         try:
             schedule = args.get("schedule", {})
 
-            # Process weeks if provided
-            weeks = []
-            for week_data in args.get("weeks", []):
-                week = {
-                    "_id": ObjectId(),
-                    "weekNumber": week_data.get("weekNumber", 1),
-                    "focus": week_data.get("focus", ""),
-                    "description": week_data.get("description", ""),
-                    "deloadWeek": week_data.get("deloadWeek", False),
-                    "workouts": [],
-                    "restDays": []
-                }
-                # Rolling-materialization flags: only set when the caller provides
-                # them (missing = resolved, the legacy/back-compat convention).
-                if "resolved" in week_data:
-                    week["resolved"] = bool(week_data["resolved"])
-                    if week_data.get("resolvedAt"):
-                        week["resolvedAt"] = week_data["resolvedAt"]
-
-                # Process workouts for this week
-                for workout in week_data.get("workouts", []):
-                    weekly_workout = {
-                        "_id": ObjectId(),
-                        "dayOfWeek": workout.get("dayOfWeek", 1),
-                        "workoutType": workout.get("workoutType", "custom"),
-                        "notes": workout.get("notes", ""),
-                        "isOptional": workout.get("isOptional", False)
-                    }
-
-                    if workout.get("workoutType") == "predefined" and workout.get("predefinedWorkoutId"):
-                        try:
-                            weekly_workout["predefinedWorkoutId"] = ObjectId(workout["predefinedWorkoutId"])
-                        except Exception:
-                            pass
-                    elif workout.get("customWorkout"):
-                        custom = workout["customWorkout"]
-                        exercises = []
-                        for ex in custom.get("exercises", []):
-                            ex_doc = {
-                                "exerciseName": ex.get("exerciseName", ""),
-                                "sets": ex.get("sets", [])
-                            }
-                            if ex.get("notes"):
-                                ex_doc["notes"] = ex["notes"]
-                            exercises.append(ex_doc)
-                        weekly_workout["customWorkout"] = {
-                            "title": custom.get("title", ""),
-                            "type": custom.get("type", "strength"),
-                            "durationMinutes": custom.get("durationMinutes", 45),
-                            "exercises": exercises
-                        }
-
-                    week["workouts"].append(weekly_workout)
-
-                weeks.append(week)
+            weeks = self._normalize_week_docs(args.get("weeks", []))
 
             plan_data = {
                 "userId": ObjectId(user_id),
@@ -136,6 +143,45 @@ class PlanService:
         except Exception as e:
             logger.error(f"Error creating plan: {e}")
             return {"success": False, "message": str(e)}
+
+    async def update_plan_content(self, user_id: str, plan_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Replace a plan's weeks/skeleton/schedule/name in place. Used by the
+        dedupe guard in generate_plan: when an unscheduled AI draft for the same
+        goal already exists, we regenerate INTO it instead of creating a duplicate.
+        Reuses create_plan's week-normalization by delegating the heavy lifting
+        there is overkill — the caller passes already-built plan_builder weeks, so
+        persist them verbatim (same shape create_plan writes)."""
+        try:
+            plan_oid = ObjectId(plan_id)
+            user_oid = ObjectId(user_id)
+        except Exception:
+            return {"success": False, "message": "Invalid plan_id."}
+
+        weeks = self._normalize_week_docs(args.get("weeks", []))
+        set_doc: Dict[str, Any] = {
+            "weeks": weeks,
+            "updatedAt": datetime.utcnow(),
+            "progress.totalWorkouts": sum(len(w.get("workouts", []) or []) for w in weeks),
+            "progress.currentWeek": 1,
+            "progress.completedWorkouts": 0,
+        }
+        if args.get("name"):
+            set_doc["name"] = args["name"]
+        if args.get("description") is not None:
+            set_doc["description"] = args["description"]
+        if args.get("schedule"):
+            set_doc["schedule"] = args["schedule"]
+        if args.get("skeleton"):
+            set_doc["skeleton"] = args["skeleton"]
+        if args.get("tags") is not None:
+            set_doc["tags"] = args["tags"]
+
+        result = await self.db.plans.update_one(
+            {"_id": plan_oid, "userId": user_oid}, {"$set": set_doc}
+        )
+        if result.matched_count == 0:
+            return {"success": False, "message": "Plan not found."}
+        return {"success": True, "plan_id": plan_id, "message": "Updated existing draft plan."}
 
     async def list_plans(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """List user's training plans"""

--- a/ai-coach-service/app/core/agents/skills/__init__.py
+++ b/ai-coach-service/app/core/agents/skills/__init__.py
@@ -29,6 +29,7 @@ from app.core.agents.skills import reschedule_session_skill  # noqa: F401,E402
 from app.core.agents.skills import adjust_plan_skill  # noqa: F401,E402
 from app.core.agents.skills import update_calendar_workout_skill  # noqa: F401,E402
 from app.core.agents.skills import resolve_week_skill  # noqa: F401,E402
+from app.core.agents.skills import show_plan_skill  # noqa: F401,E402
 
 __all__ = [
     "SkillContext",

--- a/ai-coach-service/app/core/agents/skills/generate_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/generate_plan_skill.py
@@ -26,6 +26,7 @@ from app.core.agents.skills.registry import SkillContext, skill
 from app.core.agents.skills.knowledge import training_knowledge as tk
 from app.core.agents.skills.plan_builder import (
     DEFAULT_HORIZON_WEEKS,
+    build_plan_overview,
     build_plan_weeks_from_skeleton,
     normalize_skeleton,
     planner_model,
@@ -117,6 +118,33 @@ Rules: phases contiguous covering weeks 1..{weeks}; one weekIntent per week 1..{
 `sets` and `reps` MUST be integers. For runs/holds/timed work use reps=1, put the duration in timeSeconds, and the real prescription (pace, intervals, rest) in `notes` — never write prose into sets/reps."""
 
 
+async def _find_reusable_draft(
+    ctx: SkillContext, user_oid: ObjectId, goal_oid: Optional[ObjectId],
+    goal_name: str, category: str,
+) -> Optional[Dict[str, Any]]:
+    """Find an existing unscheduled AI DRAFT for the same goal to regenerate into,
+    so "rebuild/show" doesn't spawn duplicate drafts. Matches the linked goal when
+    there is one, else the same free-text goal (stored in the draft's description).
+    Only status:'draft' plans qualify — scheduling flips a plan to active."""
+    query: Dict[str, Any] = {
+        "userId": user_oid,
+        "status": "draft",
+        "tags": "ai-generated",
+    }
+    if goal_oid is not None:
+        query["goalId"] = goal_oid
+    else:
+        # Match on the stable goal CATEGORY tag, not the free-text goal_name: the
+        # model rephrases goal_text on every call ("run a 10k" vs "Run 10K in 3
+        # months from 1-2km…"), so a description match would miss and spawn a
+        # duplicate draft. A user iterating on one goal has one draft category.
+        query["tags"] = {"$all": ["ai-generated", f"cat:{category}"]}
+    try:
+        return await ctx.db.plans.find_one(query, sort=[("updatedAt", -1)])
+    except Exception:
+        return None
+
+
 async def _validate_exercise_names(ctx: SkillContext, user_id: str, names: List[str]) -> List[str]:
     """Best-effort: return names not found in the exercise library (advisory)."""
     if not names:
@@ -203,7 +231,10 @@ async def generate_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -
     tuning = ctx.settings.llm_tuning_params(temperature=0.4)
     # Reasoning tokens count against max_completion_tokens — without headroom a
     # reasoning model burns the whole budget thinking and returns empty content.
-    max_tokens = 16000 if "reasoning_effort" in tuning else 6000
+    # A full skeleton (up to 26 weeks, per-phase detailed blueprints) can exceed
+    # 6000 output tokens and truncate into invalid JSON (observed with the mini
+    # model on a 16-week plan) — which fails the whole generation. Give it room.
+    max_tokens = 16000 if "reasoning_effort" in tuning else 12000
     logger.info("generate_plan LLM call", model=model, weeks=weeks,
                 days_per_week=days_per_week, tuning=tuning)
     try:
@@ -238,6 +269,10 @@ async def generate_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -
         {"schedule": {"weeksTotal": len(resolved_weeks), "workoutsPerWeek": len(workout_days)},
          "weeks": resolved_weeks},
         category,
+        # Skeleton plans get their ramp check from validate_skeleton (deload-aware,
+        # on week-intent multipliers); the materialized set-count ramp check would
+        # false-flag phase transitions here.
+        check_ramp=False,
     )
     skeleton_report = validate_skeleton(skeleton, category, weeks)
 
@@ -261,41 +296,65 @@ async def generate_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -
         },
         "weeks": plan_weeks,
         "skeleton": skeleton,
-        "tags": ["ai-generated", "draft"],
+        # `cat:<category>` lets the dedupe guard find this draft again even when
+        # the model rephrases goal_text on a later generate_plan call.
+        "tags": ["ai-generated", "draft", f"cat:{category}"],
     }
     if linked_goal_oid:
         create_args["goalId"] = str(linked_goal_oid)
 
-    create_result = await ctx.plan_service.create_plan(user_id, create_args)
+    # --- Dedupe guard: reuse an existing unscheduled AI draft for the same goal ---
+    # Without this, every "show me / rebuild" that reaches generate_plan spawns a
+    # new draft (the user saw 3 duplicate 10K drafts in one conversation). If an
+    # unscheduled AI draft already targets this goal, regenerate INTO it.
+    existing = await _find_reusable_draft(ctx, user_oid, linked_goal_oid, goal_name, category)
+    if existing:
+        create_result = await ctx.plan_service.update_plan_content(
+            user_id, str(existing["_id"]), create_args,
+        )
+        reused = create_result.get("success", False)
+    else:
+        create_result = await ctx.plan_service.create_plan(user_id, create_args)
+        reused = False
     if not create_result.get("success"):
         return {"success": False, "message": create_result.get("message", "Failed to save the draft plan.")}
 
+    # Layered, renderable view so the coach shows the REAL plan (phases + each
+    # week's focus/workouts), not just counts. L3 exercise detail is fetched on
+    # demand via show_plan when the user drills into a week.
+    overview = build_plan_overview(skeleton, plan_weeks, level="weeks")
+
     phase_names = " → ".join(p.get("name", "?") for p in skeleton.get("phases", []))
     milestones = skeleton.get("milestones", [])
+    all_violations = report["violations"] + skeleton_report["violations"]
+    # Structure-first opener (progressive disclosure): show the shape and invite a
+    # drill-down. Do NOT dump every week — the coach unfolds detail on request.
+    verb = "Updated your draft" if reused else "Drafted"
     msg = (
-        f"📋 Drafted **{plan_name}** — {weeks} weeks, {len(workout_days)} days/week.\n"
+        f"📋 {verb} **{plan_name}** — {weeks} weeks, {len(workout_days)} days/week.\n"
         f"Phases: {phase_names}."
         + (f" Milestones at week {', '.join(str(m['week']) for m in milestones)}." if milestones else "")
-        + f"\nThe first {len(resolved_weeks)} week(s) are fully written out; later weeks follow the "
-        f"plan's structure and get finalized from your actual training as you go.\n\n"
+        + f"\nThe first {len(resolved_weeks)} weeks are written out to the exercise; later weeks are "
+        f"planned at the phase level and finalized from your actual training as you go.\n\n"
     )
-    all_violations = report["violations"] + skeleton_report["violations"]
     if all_violations:
-        msg += "A few things to review:\n" + "\n".join(f"- {v}" for v in all_violations) + "\n\n"
+        msg += "A couple of things worth tightening before scheduling:\n" + "\n".join(f"- {v}" for v in all_violations) + "\n\n"
     else:
         msg += "It passes the quality checks. "
     if unverified:
         msg += f"Note: {len(unverified)} exercise name(s) weren't found in your library and may be created on scheduling.\n\n"
-    msg += "Want me to put it on your calendar?"
+    msg += "Want to look at a specific phase or week, or should I put it on your calendar?"
 
     return {
         "success": True,
         "dry_run": True,
+        "reused_existing_draft": reused,
         "plan_id": create_result.get("plan_id"),
         "name": plan_name,
         "weeks": weeks,
         "days_per_week": len(workout_days),
         "resolved_weeks": len(resolved_weeks),
+        "overview": overview,
         "validation": report,
         "skeleton_validation": skeleton_report,
         "unverified_exercises": unverified,

--- a/ai-coach-service/app/core/agents/skills/plan_builder.py
+++ b/ai-coach-service/app/core/agents/skills/plan_builder.py
@@ -299,6 +299,119 @@ def build_plan_weeks_from_skeleton(
 
 
 # ---------------------------------------------------------------------------
+# Layered, renderable plan views (progressive disclosure)
+#
+# The coach reveals a plan top-down: phases → weeks → workouts → exercises. These
+# pure helpers turn a stored plan (skeleton + materialized/stub weeks) into JSON
+# the model can render at the depth the user asked for. Shared by generate_plan
+# (returns L1+L2 so the coach can show the real structure, not just counts) and
+# show_plan (drills to any level). No DB, no LLM.
+# ---------------------------------------------------------------------------
+
+DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+
+def phase_overview(skeleton: Dict[str, Any]) -> Dict[str, Any]:
+    """L1: phases (name, week range, focus, progression) and milestones."""
+    skeleton = skeleton or {}
+    phases = [
+        {
+            "name": p.get("name", ""),
+            "weekRange": [p.get("startWeek"), p.get("endWeek")],
+            "focus": p.get("focus", ""),
+            "progression": p.get("progression", ""),
+        }
+        for p in skeleton.get("phases", []) or []
+    ]
+    milestones = [
+        {"week": m.get("week"), "title": m.get("title", ""), "criteria": m.get("criteria", "")}
+        for m in skeleton.get("milestones", []) or []
+    ]
+    return {"phases": phases, "milestones": milestones}
+
+
+def week_summary(week: Dict[str, Any]) -> Dict[str, Any]:
+    """L2: one week's focus + workout titles (no exercise detail)."""
+    return {
+        "weekNumber": week.get("weekNumber"),
+        "focus": week.get("focus", ""),
+        "deload": bool(week.get("deloadWeek")),
+        "resolved": week.get("resolved") is not False,
+        "workoutTitles": [
+            (w.get("customWorkout") or {}).get("title", "Workout")
+            for w in week.get("workouts", []) or []
+        ],
+    }
+
+
+def _exercise_view(ex: Dict[str, Any]) -> Dict[str, Any]:
+    """One exercise summarized for display: set count + the per-set prescription."""
+    sets = ex.get("sets", []) or []
+    first = sets[0] if sets else {}
+    view: Dict[str, Any] = {
+        "exerciseName": ex.get("exerciseName", ""),
+        "sets": len(sets),
+        "reps": first.get("reps"),
+    }
+    if first.get("time"):
+        view["timeSeconds"] = first.get("time")
+    if ex.get("notes"):
+        view["notes"] = ex["notes"]
+    return view
+
+
+def workout_detail(workout: Dict[str, Any]) -> Dict[str, Any]:
+    """L3: one workout with its exercises/sets/times/notes."""
+    day = workout.get("dayOfWeek")
+    custom = workout.get("customWorkout") or {}
+    return {
+        "dayOfWeek": day,
+        "dayName": DAY_NAMES[day] if isinstance(day, int) and 0 <= day <= 6 else None,
+        "title": custom.get("title", "Workout"),
+        "type": custom.get("type", "strength"),
+        "durationMinutes": custom.get("durationMinutes"),
+        "notes": workout.get("notes", ""),
+        "exercises": [_exercise_view(ex) for ex in custom.get("exercises", []) or []],
+    }
+
+
+def week_detail(week: Dict[str, Any]) -> Dict[str, Any]:
+    """L3: one full week — its workouts drilled down to exercises."""
+    return {
+        "weekNumber": week.get("weekNumber"),
+        "focus": week.get("focus", ""),
+        "deload": bool(week.get("deloadWeek")),
+        "resolved": week.get("resolved") is not False,
+        "workouts": [workout_detail(w) for w in week.get("workouts", []) or []],
+    }
+
+
+def build_plan_overview(
+    skeleton: Dict[str, Any],
+    weeks: List[Dict[str, Any]],
+    level: str = "weeks",
+    week_number: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Layered plan view. `level`:
+      - "overview": phases + milestones only (L1)
+      - "weeks":    L1 + per-week summaries (L2) — the generate_plan default
+      - "week":     L1 + full detail for `week_number` (L3)
+      - "workout":  same as "week" (caller picks the workout to show)
+    """
+    weeks = weeks or []
+    overview = phase_overview(skeleton)
+    if level == "overview":
+        return overview
+    if level in ("week", "workout"):
+        target = next((w for w in weeks if w.get("weekNumber") == week_number), None)
+        overview["week"] = week_detail(target) if target else None
+        return overview
+    # default: "weeks"
+    overview["weeks"] = [week_summary(w) for w in weeks]
+    return overview
+
+
+# ---------------------------------------------------------------------------
 # Adaptation (Stage 3 rules — constants from training_knowledge only)
 # ---------------------------------------------------------------------------
 

--- a/ai-coach-service/app/core/agents/skills/show_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/show_plan_skill.py
@@ -1,0 +1,114 @@
+"""
+Skill: show_plan
+
+Read-only drill-down into an existing plan, for progressive disclosure. This is
+the path the coach uses to SHOW a plan — "show me the draft", "what's in week 3",
+"see the workouts". It returns a layered, renderable view at the requested depth
+so the coach can reveal the plan top-down (phases → weeks → workouts → exercises)
+instead of re-running generate_plan (which builds a NEW draft and only ever handed
+back counts — the reason plans were invisible and got duplicated).
+
+No writes, no LLM. Pure read + plan_builder's layered-view helpers.
+
+Levels:
+  - overview: phases + milestones (the shape of the plan)
+  - weeks:    per-week focus + workout titles (default)
+  - week:     one week drilled down to every workout's exercises/sets/times
+  - workout:  same detail as `week`, scoped to a single day
+"""
+
+from typing import Any, Dict
+
+from bson import ObjectId
+
+from app.core.agents.skills.registry import SkillContext, skill
+from app.core.agents.skills.plan_builder import build_plan_overview
+
+
+async def _resolve_plan(ctx: SkillContext, user_oid: ObjectId, plan_id: str = None) -> Dict[str, Any]:
+    """Load the requested plan, or the user's most-recent non-completed plan
+    (draft/active/paused) when no id is given — so "show me the plan" just works."""
+    if plan_id:
+        try:
+            return await ctx.db.plans.find_one({"_id": ObjectId(plan_id), "userId": user_oid})
+        except Exception:
+            return None
+    return await ctx.db.plans.find_one(
+        {"userId": user_oid, "status": {"$in": ["draft", "active", "paused"]}},
+        sort=[("updatedAt", -1)],
+    )
+
+
+@skill(
+    name="show_plan",
+    description=(
+        "Show the contents of an existing training plan at the depth requested, for "
+        "progressively revealing it to the user. USE THIS (not generate_plan) whenever the "
+        "user wants to SEE a plan they already have — 'show me the draft/plan', 'what's in "
+        "week 3', 'see the workouts'. Read-only. Defaults to the user's most recent plan when "
+        "no plan_id is given. Levels: 'overview' (phases + milestones), 'weeks' (each week's "
+        "focus + workout titles), 'week' (one week's full workouts/exercises/sets), 'workout' "
+        "(a single day in detail)."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "plan_id": {"type": "string", "description": "Plan to show (default: the user's most recent draft/active plan)."},
+            "level": {
+                "type": "string",
+                "enum": ["overview", "weeks", "week", "workout"],
+                "description": "Disclosure depth (default 'weeks'). Use 'week'/'workout' with week_number to drill into exercises.",
+            },
+            "week_number": {"type": "integer", "minimum": 1, "description": "Required for level 'week' or 'workout'."},
+            "day_of_week": {"type": "integer", "minimum": 0, "maximum": 6, "description": "For level 'workout': 0=Sun..6=Sat."},
+        },
+    },
+)
+async def show_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid user."}
+
+    plan = await _resolve_plan(ctx, user_oid, args.get("plan_id"))
+    if not plan:
+        return {"success": True, "not_found": True,
+                "message": "I don't see a plan to show yet — want me to build one for a goal?"}
+
+    level = args.get("level") or "weeks"
+    week_number = args.get("week_number")
+    if level in ("week", "workout") and week_number is None:
+        # Nothing specified to drill into — fall back to the week list so the
+        # coach can ask which week rather than erroring.
+        level = "weeks"
+
+    skeleton = plan.get("skeleton") or {}
+    weeks = plan.get("weeks") or []
+    overview = build_plan_overview(skeleton, weeks, level=level, week_number=week_number)
+
+    schedule = plan.get("schedule") or {}
+    result: Dict[str, Any] = {
+        "success": True,
+        "plan_id": str(plan["_id"]),
+        "name": plan.get("name", ""),
+        "status": plan.get("status"),
+        "weeks_total": schedule.get("weeksTotal") or len(weeks),
+        "days_per_week": schedule.get("workoutsPerWeek"),
+        "level": level,
+        "overview": overview,
+    }
+
+    # For a single-day request, narrow the week's workouts to the chosen day.
+    if level == "workout" and overview.get("week"):
+        day = args.get("day_of_week")
+        workouts = overview["week"].get("workouts", [])
+        if day is not None:
+            workouts = [w for w in workouts if w.get("dayOfWeek") == day]
+        if not workouts:
+            result["message"] = f"No workout found for that day in week {week_number}."
+            return result
+        result["overview"]["week"]["workouts"] = workouts
+
+    if level in ("week", "workout") and not (overview.get("week")):
+        result["message"] = f"Week {week_number} isn't in this plan."
+    return result

--- a/ai-coach-service/app/core/agents/skills/validate_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/validate_plan_skill.py
@@ -42,17 +42,63 @@ def _week_metrics(week: Dict[str, Any]) -> Tuple[int, int, List[Dict[str, Any]]]
     return len(workouts), sets, workouts
 
 
+def _session_timed_minutes(custom: Dict[str, Any]) -> int:
+    """Minutes of timed work in a session = sum of set['time'] (seconds) / 60.
+    Runs/holds are stored as timed sets, so this is the ground truth for a
+    session's aerobic time regardless of its durationMinutes label."""
+    seconds = sum(
+        int(s.get("time") or 0)
+        for ex in (custom.get("exercises") or [])
+        for s in (ex.get("sets") or [])
+    )
+    return seconds // 60
+
+
+def _aerobic_minutes(workouts_list: List[Dict[str, Any]]) -> int:
+    """Aerobic minutes in one week's workouts. Measured from the actual timed work
+    in each session (the model sometimes leaves durationMinutes at the target while
+    the real run length lives in the sets), falling back to durationMinutes for a
+    cardio session that carries no timed sets. Hybrid (strength+run) sessions
+    contribute only their timed portion, so strength blocks aren't miscounted."""
+    minutes = 0
+    for w in workouts_list:
+        custom = w.get("customWorkout") or {}
+        wtype = (custom.get("type") or "").lower()
+        timed = _session_timed_minutes(custom)
+        if wtype in tk.AEROBIC_WORKOUT_TYPES:
+            minutes += timed or int(custom.get("durationMinutes") or 0)
+        elif wtype == "hybrid":
+            minutes += timed
+    return minutes
+
+
 def _has_aerobic(weeks: List[Dict[str, Any]]) -> bool:
+    """Any aerobic stimulus present? True for cardio/hiit/endurance sessions, and
+    for hybrid sessions that carry timed work (embedded runs)."""
     for week in weeks:
         for w in week.get("workouts", []) or []:
-            wtype = ((w.get("customWorkout") or {}).get("type") or "").lower()
+            custom = w.get("customWorkout") or {}
+            wtype = (custom.get("type") or "").lower()
             if wtype in tk.AEROBIC_WORKOUT_TYPES:
+                return True
+            if wtype == "hybrid" and any(
+                (s.get("time") or 0)
+                for ex in (custom.get("exercises") or [])
+                for s in (ex.get("sets") or [])
+            ):
                 return True
     return False
 
 
-def validate_plan_doc(plan: Dict[str, Any], goal_category: str) -> Dict[str, Any]:
-    """Pure validator. Returns {valid, violations[], suggestions[], metrics}."""
+def validate_plan_doc(plan: Dict[str, Any], goal_category: str, check_ramp: bool = True) -> Dict[str, Any]:
+    """Pure validator. Returns {valid, violations[], suggestions[], metrics}.
+
+    `check_ramp`: run the materialized week-over-week set-count ramp check (V5).
+    Skeleton-based plans should pass check_ramp=False — set counts differ across
+    phases by design (different blueprints), not by load ramp, so V5 produces
+    false positives there; `validate_skeleton` does the authoritative, deload-aware
+    ramp check on the week-intent multipliers instead.
+    """
     violations: List[str] = []
     suggestions: List[str] = []
 
@@ -85,21 +131,22 @@ def validate_plan_doc(plan: Dict[str, Any], goal_category: str) -> Dict[str, Any
     # one "set"), so aerobic-oriented goals are measured in weekly aerobic
     # MINUTES against the WHO floor instead.
     if goal_category.lower() in {"endurance", "weight", "health"}:
-        weekly_minutes = []
-        for week, (sessions, _s, workouts_list) in zip(weeks, per_week):
-            if sessions == 0:
-                continue
-            minutes = sum(
-                int((w.get("customWorkout") or {}).get("durationMinutes") or 0)
-                for w in workouts_list
-                if ((w.get("customWorkout") or {}).get("type") or "").lower() in tk.AEROBIC_WORKOUT_TYPES
-            )
-            weekly_minutes.append(minutes)
-        avg_minutes = sum(weekly_minutes) / len(weekly_minutes) if weekly_minutes else 0
-        if avg_minutes < tk.WHO_AEROBIC_MIN_MINUTES:
+        # Aerobic minutes/week. A progressive plan starts low and BUILDS, so the
+        # whole-horizon average understates a good beginner plan (early base weeks
+        # drag it down). Judge the plan by whether it ever builds to an adequate
+        # dose: the peak non-deload week vs the WHO floor. A plan that never reaches
+        # the floor is genuinely under-dosing aerobic work for the goal.
+        weekly_minutes = [
+            _aerobic_minutes(workouts_list)
+            for week, (sessions, _s, workouts_list) in zip(weeks, per_week)
+            if sessions > 0 and not week.get("deloadWeek")
+        ]
+        peak_minutes = max(weekly_minutes) if weekly_minutes else 0
+        if peak_minutes < tk.WHO_AEROBIC_MIN_MINUTES:
             msg = (
-                f"~{avg_minutes:.0f} aerobic minutes/week is below the {tk.WHO_AEROBIC_MIN_MINUTES} "
-                f"recommended for a {goal_category} goal."
+                f"Aerobic volume peaks at ~{peak_minutes} min/week, below the "
+                f"{tk.WHO_AEROBIC_MIN_MINUTES} recommended for a {goal_category} goal — "
+                f"the plan should build key sessions longer."
             )
             # Strength-only training is a legitimate health plan (WHO also has
             # muscle-strengthening guidance) — advisory there, hard for
@@ -128,13 +175,19 @@ def validate_plan_doc(plan: Dict[str, Any], goal_category: str) -> Dict[str, Any
             f"Plans of {weeks_total} weeks benefit from a deload every {tk.DELOAD_EVERY_WEEKS_MIN}–{tk.DELOAD_EVERY_WEEKS_MAX} weeks; none is marked."
         )
 
-    # V5 ramp — flag aggressive week-over-week volume jumps
-    for i in range(1, len(sets_list)):
-        prev, cur = sets_list[i - 1], sets_list[i]
-        if prev > 0 and cur > prev * tk.WEEKLY_RAMP_HARD_FLAG:
-            violations.append(
-                f"Week {weeks[i].get('weekNumber')} volume jumps {((cur/prev)-1)*100:.0f}% over the prior week (aggressive)."
-            )
+    # V5 ramp — flag aggressive week-over-week volume jumps. Deload-aware: a
+    # deload week legitimately drops volume, so the rebuild after it (or the drop
+    # into it) is not an "aggressive jump". Skipped entirely for skeleton plans
+    # (see check_ramp docstring).
+    if check_ramp:
+        for i in range(1, len(sets_list)):
+            if weeks[i - 1].get("deloadWeek") or weeks[i].get("deloadWeek"):
+                continue
+            prev, cur = sets_list[i - 1], sets_list[i]
+            if prev > 0 and cur > prev * tk.WEEKLY_RAMP_HARD_FLAG:
+                violations.append(
+                    f"Week {weeks[i].get('weekNumber')} volume jumps {((cur/prev)-1)*100:.0f}% over the prior week (aggressive)."
+                )
 
     # V6 goal specificity — aerobic-oriented goals need aerobic work
     if goal_category.lower() in {"endurance", "health", "weight"} and not _has_aerobic(weeks):
@@ -264,6 +317,7 @@ async def validate_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -
         report = validate_plan_doc(
             {"schedule": {**(plan.get("schedule") or {}), "weeksTotal": len(resolved)}, "weeks": resolved},
             goal_category,
+            check_ramp=False,  # skeleton plans: ramp is checked by validate_skeleton
         )
         skel_report = validate_skeleton(
             skeleton, goal_category,

--- a/ai-coach-service/app/core/agents/text_utils.py
+++ b/ai-coach-service/app/core/agents/text_utils.py
@@ -1,0 +1,59 @@
+"""
+Small, pure text helpers for the coach's response pipeline.
+
+`dedupe_repeated_response` is a safety net for a specific gpt-5.4-mini failure
+mode: under the large system prompt the model sometimes emits its ENTIRE reply
+twice back-to-back (observed on the opening turn — "…run right now?\n…run right
+now?"). We collapse that exact full-duplication deterministically rather than
+letting it stream and persist doubled. Deliberately conservative: it only fires
+when the message body is two (near-)identical halves, so legitimately repetitive
+content (a plan listing the same exercise across weeks) is never touched.
+"""
+
+import re
+
+# Trailing structured blocks the model appends AFTER the (duplicated) prose —
+# these are the unique tail and must be preserved, not folded into the halves.
+_TAIL_RE = re.compile(r"(\n*<(?:quick-replies|video-embed|action-button)\b[\s\S]*)$", re.IGNORECASE)
+
+# Don't attempt on long messages (real programs/plans) — the doubling is a
+# conversational-reply failure; long structured answers don't exhibit it and we
+# won't risk a false collapse.
+_MAX_BODY = 4000
+_MIN_HALF = 20
+
+
+def _collapse_exact_double(body: str) -> str:
+    """If `body` is two identical halves separated only by whitespace, return one
+    half; else return body unchanged."""
+    b = body.strip()
+    n = len(b)
+    if n < 2 * _MIN_HALF or n > _MAX_BODY:
+        return body
+    mid = n // 2
+    # The separator between copies is whitespace (often a single "\n"), so the
+    # split point sits within a few chars of the midpoint — scan a small window.
+    for i in range(mid - 3, mid + 4):
+        if i <= 0 or i >= n:
+            continue
+        left, right = b[:i].strip(), b[i:].strip()
+        if len(left) >= _MIN_HALF and left == right:
+            return left
+    return body
+
+
+def dedupe_repeated_response(text: str) -> str:
+    """Collapse a fully-duplicated reply to a single copy. Preserves any trailing
+    quick-replies/video-embed/action-button block. No-op for normal text."""
+    if not text:
+        return text
+    m = _TAIL_RE.search(text)
+    tail = text[m.start():] if m else ""
+    body = text[: m.start()] if m else text
+
+    collapsed = _collapse_exact_double(body)
+    if collapsed == body:
+        return text  # nothing to do
+
+    tail = tail.strip()
+    return collapsed + ("\n\n" + tail if tail else "")

--- a/ai-coach-service/tests/test_generate_plan_skill.py
+++ b/ai-coach-service/tests/test_generate_plan_skill.py
@@ -84,7 +84,7 @@ def _llm_response(payload):
 
 
 def _make_ctx(profile=None, goal=None, create_ok=True, missing=None, skeleton=None,
-              planner_model=None):
+              planner_model=None, existing_draft=None):
     profile = profile if profile is not None else {
         "fitnessLevel": "intermediate",
         "preferences": {"equipment": ["barbell"], "workoutDays": [1, 3, 5]},
@@ -94,6 +94,8 @@ def _make_ctx(profile=None, goal=None, create_ok=True, missing=None, skeleton=No
     db = MagicMock()
     db.users.find_one = AsyncMock(return_value={"profile": profile})
     db.goals.find_one = AsyncMock(return_value=goal)
+    # Dedupe guard looks here for a reusable draft (None = none exists).
+    db.plans.find_one = AsyncMock(return_value=existing_draft)
 
     ctx = MagicMock()
     ctx.db = db
@@ -108,6 +110,9 @@ def _make_ctx(profile=None, goal=None, create_ok=True, missing=None, skeleton=No
     ctx.plan_service.create_plan = AsyncMock(
         return_value={"success": create_ok, "plan_id": str(ObjectId()) if create_ok else None,
                       "message": "" if create_ok else "fail"}
+    )
+    ctx.plan_service.update_plan_content = AsyncMock(
+        return_value={"success": True, "plan_id": str((existing_draft or {}).get("_id", ObjectId()))}
     )
     return ctx
 
@@ -197,3 +202,32 @@ class TestHandler:
         ctx = _make_ctx(create_ok=False)
         result = await generate_plan(ctx, str(ObjectId()), {"goal_text": "get stronger"})
         assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_returns_layered_overview(self):
+        ctx = _make_ctx()
+        result = await generate_plan(ctx, str(ObjectId()), {"goal_text": "get stronger", "weeks": 8})
+        ov = result["overview"]
+        assert [p["name"] for p in ov["phases"]] == ["Base", "Build"]
+        assert len(ov["weeks"]) == 8
+        assert ov["weeks"][0]["workoutTitles"]  # real content, not just counts
+
+    @pytest.mark.asyncio
+    async def test_dedupes_into_existing_draft(self):
+        existing = {"_id": ObjectId(), "status": "draft", "tags": ["ai-generated", "draft"],
+                    "description": "AI-generated draft for: get stronger"}
+        ctx = _make_ctx(existing_draft=existing)
+        result = await generate_plan(ctx, str(ObjectId()), {"goal_text": "get stronger", "weeks": 8})
+        assert result["success"] is True
+        assert result["reused_existing_draft"] is True
+        assert result["plan_id"] == str(existing["_id"])
+        ctx.plan_service.update_plan_content.assert_awaited_once()
+        ctx.plan_service.create_plan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_existing_draft_creates_new(self):
+        ctx = _make_ctx(existing_draft=None)
+        result = await generate_plan(ctx, str(ObjectId()), {"goal_text": "get stronger"})
+        assert result["reused_existing_draft"] is False
+        ctx.plan_service.create_plan.assert_awaited_once()
+        ctx.plan_service.update_plan_content.assert_not_called()

--- a/ai-coach-service/tests/test_plan_builder.py
+++ b/ai-coach-service/tests/test_plan_builder.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.core.agents.skills.plan_builder import (
     _scaled_sets,
+    build_plan_overview,
     build_plan_weeks_from_skeleton,
     build_week_stub,
     coerce_exercise_numbers,
@@ -58,6 +59,43 @@ def _skeleton(weeks_total=8):
         "deloadWeeks": [5],
         "milestones": [{"week": 4, "title": "Checkpoint", "criteria": "3 strict pull-ups"}],
     }
+
+
+class TestPlanOverview:
+    def _plan_weeks(self):
+        skel = normalize_skeleton(_skeleton(8), 8, 2)
+        return skel, build_plan_weeks_from_skeleton(skel, [1, 3], 8, horizon=4)
+
+    def test_overview_level_is_phases_and_milestones_only(self):
+        skel, weeks = self._plan_weeks()
+        ov = build_plan_overview(skel, weeks, level="overview")
+        assert [p["name"] for p in ov["phases"]] == ["Base", "Build"]
+        assert ov["phases"][0]["weekRange"] == [1, 4]
+        assert ov["milestones"][0]["criteria"] == "3 strict pull-ups"
+        assert "weeks" not in ov  # no per-week detail at this level
+
+    def test_weeks_level_summarizes_each_week(self):
+        skel, weeks = self._plan_weeks()
+        ov = build_plan_overview(skel, weeks, level="weeks")
+        assert len(ov["weeks"]) == 8
+        wk1 = ov["weeks"][0]
+        assert wk1["weekNumber"] == 1 and wk1["resolved"] is True
+        assert wk1["workoutTitles"]  # titles present, but not exercise detail
+        assert ov["weeks"][5]["resolved"] is False  # week 6 is a stub (horizon 4)
+
+    def test_week_level_drills_to_exercises(self):
+        skel, weeks = self._plan_weeks()
+        ov = build_plan_overview(skel, weeks, level="week", week_number=1)
+        wk = ov["week"]
+        assert wk["weekNumber"] == 1
+        assert wk["workouts"][0]["dayName"] in {"Monday", "Wednesday"}
+        ex = wk["workouts"][0]["exercises"][0]
+        assert "exerciseName" in ex and "sets" in ex
+
+    def test_week_level_missing_week_is_none(self):
+        skel, weeks = self._plan_weeks()
+        ov = build_plan_overview(skel, weeks, level="week", week_number=99)
+        assert ov["week"] is None
 
 
 class TestCoerce:

--- a/ai-coach-service/tests/test_show_plan_skill.py
+++ b/ai-coach-service/tests/test_show_plan_skill.py
@@ -1,0 +1,85 @@
+"""Tests for the show_plan skill (read-only layered plan view)."""
+
+import pytest
+from bson import ObjectId
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.agents.skills.show_plan_skill import show_plan
+
+
+def _plan():
+    return {
+        "_id": ObjectId(),
+        "userId": ObjectId(),
+        "name": "Beginner 10K Plan",
+        "status": "draft",
+        "schedule": {"weeksTotal": 8, "workoutsPerWeek": 3},
+        "skeleton": {
+            "phases": [{"name": "Base", "startWeek": 1, "endWeek": 8, "focus": "aerobic", "progression": "ramp"}],
+            "milestones": [{"week": 8, "title": "10K", "criteria": "run 10k"}],
+        },
+        "weeks": [
+            {"weekNumber": 1, "focus": "easy", "deloadWeek": False, "resolved": True,
+             "workouts": [{"dayOfWeek": 0, "customWorkout": {
+                 "title": "Easy Run", "type": "cardio", "durationMinutes": 40,
+                 "exercises": [{"exerciseName": "Easy Run", "sets": [{"reps": 1, "time": 1800}], "notes": "zone2"}]}}]},
+            {"weekNumber": 2, "focus": "build", "deloadWeek": False, "resolved": False, "workouts": []},
+        ],
+    }
+
+
+def _ctx(plan):
+    db = MagicMock()
+    db.plans.find_one = AsyncMock(return_value=plan)
+    ctx = MagicMock()
+    ctx.db = db
+    return ctx
+
+
+class TestShowPlan:
+    @pytest.mark.asyncio
+    async def test_overview_returns_phases(self):
+        plan = _plan()
+        ctx = _ctx(plan)
+        res = await show_plan(ctx, str(plan["userId"]), {"plan_id": str(plan["_id"]), "level": "overview"})
+        assert res["success"] is True
+        assert res["name"] == "Beginner 10K Plan"
+        assert res["overview"]["phases"][0]["name"] == "Base"
+        assert "weeks" not in res["overview"]
+
+    @pytest.mark.asyncio
+    async def test_weeks_level_lists_summaries(self):
+        plan = _plan()
+        res = await show_plan(_ctx(plan), str(plan["userId"]), {"level": "weeks"})
+        assert len(res["overview"]["weeks"]) == 2
+        assert res["overview"]["weeks"][0]["workoutTitles"] == ["Easy Run"]
+
+    @pytest.mark.asyncio
+    async def test_week_level_drills_to_exercises(self):
+        plan = _plan()
+        res = await show_plan(_ctx(plan), str(plan["userId"]), {"level": "week", "week_number": 1})
+        wk = res["overview"]["week"]
+        assert wk["workouts"][0]["exercises"][0]["exerciseName"] == "Easy Run"
+        assert wk["workouts"][0]["exercises"][0]["timeSeconds"] == 1800
+
+    @pytest.mark.asyncio
+    async def test_workout_level_filters_by_day(self):
+        plan = _plan()
+        res = await show_plan(_ctx(plan), str(plan["userId"]),
+                              {"level": "workout", "week_number": 1, "day_of_week": 0})
+        assert len(res["overview"]["week"]["workouts"]) == 1
+        assert res["overview"]["week"]["workouts"][0]["dayOfWeek"] == 0
+
+    @pytest.mark.asyncio
+    async def test_default_plan_used_when_no_id(self):
+        plan = _plan()
+        ctx = _ctx(plan)
+        await show_plan(ctx, str(plan["userId"]), {})
+        # queried for the user's most-recent non-completed plan
+        assert ctx.db.plans.find_one.await_args.args[0]["status"]["$in"] == ["draft", "active", "paused"]
+
+    @pytest.mark.asyncio
+    async def test_no_plan_found_offers_to_build(self):
+        res = await show_plan(_ctx(None), str(ObjectId()), {})
+        assert res["success"] is True
+        assert res.get("not_found") is True

--- a/ai-coach-service/tests/test_text_utils.py
+++ b/ai-coach-service/tests/test_text_utils.py
@@ -1,0 +1,38 @@
+"""Tests for dedupe_repeated_response (the gpt-5.4-mini stutter safety net)."""
+
+from app.core.agents.text_utils import dedupe_repeated_response as dedupe
+
+
+def test_collapses_exact_double_with_newline():
+    s = "How many days per week can you run?\nHow many days per week can you run?"
+    assert dedupe(s) == "How many days per week can you run?"
+
+
+def test_collapses_double_and_preserves_quick_replies():
+    body = "Yes — 10K in 3 months is realistic from where you are."
+    s = f"{body}\n{body}\n\n<quick-replies>\n- Let's do it\n- Not yet\n</quick-replies>"
+    out = dedupe(s)
+    assert out.count(body) == 1
+    assert "<quick-replies>" in out and "Let's do it" in out
+
+
+def test_leaves_normal_reply_untouched():
+    s = "What's your current longest run — 1 km, 3 km, or 5 km?"
+    assert dedupe(s) == s
+
+
+def test_does_not_collapse_legit_repetition():
+    # Two halves are NOT identical → must not fold.
+    s = "Week 1: Easy Run 3x. Week 2: Easy Run 3x. Week 3: Long Run once."
+    assert dedupe(s) == s
+
+
+def test_empty_and_none_safe():
+    assert dedupe("") == ""
+    assert dedupe(None) is None
+
+
+def test_ignores_long_bodies():
+    # A long structured answer that happens to have repetitive lines must be safe.
+    para = "Do 3 sets of squats and rest 90 seconds between sets for recovery. " * 80
+    assert dedupe(para) == para

--- a/ai-coach-service/tests/test_validate_plan_skill.py
+++ b/ai-coach-service/tests/test_validate_plan_skill.py
@@ -75,6 +75,66 @@ class TestValidatePlanDoc:
         report = validate_plan_doc(_good_strength_plan(), "endurance")
         assert any("aerobic" in s.lower() or "cardio" in s.lower() for s in report["suggestions"])
 
+    def test_ramp_skipped_for_skeleton_plans(self):
+        # Same aggressive week-2 jump, but with check_ramp=False (skeleton plans
+        # get their ramp check from validate_skeleton) it must NOT be flagged.
+        weeks = [
+            {"weekNumber": 1, "restDays": [0], "workouts": [_custom_workout(1, n_ex=2, sets_per=3)]},
+            {"weekNumber": 2, "restDays": [0], "workouts": [_custom_workout(1, n_ex=10, sets_per=5)]},
+        ]
+        plan = {"schedule": {"weeksTotal": 2}, "weeks": weeks}
+        assert any("jumps" in v for v in validate_plan_doc(plan, "strength")["violations"])
+        assert not any("jumps" in v for v in validate_plan_doc(plan, "strength", check_ramp=False)["violations"])
+
+    def test_ramp_deload_aware_no_false_positive_on_rebuild(self):
+        # A deload week (few sets) then a normal rebuild is NOT an aggressive jump.
+        weeks = [
+            {"weekNumber": 1, "restDays": [0, 6], "workouts": [_custom_workout(1), _custom_workout(3), _custom_workout(5)]},
+            {"weekNumber": 2, "deloadWeek": True, "restDays": [0, 6], "workouts": [_custom_workout(1, n_ex=2, sets_per=2)]},
+            {"weekNumber": 3, "restDays": [0, 6], "workouts": [_custom_workout(1), _custom_workout(3), _custom_workout(5)]},
+        ]
+        report = validate_plan_doc({"schedule": {"weeksTotal": 3}, "weeks": weeks}, "strength")
+        assert not any("jumps" in v for v in report["violations"])
+
+    def test_aerobic_counts_hybrid_timed_work(self):
+        # A hybrid session whose timed runs total 150 min should satisfy the floor
+        # even though its type isn't "cardio".
+        hybrid = {
+            "dayOfWeek": 1, "workoutType": "custom",
+            "customWorkout": {"title": "Run + Strength", "type": "hybrid", "durationMinutes": 60,
+                              "exercises": [
+                                  {"exerciseName": "Easy Run", "sets": [{"reps": 1, "time": 9000}]},  # 150 min
+                                  {"exerciseName": "Squat", "sets": [{"reps": 8}] * 3},
+                              ]},
+        }
+        weeks = [{"weekNumber": 1, "restDays": [0, 6], "workouts": [hybrid, _custom_workout(3, "cardio"), _custom_workout(5, "cardio")]}]
+        report = validate_plan_doc({"schedule": {"weeksTotal": 1}, "weeks": weeks}, "endurance", check_ramp=False)
+        assert not any("Aerobic volume" in v for v in report["violations"])
+
+    def test_aerobic_flags_when_never_reaches_floor(self):
+        # Cardio sessions that never build past ~90 min/week peak → flagged.
+        def short_cardio(day):
+            return {"dayOfWeek": day, "workoutType": "custom",
+                    "customWorkout": {"title": "Easy Run", "type": "cardio", "durationMinutes": 45,
+                                      "exercises": [{"exerciseName": "Easy Run", "sets": [{"reps": 1, "time": 2700}]}]}}  # 45 min
+        weeks = [{"weekNumber": wn, "restDays": [0, 6], "workouts": [short_cardio(1), short_cardio(3)]}
+                 for wn in range(1, 5)]
+        report = validate_plan_doc({"schedule": {"weeksTotal": 4}, "weeks": weeks}, "endurance", check_ramp=False)
+        assert any("Aerobic volume" in v for v in report["violations"])
+
+    def test_aerobic_peak_based_ignores_low_early_weeks(self):
+        # Beginner ramp: early weeks low, later weeks build past the floor → clean.
+        def cardio(day, minutes):
+            return {"dayOfWeek": day, "workoutType": "custom",
+                    "customWorkout": {"title": "Run", "type": "cardio", "durationMinutes": minutes,
+                                      "exercises": [{"exerciseName": "Run", "sets": [{"reps": 1, "time": minutes * 60}]}]}}
+        weeks = [
+            {"weekNumber": 1, "restDays": [0, 6], "workouts": [cardio(1, 30), cardio(3, 30), cardio(5, 30)]},  # 90
+            {"weekNumber": 2, "restDays": [0, 6], "workouts": [cardio(1, 60), cardio(3, 60), cardio(5, 60)]},  # 180 peak
+        ]
+        report = validate_plan_doc({"schedule": {"weeksTotal": 2}, "weeks": weeks}, "endurance", check_ramp=False)
+        assert not any("Aerobic volume" in v for v in report["violations"])
+
 
 def _make_ctx(plan, goal=None):
     db = MagicMock()


### PR DESCRIPTION
## Why

Reported: "plan generation is awful." Verified with **real LLM calls** and by reading prod conversations that the skeleton *content* is actually good on both `gpt-5.4-mini` and `gpt-5.4` — the failures were elsewhere. Three root causes, all fixed here.

## 1. Validator fired false violations on nearly every plan
- **Ramp check** flagged every normal post-deload rebuild / phase transition as an "aggressive jump." Now deload-aware and skipped for skeleton plans (the deload-aware skeleton check is authoritative).
- **Aerobic minutes** were undercounted — `hybrid` (strength+run) sessions were excluded and the low beginner/deload weeks dragged the average down. Now measured from actual timed work (incl. hybrid) and judged on the plan's built-up **peak** week.

## 2. The coach couldn't show or co-create the plan
- `generate_plan` now returns a **layered overview** (phases → weeks → workout titles) instead of bare counts (`plan_builder.build_plan_overview`).
- New **`show_plan`** read skill for progressive disclosure (`overview`/`weeks`/`week`/`workout`) — the path for "show me the plan", "what's in week 3".
- **Dedupe guard**: regenerating for the same goal category updates the existing draft instead of spawning duplicates (`plan_service.update_plan_content`, matched on a `cat:<category>` tag so goal-text rephrasing doesn't miss).
- **Prompt**: hard rule that multi-week plans MUST come from `generate_plan` and are shown via `show_plan` — the model was hand-writing fake plans in prose ("I didn't use the planner skill, I just mapped it manually"). Also fixed the stale "~2 weeks written out" (horizon is 12) and added progressive-disclosure guidance.
- Bumped planner `max_completion_tokens` 6000 → 12000 (long plans truncated into invalid JSON = total failure).

## 3. Duplicated-reply bug (gpt-5.4-mini stutter)
- Under the 28 KB system prompt the model sometimes emits its **entire reply twice** (isolated: full prompt dups 2/2, minimal prompt 0/2). Added `text_utils.dedupe_repeated_response` (conservative — only collapses an exact double, preserves trailing quick-replies), wired into streaming (emits a `revision` so the frontend replaces it), the non-streaming returns, and the SSE save path so the persisted message is single.

## Verification
- Full suite: **261 passed** (added `test_text_utils`, `test_show_plan_skill`, `build_plan_overview`, validator ramp/aerobic, generate_plan overview+dedupe).
- Drove the whole conversation end-to-end against real data: gather info → `generate_plan` → `show_plan` overview → `show_plan` week 1 (real Sun/Tue/Fri workouts). No false violations, no duplicated reply, no duplicate drafts.

## Follow-ups (not in this PR)
- **Set `OPENAI_MODEL_PLANNER=gpt-5.4` on the Render ai-coach service** (env is in the dashboard, not in repo; `.env` is gitignored).
- Root-cause the stutter by shrinking the 28 KB system prompt (safety net handles the symptom for now).
- Frontend `<plan-embed>` card is a separate track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)