### PR TITLE
feat(dashboard): redesign mobile Today view + memory-driven coach check-in

### DIFF
--- a/ai-coach-service/app/api/v1/coach_question.py
+++ b/ai-coach-service/app/api/v1/coach_question.py
@@ -1,0 +1,328 @@
+"""
+Coach question endpoint - generates a single, personalized readiness/check-in
+question for the Today dashboard, driven by the user's memories and recent
+training history.
+
+Unlike the chat suggestions endpoint (which returns conversation starters), this
+returns ONE short question the coach wants to ask right now, a small set of quick
+reply chips, and a provenance line so the athlete can see what the question was
+based on (and correct the coach if a memory is wrong).
+"""
+
+from fastapi import APIRouter, Depends, Body
+from typing import Dict, Any
+from datetime import datetime
+from zoneinfo import ZoneInfo
+import json
+import structlog
+from openai import AsyncOpenAI
+
+from app.config import get_settings
+from app.middleware.auth import get_current_user
+from app.core.agents.data_reader import DataReaderAgent
+from app.core.agents.prompts import SYSTEM_PROMPT
+from app.core.agents.services import MemoryService
+from app.services.conversation_service import ConversationService
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+COACH_QUESTION_PROMPT = """You are the athlete's coach opening their Today screen.
+Based on their profile, recent training, and memories above, write ONE short
+check-in question you genuinely want to ask them right now, before today's session.
+
+Rules:
+1. Ground the question in something specific you actually know - a recent workout,
+   a logged note, an injury/fatigue memory, a schedule constraint, or today's plan.
+   Do NOT invent facts that aren't in the context.
+2. Keep it to one or two sentences, warm and concise. Offer to adapt if relevant
+   (e.g. "I can ease the intervals if you need it").
+3. Provide 2-4 short quick-reply chips (each <= 14 chars) the athlete can tap to
+   answer. Order them best-state to worst-state where that makes sense
+   (e.g. "Fresh", "A bit heavy", "Cooked"). Do NOT pre-select one.
+4. Provide a short provenance label (<= 32 chars) naming what the question is based
+   on, e.g. "run log - Jul 10", "knee injury note", "your Tuesday plan".
+
+Return ONLY a JSON object, nothing else, in exactly this shape:
+{"question": "...", "chips": ["...", "..."], "source": "..."}"""
+
+
+FALLBACK_QUESTION = {
+    "question": "How are you feeling before today's session? I can adjust it if you need.",
+    "chips": ["Fresh", "A bit heavy", "Cooked"],
+    "source": "readiness check",
+}
+
+
+@router.get("")
+async def get_coach_question(
+    current_user: Dict[str, Any] = Depends(get_current_user)
+) -> Dict[str, Any]:
+    """
+    Generate a single memory-driven coach check-in question for the Today dashboard.
+    """
+    from app.main import db
+
+    settings = get_settings()
+    client = AsyncOpenAI(api_key=settings.openai_api_key)
+    data_reader = DataReaderAgent(db)
+    memory_service = MemoryService(db)
+
+    user_id = current_user["user_id"]
+
+    try:
+        user_context = {
+            "user_id": user_id,
+            "email": current_user.get("email"),
+            "username": current_user.get("username"),
+        }
+
+        # Read user data (profile, workouts, goals, plans)
+        data_context = await data_reader.process("", user_context)
+
+        # Load user memories
+        user_memories = await memory_service.get_user_memories(user_id)
+
+        user_profile = data_context.get("user_profile", {})
+        user_name = user_profile.get("name", "").strip()
+        timezone = user_profile.get("timezone") or "UTC"
+
+        try:
+            tz = ZoneInfo(timezone)
+            local_now = datetime.now(tz)
+        except Exception:
+            local_now = datetime.now()
+        local_time_str = local_now.strftime("%A, %B %d, %Y at %I:%M %p")
+        today_date = local_now.strftime("%Y-%m-%d")
+
+        # Summarise recent workouts so the question can reference them
+        recent_workouts = data_context.get("workouts", [])[:8]
+        workouts_str = ""
+        for w in recent_workouts:
+            title = w.get("title") or w.get("name") or "workout"
+            date = w.get("date") or w.get("completedAt") or ""
+            wtype = w.get("type") or (w.get("primary_disciplines") or [None])[0] or ""
+            note = w.get("feedback") or w.get("notes") or ""
+            line = f"\n- {date} {wtype} \"{title}\""
+            if note:
+                line += f" (note: {note})"
+            workouts_str += line
+
+        context_str = f"""CURRENT TIME:
+- User's local time: {local_time_str}
+- Today's date: {today_date}
+
+USER PROFILE:
+- Name: {user_name or 'not set'}
+- Fitness Level: {user_profile.get('fitnessLevel', 'not set')}
+- Goals: {', '.join(user_profile.get('goals', [])) or 'not specified'}
+- Sport Preferences: {', '.join(user_profile.get('sportPreferences', [])) or 'not specified'}
+
+RECENT WORKOUTS:{workouts_str or ' none logged recently'}
+
+USER DATA:
+- {len(data_context.get('goals', []))} active goals
+- {len(data_context.get('plans', []))} training plans"""
+
+        if user_memories:
+            memory_str = "\n\nUSER MEMORIES (important things about this user):"
+            for mem in user_memories[:15]:
+                category = mem.get("category", "general")
+                content = mem.get("content", "")
+                importance = mem.get("importance", "medium")
+                prefix = "HIGH PRIORITY: " if importance == "high" else "- "
+                memory_str += f"\n{prefix}[{category}] {content}"
+            context_str += memory_str
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"{context_str}\n\n{COACH_QUESTION_PROMPT}"},
+        ]
+
+        response = await client.chat.completions.create(
+            model=settings.openai_model_fast,
+            messages=messages,
+            max_completion_tokens=250,
+            **settings.llm_tuning_params(temperature=0.7),
+        )
+
+        response_text = response.choices[0].message.content.strip()
+
+        # Clean markdown fences if present
+        if response_text.startswith("```"):
+            response_text = response_text.split("```")[1]
+            if response_text.startswith("json"):
+                response_text = response_text[4:]
+        response_text = response_text.strip()
+
+        parsed = json.loads(response_text)
+
+        question = (parsed.get("question") or "").strip()
+        chips = parsed.get("chips") or []
+        source = (parsed.get("source") or "").strip()
+
+        if not question or not isinstance(chips, list) or len(chips) < 2:
+            raise ValueError("Invalid coach question format")
+
+        # Normalise chips to short strings
+        chips = [str(c).strip() for c in chips if str(c).strip()][:4]
+
+        logger.info(f"Generated coach question for user {user_id}: {question}")
+
+        return {
+            "success": True,
+            "question": question,
+            "chips": chips,
+            "source": source or "your training",
+        }
+
+    except Exception as e:
+        logger.error(f"Error generating coach question: {e}", exc_info=True)
+        return {
+            "success": True,
+            **FALLBACK_QUESTION,
+            "fallback": True,
+        }
+
+
+COACH_REPLY_PROMPT = """You are the athlete's coach, replying INLINE on their home
+(Today) screen — not in a full chat. They just answered your check-in question by
+tapping a quick reply.
+
+Write a VERY short response: 1-2 sentences, max ~30 words. Acknowledge their answer
+and, if relevant, state the one concrete adjustment you'll make to today's session
+(e.g. "I'll drop the intervals to steady Zone 2"). No greetings, no follow-up
+questions, no lists. This is a glanceable reply; the athlete can tap "Continue" to
+open a full conversation if they want more.
+
+Return ONLY a JSON object: {"reply": "..."}"""
+
+
+@router.post("/reply")
+async def post_coach_reply(
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    payload: Dict[str, Any] = Body(...),
+) -> Dict[str, Any]:
+    """
+    Given the coach's check-in question and the athlete's tapped answer, return a
+    very short, home-page-appropriate coach reply (with the option to continue in
+    the full Sensei chat).
+    """
+    from app.main import db
+
+    settings = get_settings()
+    client = AsyncOpenAI(api_key=settings.openai_api_key)
+    memory_service = MemoryService(db)
+
+    user_id = current_user["user_id"]
+    question = (payload.get("question") or "").strip()
+    answer = (payload.get("answer") or "").strip()
+
+    if not answer:
+        return {"success": False, "reply": ""}
+
+    try:
+        # Light context: memories only (kept small — this must be fast + short)
+        user_memories = await memory_service.get_user_memories(user_id)
+        memory_str = ""
+        if user_memories:
+            memory_str = "\n\nRELEVANT MEMORIES:"
+            for mem in user_memories[:8]:
+                category = mem.get("category", "general")
+                content = mem.get("content", "")
+                memory_str += f"\n- [{category}] {content}"
+
+        context = (
+            f'Your check-in question was: "{question}"\n'
+            f'The athlete tapped: "{answer}"{memory_str}'
+        )
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"{context}\n\n{COACH_REPLY_PROMPT}"},
+        ]
+
+        response = await client.chat.completions.create(
+            model=settings.openai_model_fast,
+            messages=messages,
+            max_completion_tokens=120,
+            **settings.llm_tuning_params(temperature=0.6),
+        )
+
+        response_text = response.choices[0].message.content.strip()
+        if response_text.startswith("```"):
+            response_text = response_text.split("```")[1]
+            if response_text.startswith("json"):
+                response_text = response_text[4:]
+        response_text = response_text.strip()
+
+        try:
+            reply = (json.loads(response_text).get("reply") or "").strip()
+        except Exception:
+            # Model returned plain text — use it directly, trimmed
+            reply = response_text.strip().strip('"')
+
+        if not reply:
+            raise ValueError("Empty reply")
+
+        logger.info(f"Coach inline reply for user {user_id}: {reply}")
+        return {"success": True, "reply": reply}
+
+    except Exception as e:
+        logger.error(f"Error generating coach reply: {e}", exc_info=True)
+        return {
+            "success": True,
+            "reply": "Got it — I've noted that. Tap continue if you want to talk it through.",
+            "fallback": True,
+        }
+
+
+@router.post("/continue")
+async def post_coach_continue(
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    payload: Dict[str, Any] = Body(...),
+) -> Dict[str, Any]:
+    """
+    Promote the home-screen mini check-in into a full, persisted conversation.
+
+    Creates a real ChatConversation seeded with the exact turns the athlete already
+    saw on the Today screen — the coach's question (assistant), the athlete's tapped
+    answer (human), and the coach's short reply (assistant) — then returns its
+    conversation_id so the client can open it in Sensei and keep chatting with full
+    context.
+    """
+    from app.main import db
+
+    user_id = current_user["user_id"]
+    question = (payload.get("question") or "").strip()
+    answer = (payload.get("answer") or "").strip()
+    reply = (payload.get("reply") or "").strip()
+
+    if not question or not answer:
+        return {"success": False, "message": "question and answer are required"}
+
+    try:
+        service = ConversationService(db)
+
+        created = await service.create_conversation(
+            user_id=user_id,
+            title=question[:60],
+        )
+        if not created.get("success"):
+            raise RuntimeError(created.get("message") or "create failed")
+
+        conversation_id = created["conversation_id"]
+
+        # Seed the turns the athlete already saw (roles: human=user, ai=assistant)
+        await service.add_message(conversation_id, "ai", question, user_id=user_id)
+        await service.add_message(conversation_id, "human", answer, user_id=user_id)
+        if reply:
+            await service.add_message(conversation_id, "ai", reply, user_id=user_id)
+
+        logger.info(f"Promoted coach check-in to conversation {conversation_id} for user {user_id}")
+        return {"success": True, "conversation_id": conversation_id}
+
+    except Exception as e:
+        logger.error(f"Error creating coach conversation: {e}", exc_info=True)
+        return {"success": False, "message": str(e)}

--- a/ai-coach-service/app/main.py
+++ b/ai-coach-service/app/main.py
@@ -7,7 +7,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 import redis.asyncio as redis
 
 from app.config import get_settings, Settings
-from app.api.v1 import health, chat, chat_stream, conversations, documents, exercises, internal, progressions, suggestions, train_now
+from app.api.v1 import health, chat, chat_stream, conversations, documents, exercises, internal, progressions, suggestions, train_now, coach_question
 from app.services.conversation_service import ConversationService
 
 logger = structlog.get_logger()
@@ -87,6 +87,7 @@ app.include_router(exercises.router, prefix="/api/v1/exercises", tags=["exercise
 app.include_router(progressions.router, prefix="/api/v1/progressions", tags=["progressions"])
 app.include_router(suggestions.router, prefix="/api/v1/suggestions", tags=["suggestions"])
 app.include_router(train_now.router, prefix="/api/v1/train-now", tags=["train-now"])
+app.include_router(coach_question.router, prefix="/api/v1/coach-question", tags=["coach-question"])
 app.include_router(internal.router, prefix="/api/v1/internal", tags=["internal"])
 
 

--- a/backend/src/routes/coachQuestion.js
+++ b/backend/src/routes/coachQuestion.js
@@ -1,0 +1,157 @@
+const express = require('express');
+const router = express.Router();
+const { auth: authMiddleware } = require('../middleware/auth');
+
+const AI_SERVICE_URL = process.env.AI_SERVICE_URL || 'http://localhost:8001';
+
+// Fallback returned when the AI service is unreachable
+const FALLBACK = {
+  success: true,
+  question: "How are you feeling before today's session? I can adjust it if you need.",
+  chips: ['Fresh', 'A bit heavy', 'Cooked'],
+  source: 'readiness check',
+  fallback: true
+};
+
+// GET /api/v1/coach-question - Get a memory-driven coach check-in question for Today
+router.get('/', authMiddleware, async (req, res) => {
+  try {
+    const url = `${AI_SERVICE_URL}/api/v1/coach-question`;
+    const urlParts = new URL(url);
+    const isHttps = urlParts.protocol === 'https:';
+    const http = require(isHttps ? 'https' : 'http');
+
+    const options = {
+      hostname: urlParts.hostname,
+      port: urlParts.port || (isHttps ? 443 : 80),
+      path: urlParts.pathname,
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': req.headers.authorization
+      }
+    };
+
+    const proxyReq = http.request(options, (proxyRes) => {
+      let data = '';
+      proxyRes.on('data', chunk => data += chunk);
+      proxyRes.on('end', () => {
+        try {
+          res.status(proxyRes.statusCode).json(JSON.parse(data));
+        } catch {
+          res.status(proxyRes.statusCode).send(data);
+        }
+      });
+    });
+
+    proxyReq.on('error', (error) => {
+      console.error('Error proxying to AI service:', error);
+      res.status(200).json(FALLBACK);
+    });
+
+    proxyReq.end();
+  } catch (error) {
+    console.error('Error fetching coach question:', error);
+    res.status(200).json(FALLBACK);
+  }
+});
+
+// POST /api/v1/coach-question/reply - Short inline coach reply to a tapped answer
+router.post('/reply', authMiddleware, async (req, res) => {
+  const REPLY_FALLBACK = {
+    success: true,
+    reply: "Got it — I've noted that. Tap continue if you want to talk it through.",
+    fallback: true
+  };
+
+  try {
+    const body = JSON.stringify(req.body || {});
+    const url = `${AI_SERVICE_URL}/api/v1/coach-question/reply`;
+    const urlParts = new URL(url);
+    const isHttps = urlParts.protocol === 'https:';
+    const http = require(isHttps ? 'https' : 'http');
+
+    const options = {
+      hostname: urlParts.hostname,
+      port: urlParts.port || (isHttps ? 443 : 80),
+      path: urlParts.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        'Authorization': req.headers.authorization
+      }
+    };
+
+    const proxyReq = http.request(options, (proxyRes) => {
+      let data = '';
+      proxyRes.on('data', chunk => data += chunk);
+      proxyRes.on('end', () => {
+        try {
+          res.status(proxyRes.statusCode).json(JSON.parse(data));
+        } catch {
+          res.status(proxyRes.statusCode).send(data);
+        }
+      });
+    });
+
+    proxyReq.on('error', (error) => {
+      console.error('Error proxying coach reply to AI service:', error);
+      res.status(200).json(REPLY_FALLBACK);
+    });
+
+    proxyReq.write(body);
+    proxyReq.end();
+  } catch (error) {
+    console.error('Error fetching coach reply:', error);
+    res.status(200).json(REPLY_FALLBACK);
+  }
+});
+
+// POST /api/v1/coach-question/continue - Promote the mini check-in into a full conversation
+router.post('/continue', authMiddleware, async (req, res) => {
+  try {
+    const body = JSON.stringify(req.body || {});
+    const url = `${AI_SERVICE_URL}/api/v1/coach-question/continue`;
+    const urlParts = new URL(url);
+    const isHttps = urlParts.protocol === 'https:';
+    const http = require(isHttps ? 'https' : 'http');
+
+    const options = {
+      hostname: urlParts.hostname,
+      port: urlParts.port || (isHttps ? 443 : 80),
+      path: urlParts.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        'Authorization': req.headers.authorization
+      }
+    };
+
+    const proxyReq = http.request(options, (proxyRes) => {
+      let data = '';
+      proxyRes.on('data', chunk => data += chunk);
+      proxyRes.on('end', () => {
+        try {
+          res.status(proxyRes.statusCode).json(JSON.parse(data));
+        } catch {
+          res.status(proxyRes.statusCode).send(data);
+        }
+      });
+    });
+
+    proxyReq.on('error', (error) => {
+      console.error('Error proxying coach continue to AI service:', error);
+      res.status(200).json({ success: false, message: 'AI service unavailable' });
+    });
+
+    proxyReq.write(body);
+    proxyReq.end();
+  } catch (error) {
+    console.error('Error creating coach conversation:', error);
+    res.status(200).json({ success: false, message: 'error' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -55,6 +55,7 @@ const integrationRoutes = require('./routes/integrations');
 const webhookRoutes = require('./routes/webhooks');
 const workoutLogRoutes = require('./routes/workoutLogs');
 const trainNowRoutes = require('./routes/trainNow');
+const coachQuestionRoutes = require('./routes/coachQuestion');
 const mcpAuthRoutes = require('./routes/mcpAuth');
 const mcpRoutes = require('./routes/mcp');
 
@@ -286,6 +287,7 @@ app.use('/api/v1/integrations', integrationRoutes);
 app.use('/api/v1/webhooks', webhookRoutes);
 app.use('/api/v1/workout-logs', workoutLogRoutes);
 app.use('/api/v1/train-now', trainNowRoutes);
+app.use('/api/v1/coach-question', coachQuestionRoutes);
 
 // MCP connector: OAuth authorization-server routes (mounted at root — the
 // `.well-known` discovery documents are origin-rooted) and the /mcp endpoint.

--- a/frontend/src/components/dashboard/TodayView.css
+++ b/frontend/src/components/dashboard/TodayView.css
@@ -1,0 +1,212 @@
+/* ============================================================
+   Today dashboard view — "Claudy" warm-paper shell + Torii colors
+   Scoped under .today-view. Dark mode via app's `.dark` ancestor.
+   ============================================================ */
+.today-view {
+  --tv-surface-1: #F5F4EE;
+  --tv-surface-2: #FFFFFF;
+  --tv-text-primary: #23221E;
+  --tv-text-secondary: #6E6B62;
+  --tv-text-muted: #9C998E;
+  --tv-border: #E7E4DA;
+  --tv-border-strong: #D9D5C8;
+  --tv-border-stronger: #C7C2B3;
+  --tv-fill-primary: #23221E;
+  --tv-on-primary: #F5F4EE;
+
+  --tv-accent: #FF6B52;
+  --tv-accent-strong: #FF5238;
+
+  --tv-success: #16A34A;
+  --tv-success-tint: #EAF7EE;
+
+  --tv-sparkle-bg: #F0ECFF;
+  --tv-sparkle-fg: #7C6FE6;
+
+  background: var(--tv-surface-1);
+  color: var(--tv-text-primary);
+  min-height: 100%;
+  border-radius: 20px;
+  padding: 14px 12px;
+  -webkit-font-smoothing: antialiased;
+}
+
+.dark .today-view {
+  --tv-surface-1: #232219;
+  --tv-surface-2: #2B2A20;
+  --tv-text-primary: #F2F0E8;
+  --tv-text-secondary: #A6A296;
+  --tv-text-muted: #77746A;
+  --tv-border: #3A3830;
+  --tv-border-strong: #454339;
+  --tv-border-stronger: #524F43;
+  --tv-fill-primary: #F2F0E8;
+  --tv-on-primary: #232219;
+  --tv-success-tint: #1c2b20;
+  --tv-sparkle-bg: #2c2740;
+  --tv-sparkle-fg: #b3a6ff;
+}
+
+.today-view * { box-sizing: border-box; }
+
+.tv-stack { display: flex; flex-direction: column; gap: 12px; }
+
+.tv-ico { width: 16px; height: 16px; }
+.tv-ico-sm { width: 12px; height: 12px; }
+.tv-muted { color: var(--tv-text-muted); }
+
+/* section head */
+.tv-goals-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 2px 4px 0;
+}
+.tv-h { font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
+.tv-all { font-size: 11px; color: var(--tv-text-muted); cursor: pointer; }
+
+/* GOALS */
+.tv-goals { display: flex; gap: 8px; }
+.tv-goal {
+  flex: 1; min-width: 0;
+  background: var(--tv-surface-2);
+  border: 0.5px solid var(--tv-border);
+  border-radius: 14px; padding: 11px 12px;
+  cursor: pointer;
+}
+.tv-goal-empty { display: flex; flex-direction: column; justify-content: center; }
+.tv-goal-kicker {
+  font-size: 10px; font-weight: 600; letter-spacing: .05em; text-transform: uppercase;
+  color: var(--goal-c);
+  display: flex; align-items: center; gap: 5px;
+}
+.tv-swatch { width: 7px; height: 7px; border-radius: 2px; flex: 0 0 auto; background: var(--goal-c); }
+.tv-goal-title {
+  font-size: 13px; font-weight: 600; margin-top: 5px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.tv-goal-sub { font-size: 10.5px; color: var(--tv-text-secondary); margin-top: 2px; }
+.tv-goal-track { height: 4px; border-radius: 2px; background: var(--tv-border); margin-top: 9px; overflow: hidden; }
+.tv-goal-fill { height: 100%; border-radius: 2px; background: var(--goal-c); }
+
+/* HERO */
+.tv-hero {
+  background: var(--tv-surface-2);
+  border: 0.5px solid var(--tv-border);
+  border-radius: 16px; padding: 16px;
+}
+.tv-hero-kicker {
+  display: flex; align-items: center; gap: 7px;
+  font-size: 12px; font-weight: 600; letter-spacing: .01em;
+}
+.tv-hero-title { font-size: 23px; font-weight: 600; letter-spacing: -0.02em; margin: 8px 0 3px; }
+.tv-hero-meta { font-size: 12.5px; color: var(--tv-text-secondary); margin-bottom: 14px; }
+.tv-cta {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  background: var(--tv-accent); color: #fff;
+  border: none; width: 100%;
+  border-radius: 12px; padding: 13px;
+  font: inherit; font-size: 14.5px; font-weight: 600; letter-spacing: -0.01em;
+  cursor: pointer; transition: background .2s ease;
+}
+.tv-cta:hover { background: var(--tv-accent-strong); }
+.tv-horizon {
+  display: flex; align-items: center; gap: 6px; justify-content: center;
+  font-size: 11px; color: var(--tv-text-muted); padding: 9px 4px 0;
+}
+
+/* COACH */
+.tv-coach {
+  border: 0.5px solid var(--tv-border);
+  background: var(--tv-surface-2);
+  border-radius: 14px; padding: 13px;
+  display: flex; align-items: flex-start; gap: 10px;
+}
+.tv-sparkle {
+  width: 27px; height: 27px; border-radius: 50%;
+  background: var(--tv-sparkle-bg); color: var(--tv-sparkle-fg);
+  display: flex; align-items: center; justify-content: center; flex: 0 0 auto;
+}
+.tv-coach-body { flex: 1; min-width: 0; }
+.tv-coach-text { font-size: 12.75px; line-height: 1.5; }
+.tv-coach-src {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; color: var(--tv-text-muted); margin-top: 7px;
+}
+.tv-chips { display: flex; gap: 6px; margin-top: 9px; flex-wrap: wrap; }
+.tv-chip {
+  font-size: 11.5px; font-weight: 500; padding: 6px 12px; border-radius: 999px;
+  border: 0.5px solid var(--tv-border-strong); color: var(--tv-text-secondary);
+  background: transparent; cursor: pointer; transition: all .18s ease;
+}
+.tv-chip:hover { border-color: var(--tv-success); color: var(--tv-success); background: var(--tv-success-tint); }
+.tv-coach-x { color: var(--tv-text-muted); cursor: pointer; flex: 0 0 auto; }
+
+/* Coach answered / inline reply */
+.tv-coach-answered { margin-top: 9px; }
+.tv-answer-pill {
+  display: inline-block;
+  font-size: 11px; font-weight: 600;
+  padding: 4px 10px; border-radius: 999px;
+  background: var(--tv-success-tint); color: var(--tv-success);
+  border: 0.5px solid var(--tv-success);
+}
+.tv-coach-reply {
+  font-size: 12.5px; line-height: 1.5;
+  color: var(--tv-text-primary);
+  margin-top: 8px;
+}
+.tv-continue {
+  display: inline-flex; align-items: center; gap: 3px;
+  margin-top: 10px;
+  font: inherit; font-size: 12px; font-weight: 600;
+  color: var(--tv-accent);
+  background: transparent; border: none; padding: 0; cursor: pointer;
+}
+.tv-continue:hover { color: var(--tv-accent-strong); }
+
+/* Typing indicator while the reply loads */
+.tv-typing { display: flex; align-items: center; gap: 4px; }
+.tv-typing span {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--tv-text-muted);
+  animation: tv-bounce 1.2s infinite ease-in-out;
+}
+.tv-typing span:nth-child(2) { animation-delay: .15s; }
+.tv-typing span:nth-child(3) { animation-delay: .3s; }
+@keyframes tv-bounce {
+  0%, 80%, 100% { opacity: .3; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-3px); }
+}
+
+/* PROGRESSION LADDER */
+.tv-prog {
+  border: 0.5px solid var(--tv-border);
+  background: var(--tv-surface-2);
+  border-radius: 14px; padding: 12px; cursor: pointer;
+}
+.tv-prog-head { display: flex; justify-content: space-between; align-items: center; }
+.tv-prog-title { font-size: 13.5px; font-weight: 600; }
+.tv-ladder { display: flex; align-items: flex-start; margin-top: 12px; }
+.tv-rung { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 6px; position: relative; }
+.tv-node {
+  width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--tv-surface-2);
+  border: 1.5px solid var(--tv-border-stronger);
+  color: var(--tv-text-muted); z-index: 1;
+}
+.tv-node-ico { width: 11px; height: 11px; }
+.tv-node-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--rung-c); }
+.tv-rung.done .tv-node { background: var(--rung-c); border-color: var(--rung-c); color: #fff; }
+.tv-rung.now .tv-node {
+  border-color: var(--rung-c);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--rung-c) 18%, transparent);
+}
+.tv-lbl { font-size: 9px; text-align: center; color: var(--tv-text-muted); line-height: 1.25; max-width: 64px; }
+.tv-rung.done .tv-lbl { color: var(--tv-text-secondary); }
+.tv-rung.now .tv-lbl { color: var(--tv-text-primary); font-weight: 600; }
+.tv-rung::before {
+  content: ""; position: absolute; top: 10px; left: -50%; width: 100%; height: 1.5px;
+  background: var(--tv-border-stronger);
+}
+.tv-rung:first-child::before { display: none; }
+.tv-rung.done::before, .tv-rung.now::before { background: var(--rung-c); }

--- a/frontend/src/components/dashboard/TodayView.jsx
+++ b/frontend/src/components/dashboard/TodayView.jsx
@@ -1,0 +1,420 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { createPageUrl } from "@/utils";
+import { CalendarEvent, UserGoalProgress } from "@/api/entities";
+import apiService from "@/services/api";
+import aiService from "@/services/aiService";
+import { getDisciplineColor } from "@/styles/designTokens";
+import {
+  Play, Sparkles, X, ChevronRight, ArrowRight, Check, Bike, Dumbbell,
+} from "lucide-react";
+import { format, parseISO, isValid } from "date-fns";
+import "./TodayView.css";
+
+// Goal identity hue by category (kept distinct from the coral action color)
+const GOAL_COLORS = {
+  event: "#6366F1",        // app secondary indigo
+  competition: "#6366F1",
+  outcome: "#22C55E",      // running green
+  endurance: "#22C55E",
+  skill: "#CA8A04",        // calisthenics yellow
+  strength: "#2563EB",
+  default: "#6366F1",
+};
+
+const goalColor = (category) =>
+  GOAL_COLORS[(category || "").toLowerCase()] || GOAL_COLORS.default;
+
+// Map a workout/discipline type to its dashboard hue
+const typeColor = (type) => getDisciplineColor(type) || "#A855F7";
+
+function fmtTime(dateStr) {
+  if (!dateStr) return null;
+  const d = parseISO(dateStr);
+  if (!isValid(d)) return null;
+  return format(d, "HH:mm");
+}
+
+export default function TodayView() {
+  const navigate = useNavigate();
+  const [goals, setGoals] = useState([]);
+  const [session, setSession] = useState(null);
+  const [coach, setCoach] = useState(null);
+  const [coachDismissed, setCoachDismissed] = useState(false);
+  const [coachAnswer, setCoachAnswer] = useState(null);
+  const [coachReply, setCoachReply] = useState(null);
+  const [coachReplyLoading, setCoachReplyLoading] = useState(false);
+  const [continuing, setContinuing] = useState(false);
+  const [progression, setProgression] = useState(null);
+  const [horizon, setHorizon] = useState([]);
+
+  useEffect(() => {
+    let alive = true;
+
+    // Goals — active, top 2
+    UserGoalProgress.list()
+      .then((data) => {
+        if (!alive) return;
+        const active = (Array.isArray(data) ? data : [])
+          .filter((g) => g.is_active && !g.completed_date)
+          .slice(0, 2);
+        setGoals(active);
+      })
+      .catch(() => {});
+
+    // Today's session — first not-yet-done calendar event, else cached AI suggestion
+    CalendarEvent.today()
+      .then((events) => {
+        if (!alive) return;
+        const list = Array.isArray(events) ? events : [];
+        const next =
+          list.find((e) => (e.status || "scheduled") !== "completed") || list[0];
+        if (next) {
+          setSession({
+            title: next.title,
+            type: next.workoutDetails?.type || next.eventType || "Workout",
+            time: fmtTime(next.date),
+            duration:
+              next.workoutDetails?.durationMinutes ||
+              next.workoutDetails?.estimatedDuration ||
+              null,
+            exercises: next.workoutDetails?.exercises?.length || null,
+            eventId: next.id,
+          });
+        } else {
+          const cached = aiService.getCachedTodayWorkout();
+          if (cached?.suggestion) {
+            const s = cached.suggestion;
+            setSession({
+              title: s.name || s.title,
+              type: s.type || s.primary_disciplines?.[0] || "Workout",
+              time: null,
+              duration: s.estimated_duration || s.duration_minutes || null,
+              exercises: s.exercises?.length || s.blocks?.length || null,
+              eventId: null,
+            });
+          }
+        }
+      })
+      .catch(() => {});
+
+    // Coach question — memory-driven
+    aiService
+      .getCoachQuestion()
+      .then((q) => {
+        if (alive && q) setCoach(q);
+      })
+      .catch(() => {});
+
+    // Progression — first in-progress skill ladder
+    apiService.progressions
+      .list()
+      .then((data) => {
+        if (!alive) return;
+        const list = Array.isArray(data) ? data : [];
+        const active =
+          list.find((p) => p.userProgress?.status === "in_progress") || list[0];
+        if (active) setProgression(active);
+      })
+      .catch(() => {});
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const startSession = () => {
+    if (session?.eventId) {
+      navigate(createPageUrl(`Calendar`));
+    } else {
+      navigate(createPageUrl("TrainNow"));
+    }
+  };
+
+  // Tap an answer chip → short inline coach reply (no navigation)
+  const handleCoachAnswer = async (chip) => {
+    if (coachAnswer) return;
+    setCoachAnswer(chip);
+    setCoachReplyLoading(true);
+    const reply = await aiService.getCoachReply(coach.question, chip);
+    setCoachReply(
+      reply || "Got it — I've noted that. Tap continue if you want to talk it through."
+    );
+    setCoachReplyLoading(false);
+  };
+
+  // Promote the mini check-in into a full, persisted conversation, then open it
+  const continueInSensei = async () => {
+    if (continuing) return;
+    setContinuing(true);
+    const convId = await aiService.continueCoachConversation(
+      coach.question,
+      coachAnswer,
+      coachReply
+    );
+    if (convId) {
+      try {
+        localStorage.setItem("openConversationId", convId);
+        localStorage.setItem("openConversationTime", String(Date.now()));
+      } catch {
+        /* ignore storage errors */
+      }
+    }
+    navigate(createPageUrl("Chat"));
+  };
+
+  // Build a compact ladder (<=5 rungs) centered on the current step
+  const rungs = buildRungs(progression);
+
+  return (
+    <div className="today-view">
+      <div className="tv-stack">
+        {/* GOALS — on top */}
+        <div className="tv-goals-head">
+          <span className="tv-h">Your goals</span>
+          <span className="tv-all" onClick={() => navigate(createPageUrl("Goals"))}>
+            See all
+          </span>
+        </div>
+        <div className="tv-goals">
+          {goals.length > 0 ? (
+            goals.map((g) => {
+              const c = goalColor(g.category || "skill");
+              const pct = Math.min(((g.current_level || 0) / 10) * 100, 100);
+              return (
+                <div
+                  key={g.id}
+                  className="tv-goal"
+                  style={{ "--goal-c": c }}
+                  onClick={() =>
+                    navigate(createPageUrl(`Goals?goal=${g.goal_id}`))
+                  }
+                >
+                  <div className="tv-goal-kicker">
+                    <span className="tv-swatch" />
+                    {g.category || "Goal"}
+                  </div>
+                  <div className="tv-goal-title">{g.goal_name}</div>
+                  <div className="tv-goal-sub">Level {g.current_level || 0}</div>
+                  <div className="tv-goal-track">
+                    <div className="tv-goal-fill" style={{ width: `${pct}%` }} />
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <div
+              className="tv-goal tv-goal-empty"
+              style={{ "--goal-c": GOAL_COLORS.default }}
+              onClick={() => navigate(createPageUrl("Goals"))}
+            >
+              <div className="tv-goal-title">Set a goal</div>
+              <div className="tv-goal-sub">Pick something to train toward</div>
+            </div>
+          )}
+        </div>
+
+        {/* HERO SESSION */}
+        <div className="tv-hero">
+          {session ? (
+            <>
+              <div className="tv-hero-kicker" style={{ color: typeColor(session.type) }}>
+                <SessionIcon type={session.type} />
+                {capitalize(session.type)}
+                {session.time ? ` · ${session.time}` : ""}
+              </div>
+              <div className="tv-hero-title">{session.title}</div>
+              <div className="tv-hero-meta">{sessionMeta(session)}</div>
+              <button className="tv-cta" onClick={startSession}>
+                <Play className="tv-ico" fill="currentColor" strokeWidth={0} />
+                Start session
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="tv-hero-kicker" style={{ color: "var(--tv-accent)" }}>
+                <Sparkles className="tv-ico" />
+                Nothing scheduled
+              </div>
+              <div className="tv-hero-title">Free day</div>
+              <div className="tv-hero-meta">
+                Log a session or let the coach suggest one.
+              </div>
+              <button className="tv-cta" onClick={() => navigate(createPageUrl("TrainNow"))}>
+                <Play className="tv-ico" fill="currentColor" strokeWidth={0} />
+                Train now
+              </button>
+            </>
+          )}
+          {horizon.length > 0 && (
+            <div className="tv-horizon">
+              <ArrowRight className="tv-ico-sm" />
+              {horizon.join(" · ")}
+            </div>
+          )}
+        </div>
+
+        {/* COACH QUESTION — memory-driven */}
+        {coach && !coachDismissed && (
+          <div className="tv-coach">
+            <span className="tv-sparkle">
+              <Sparkles className="tv-ico" />
+            </span>
+            <div className="tv-coach-body">
+              <div className="tv-coach-text">{coach.question}</div>
+
+              {!coachAnswer ? (
+                <>
+                  <div className="tv-chips">
+                    {coach.chips.map((chip, i) => (
+                      <button
+                        key={i}
+                        className="tv-chip"
+                        onClick={() => handleCoachAnswer(chip)}
+                      >
+                        {chip}
+                      </button>
+                    ))}
+                  </div>
+                  {coach.source && (
+                    <span className="tv-coach-src">
+                      <Sparkles className="tv-ico-sm" />
+                      From memory — {coach.source}
+                    </span>
+                  )}
+                </>
+              ) : (
+                <div className="tv-coach-answered">
+                  <span className="tv-answer-pill">{coachAnswer}</span>
+                  {coachReplyLoading ? (
+                    <div className="tv-coach-reply tv-typing">
+                      <span /><span /><span />
+                    </div>
+                  ) : (
+                    <>
+                      <div className="tv-coach-reply">{coachReply}</div>
+                      <button
+                        className="tv-continue"
+                        onClick={continueInSensei}
+                        disabled={continuing}
+                      >
+                        {continuing ? "Opening…" : "Continue with Sensei"}
+                        {!continuing && <ChevronRight className="tv-ico-sm" />}
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+            <span className="tv-coach-x" onClick={() => setCoachDismissed(true)}>
+              <X className="tv-ico-sm" />
+            </span>
+          </div>
+        )}
+
+        {/* PROGRESSION — horizontal ladder */}
+        {progression && rungs.length > 0 && (
+          <>
+            <div className="tv-goals-head">
+              <span className="tv-h">Progression</span>
+              <span
+                className="tv-all"
+                onClick={() => navigate(createPageUrl("Progressions"))}
+              >
+                See all
+              </span>
+            </div>
+            <div
+              className="tv-prog"
+              onClick={() => navigate(createPageUrl("Progressions"))}
+            >
+              <div className="tv-prog-head">
+                <span className="tv-prog-title">
+                  {progression.goalExercise?.name || progression.name}
+                </span>
+                <ChevronRight className="tv-ico-sm tv-muted" />
+              </div>
+              <div className="tv-ladder">
+                {rungs.map((r, i) => (
+                  <div
+                    key={i}
+                    className={`tv-rung ${r.state}`}
+                    style={{ "--rung-c": "#CA8A04" }}
+                  >
+                    <span className="tv-node">
+                      {r.state === "done" ? (
+                        <Check className="tv-node-ico" strokeWidth={3} />
+                      ) : r.state === "now" ? (
+                        <span className="tv-node-dot" />
+                      ) : null}
+                    </span>
+                    <span className="tv-lbl">{r.label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SessionIcon({ type }) {
+  const t = (type || "").toLowerCase();
+  if (t.includes("cycl") || t.includes("ride") || t.includes("bike")) {
+    return <Bike className="tv-ico" />;
+  }
+  return <Dumbbell className="tv-ico" />;
+}
+
+function capitalize(s) {
+  if (!s) return "";
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function sessionMeta(session) {
+  const parts = [];
+  if (session.duration) parts.push(`${session.duration} min`);
+  if (session.exercises) parts.push(`${session.exercises} exercises`);
+  return parts.join(" · ") || "Tap to begin";
+}
+
+// Produce up to 5 rungs, marking completed / current / upcoming
+function buildRungs(progression) {
+  if (!progression?.steps?.length) return [];
+  const steps = progression.steps;
+  const currentIdx = Math.max(
+    0,
+    steps.findIndex((s) => !isStepDone(s, progression.userProgress))
+  );
+
+  const withState = steps.map((s, i) => ({
+    label: s.name || s.exercise?.name || `Step ${i + 1}`,
+    state:
+      isStepDone(s, progression.userProgress)
+        ? "done"
+        : i === currentIdx
+        ? "now"
+        : "todo",
+  }));
+
+  // Window of 5 centered on current
+  if (withState.length <= 5) return withState;
+  let start = Math.max(0, currentIdx - 2);
+  let end = Math.min(withState.length, start + 5);
+  start = Math.max(0, end - 5);
+  return withState.slice(start, end);
+}
+
+function isStepDone(step, userProgress) {
+  const completed =
+    userProgress?.completedSteps ||
+    userProgress?.completed_steps ||
+    [];
+  const id = step._id || step.id;
+  if (Array.isArray(completed) && id) {
+    return completed.some((c) => String(c) === String(id));
+  }
+  return step.isCompleted === true || step.completed === true;
+}

--- a/frontend/src/pages/ChatWithStreaming.jsx
+++ b/frontend/src/pages/ChatWithStreaming.jsx
@@ -135,6 +135,7 @@ export default function ChatWithStreaming() {
   const messagesEndRef = useRef(null);
   const inputRef = useRef(null);
   const hasProcessedPendingRef = useRef(false); // To prevent double-processing
+  const hasProcessedOpenConvRef = useRef(false); // For opening a specific conversation once
 
   // Streaming hook
   const {
@@ -204,6 +205,26 @@ export default function ChatWithStreaming() {
 
     loadUserAndHistory();
   }, []);
+
+  // Open a specific conversation requested from another screen (e.g. the Today
+  // dashboard's "Continue with Sensei"). The conversation was already created and
+  // seeded server-side, so we just load it — no message is re-sent.
+  useEffect(() => {
+    if (!authToken || isLoadingHistory) return;
+    if (hasProcessedOpenConvRef.current) return;
+
+    const convId = localStorage.getItem('openConversationId');
+    const convTime = localStorage.getItem('openConversationTime');
+    if (convId && convTime) {
+      const age = Date.now() - parseInt(convTime, 10);
+      localStorage.removeItem('openConversationId');
+      localStorage.removeItem('openConversationTime');
+      if (age < 30000) {
+        hasProcessedOpenConvRef.current = true;
+        loadConversation(convId);
+      }
+    }
+  }, [authToken, isLoadingHistory]);
 
   // Process pending auto-send message (from WorkoutSelectionModal or other sources)
   useEffect(() => {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { createPageUrl } from "@/utils";
 import BodyRegionChart from "../components/dashboard/BodyRegionChart";
 import WeeklyOptimization from "../components/dashboard/WeeklyOptimization"; // New import
+import TodayView from "../components/dashboard/TodayView";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -225,20 +226,33 @@ export default function Dashboard() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="animate-pulse h-8 bg-gray-200 rounded w-64"></div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {Array(3).fill(0).map((_, i) => (
-            <div key={i} className="animate-pulse bg-gray-200 h-24 rounded-xl"></div>
-          ))}
+      <>
+        {/* Mobile Today view loads its own data independently of the desktop dashboard */}
+        <div className="md:hidden -m-4">
+          <TodayView />
         </div>
-        <div className="animate-pulse h-64 bg-gray-200 rounded-xl"></div>
-      </div>
+        <div className="hidden md:block space-y-6">
+          <div className="animate-pulse h-8 bg-gray-200 rounded w-64"></div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {Array(3).fill(0).map((_, i) => (
+              <div key={i} className="animate-pulse bg-gray-200 h-24 rounded-xl"></div>
+            ))}
+          </div>
+          <div className="animate-pulse h-64 bg-gray-200 rounded-xl"></div>
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="space-y-8">
+    <>
+    {/* Mobile: redesigned Today view */}
+    <div className="md:hidden -m-4">
+      <TodayView />
+    </div>
+
+    {/* Desktop: existing dashboard */}
+    <div className="hidden md:block space-y-8">
       {/* Header with View Toggle */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
@@ -560,5 +574,6 @@ export default function Dashboard() {
         </div>
       )}
     </div>
+    </>
   );
 }

--- a/frontend/src/pages/Layout.jsx
+++ b/frontend/src/pages/Layout.jsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link, useLocation, useNavigate, Outlet } from "react-router-dom";
 import { createPageUrl } from "@/utils";
-import { Activity, Calendar, Dumbbell, Zap, Target, FileText, Bot, TrendingUp, Settings, MessageSquare, Shield, Cog, Play } from "lucide-react";
+import { Activity, Calendar, Dumbbell, Zap, Target, FileText, Bot, TrendingUp, Settings, MessageSquare, Shield, Cog, Play, Home, User } from "lucide-react";
 import { hasActiveWorkout } from "@/utils/workoutSession";
 import {
   Sidebar,
@@ -62,6 +62,19 @@ const navigationItems = [
     icon: Target,
   },
 ];
+
+// Mobile bottom-nav item (Today / Plan / Workouts / Profile)
+const BottomNavItem = ({ to, icon: Icon, label, active }) => (
+  <Link
+    to={to}
+    className={`flex flex-col items-center justify-center min-w-[56px] h-14 gap-0.5 px-1 ${
+      active ? 'text-primary-500' : 'text-gray-500'
+    }`}
+  >
+    <Icon className={`w-5 h-5 ${active ? 'fill-current' : ''}`} strokeWidth={active ? 2.5 : 2} />
+    <span className="text-[10px] font-medium whitespace-nowrap">{label}</span>
+  </Link>
+);
 
 // Simple throttle utility
 const throttle = (func, limit) => {
@@ -288,12 +301,12 @@ export default function Layout({ children }) {
               ${isChatPage ? 'hidden' : ''}
             `}
           >
-            <div className="flex items-center justify-around h-14 px-2">
-              {/* Live Workout tab - shown first when active */}
-              {showLiveWorkoutTab && (
+            <div className="flex items-end justify-around h-16 px-2">
+              {/* Live Workout tab - replaces the Today slot when a workout is active */}
+              {showLiveWorkoutTab ? (
                 <Link
                   to={createPageUrl('LiveWorkout')}
-                  className={`flex flex-col items-center justify-center min-w-[64px] h-full gap-0.5 px-1 ${
+                  className={`flex flex-col items-center justify-center min-w-[56px] h-14 gap-0.5 px-1 ${
                     location.pathname.toLowerCase().includes('liveworkout')
                       ? 'text-green-600'
                       : 'text-green-500'
@@ -305,29 +318,46 @@ export default function Layout({ children }) {
                   </div>
                   <span className="text-[10px] font-semibold whitespace-nowrap">Live</span>
                 </Link>
+              ) : (
+                <BottomNavItem
+                  to={createPageUrl('Dashboard')}
+                  icon={Home}
+                  label="Today"
+                  active={location.pathname === '/' || location.pathname === createPageUrl('Dashboard')}
+                />
               )}
-              {/* Existing nav items - hide Exercises when Live is shown */}
-              {[
-                navigationItems.find(i => i.title === "Goals"),
-                navigationItems.find(i => i.title === "Plans"),
-                navigationItems.find(i => i.title === "Workouts"),
-                !showLiveWorkoutTab && navigationItems.find(i => i.title === "Exercises")
-              ].filter(Boolean).map((item, index) => {
-                const isActive = location.pathname === item.url;
-                return (
-                  <Link
-                    key={index}
-                    to={item.url}
-                    className={`flex flex-col items-center justify-center min-w-[64px] h-full gap-0.5 px-1 ${isActive ? 'text-primary-500' : 'text-gray-500'
-                      }`}
-                  >
-                    <item.icon className={`w-5 h-5 ${isActive ? 'fill-current' : ''}`} strokeWidth={isActive ? 2.5 : 2} />
-                    <span className="text-[10px] font-medium whitespace-nowrap">
-                      {item.title}
-                    </span>
-                  </Link>
-                );
-              })}
+
+              <BottomNavItem
+                to={createPageUrl('Plans')}
+                icon={FileText}
+                label="Plan"
+                active={location.pathname === createPageUrl('Plans')}
+              />
+
+              {/* Center action — Train now (replaces the old + FAB) */}
+              <Link
+                to={createPageUrl('TrainNow')}
+                className="flex flex-col items-center justify-end gap-1 min-w-[56px] h-full"
+              >
+                <div className="w-12 h-12 rounded-full bg-primary-500 text-white flex items-center justify-center shadow-lg shadow-primary-500/40 -mt-5 active:scale-95 transition-transform">
+                  <Dumbbell className="w-5 h-5" strokeWidth={2.2} />
+                </div>
+                <span className="text-[10px] font-semibold text-primary-500 whitespace-nowrap">Train now</span>
+              </Link>
+
+              <BottomNavItem
+                to={createPageUrl('PredefinedWorkouts')}
+                icon={Dumbbell}
+                label="Workouts"
+                active={location.pathname === createPageUrl('PredefinedWorkouts')}
+              />
+
+              <BottomNavItem
+                to={createPageUrl('Settings')}
+                icon={User}
+                label="Profile"
+                active={location.pathname === createPageUrl('Settings')}
+              />
             </div>
           </nav>
         </div>

--- a/frontend/src/services/aiService.js
+++ b/frontend/src/services/aiService.js
@@ -431,6 +431,88 @@ class AIService {
   }
 
   /**
+   * Get a memory-driven coach check-in question for the Today dashboard.
+   * Returns { question, chips: string[], source } — always resolves with a
+   * usable question (server falls back on error).
+   * @returns {Promise<{question: string, chips: string[], source: string}|null>}
+   */
+  async getCoachQuestion() {
+    const token = this.getAuthToken();
+    if (!token) return null;
+
+    try {
+      const response = await fetch(`${this.baseURL}/api/v1/coach-question`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (!response.ok) return null;
+      const data = await response.json();
+      if (data?.question && Array.isArray(data.chips)) {
+        return { question: data.question, chips: data.chips, source: data.source || '' };
+      }
+      return null;
+    } catch (error) {
+      console.error('Error fetching coach question:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Send the athlete's tapped answer and get a very short, home-page inline reply.
+   * @param {string} question - the coach's check-in question
+   * @param {string} answer - the answer the athlete tapped
+   * @returns {Promise<string|null>} short reply text, or null on hard failure
+   */
+  async getCoachReply(question, answer) {
+    const token = this.getAuthToken();
+    if (!token) return null;
+
+    try {
+      const response = await fetch(`${this.baseURL}/api/v1/coach-question/reply`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ question, answer })
+      });
+      if (!response.ok) return null;
+      const data = await response.json();
+      return data?.reply || null;
+    } catch (error) {
+      console.error('Error fetching coach reply:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Promote the home-screen mini check-in into a full, persisted conversation
+   * seeded with the question / answer / reply turns. Returns the conversation_id
+   * so the caller can open it in Sensei.
+   * @returns {Promise<string|null>} conversation_id, or null on failure
+   */
+  async continueCoachConversation(question, answer, reply) {
+    const token = this.getAuthToken();
+    if (!token) return null;
+
+    try {
+      const response = await fetch(`${this.baseURL}/api/v1/coach-question/continue`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ question, answer, reply })
+      });
+      if (!response.ok) return null;
+      const data = await response.json();
+      return data?.success ? data.conversation_id : null;
+    } catch (error) {
+      console.error('Error creating coach conversation:', error);
+      return null;
+    }
+  }
+
+  /**
    * Clear all cached data (call on logout)
    */
   clearAllCache() {


### PR DESCRIPTION
## Summary

Redesigns the mobile dashboard as a calm **Today** view that combines a warm-paper "Claude-style" shell with Torii's real workout colors, and adds a memory-driven AI-coach check-in. The desktop dashboard is untouched — the new view renders on mobile only.

### Today view (`TodayView.jsx` / `.css`)
- **Goals on top** — outcome cards with progress (goal identity hues, kept distinct from the action color).
- **Today's session hero** — discipline-colored kicker + coral **Start session** CTA + one-line horizon.
- **Memory-driven coach check-in** — one short readiness question with quick-reply chips and provenance ("From memory — …").
- **Progression** — horizontal skill ladder (done / current / upcoming).
- Coral is reserved for actions; disciplines/goals use their own hues (from `designTokens.js`).

### Mobile bottom nav (`Layout.jsx`)
`Today · Plan · Train now · Workouts · Profile` — the center is a raised coral **Train now** FAB (replaces the old `+`).

### AI-coach check-in (`coach_question.py` + backend proxy + `aiService`)
- `GET /coach-question` — generates the question from Sensei memories + recent workouts.
- `POST /coach-question/reply` — a **very short, home-page-aware** inline reply when the athlete taps an answer (no navigation).
- `POST /coach-question/continue` — promotes the mini check-in into a **real, persisted `chatConversation`** (question → answer → reply turns) and returns its id, so **Continue with Sensei** opens it as a natural conversation the user can keep writing in — with full server-side context.

## Verification
- `vite build` clean · Python + Node syntax checks clean.
- **Playwright** (mobile viewport) drove the full flow end-to-end with **zero page errors**:
  1. Today view renders (goals / hero / coach / nav).
  2. Tap answer → inline short reply + "Continue" (chips collapse; no nav).
  3. Continue → lands in Sensei with the question/answer/reply as proper bubbles and a ready input.

> Note: full live-data states (real goals/session/progression) weren't exercised here — no local backend/MongoDB/OpenAI — but every data call has a graceful fallback, which is what the screenshots show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)