### PR TITLE
RAG exercise similarity + fuzzy search, Sensei similar-exercise tool, replace-flow fixes

### DIFF
--- a/ai-coach-service/app/api/v1/chat_stream.py
+++ b/ai-coach-service/app/api/v1/chat_stream.py
@@ -13,6 +13,7 @@ import time
 from app.models.schemas import ChatRequest
 from app.middleware.auth import get_current_user
 from app.core.agents.orchestrator import AgentOrchestrator
+from app.services.short_term_context_service import ShortTermContextService, spawn_background
 from app.core.agents.text_utils import dedupe_repeated_response
 from app.services.conversation_service import ConversationService
 
@@ -143,6 +144,8 @@ async def chat_stream(
     # Keep force flags in saved messages so AI can see research intent in history
     # Title extraction handles stripping flags for display purposes
 
+    is_new_conversation = False
+
     if conversation_id:
         # Verify conversation exists and belongs to user
         existing = await conversation_service.get_conversation(conversation_id, user_id)
@@ -153,6 +156,7 @@ async def chat_stream(
                 initial_message=request.message
             )
             conversation_id = result["conversation_id"]
+            is_new_conversation = True
         else:
             # Get existing conversation history for context
             conversation_history = existing.get("messages", [])
@@ -171,6 +175,16 @@ async def chat_stream(
             initial_message=request.message
         )
         conversation_id = result["conversation_id"]
+        is_new_conversation = True
+
+    if is_new_conversation:
+        # A new conversation just started — lazily summarize recently-ended
+        # ones into short-term context (fire-and-forget, race-safe claim inside)
+        spawn_background(
+            ShortTermContextService(db).summarize_stale_conversations(
+                user_id, orchestrator.client, orchestrator.settings
+            )
+        )
 
     logger.info(f"Using conversation {conversation_id} for user {user_id}")
 

--- a/ai-coach-service/app/api/v1/coach_question.py
+++ b/ai-coach-service/app/api/v1/coach_question.py
@@ -23,6 +23,8 @@ from app.core.agents.data_reader import DataReaderAgent
 from app.core.agents.prompts import SYSTEM_PROMPT
 from app.core.agents.services import MemoryService
 from app.services.conversation_service import ConversationService
+from app.services.recommendation_service import RecommendationService
+from app.services.short_term_context_service import ShortTermContextService, spawn_background
 
 router = APIRouter()
 logger = structlog.get_logger()
@@ -134,6 +136,23 @@ USER DATA:
                 prefix = "HIGH PRIORITY: " if importance == "high" else "- "
                 memory_str += f"\n{prefix}[{category}] {content}"
             context_str += memory_str
+
+        # Short-term context + today's recommendation, so the question can
+        # reference recent check-ins/conversations and stay consistent with
+        # what Train Now already suggested today.
+        stc_service = ShortTermContextService(db)
+        stc_entries = await stc_service.get_recent(user_id, limit=8)
+        stc_block = ShortTermContextService.format_for_prompt(stc_entries)
+        if stc_block:
+            context_str += f"\n\n{stc_block}"
+
+        recs = await RecommendationService(db).get_recent(user_id, [today_date])
+        rec_block = RecommendationService.format_for_prompt(recs, today_date)
+        if rec_block:
+            context_str += f"\n\n{rec_block}"
+
+        # Opportunistic lazy summarization of recently-ended conversations
+        spawn_background(stc_service.summarize_stale_conversations(user_id, client, settings))
 
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
@@ -267,15 +286,34 @@ async def post_coach_reply(
             raise ValueError("Empty reply")
 
         logger.info(f"Coach inline reply for user {user_id}: {reply}")
+
+        # Persist the check-in as short-term context so the sensei remembers
+        # the answer across conversations (14-day TTL)
+        await _save_checkin_entry(db, user_id, question, answer, reply)
+
         return {"success": True, "reply": reply}
 
     except Exception as e:
         logger.error(f"Error generating coach reply: {e}", exc_info=True)
+        fallback_reply = "Got it — I've noted that. Tap continue if you want to talk it through."
+        # The athlete's answer is the valuable part — persist it even on fallback
+        await _save_checkin_entry(db, user_id, question, answer, fallback_reply)
         return {
             "success": True,
-            "reply": "Got it — I've noted that. Tap continue if you want to talk it through.",
+            "reply": fallback_reply,
             "fallback": True,
         }
+
+
+async def _save_checkin_entry(db, user_id: str, question: str, answer: str, reply: str) -> None:
+    """Best-effort: record the dashboard check-in in short-term context."""
+    content = f'Dashboard check-in: coach asked "{question}" — athlete answered "{answer}". Coach: "{reply}"'
+    await ShortTermContextService(db).add_entry(
+        user_id,
+        kind="checkin",
+        content=content,
+        meta={"question": question, "answer": answer, "reply": reply},
+    )
 
 
 @router.post("/continue")
@@ -319,6 +357,14 @@ async def post_coach_continue(
         await service.add_message(conversation_id, "human", answer, user_id=user_id)
         if reply:
             await service.add_message(conversation_id, "ai", reply, user_id=user_id)
+
+        # Mark as seeded from a check-in: the Q&A is already captured as a
+        # short-term "checkin" entry, so the lazy summarizer skips this
+        # conversation unless the athlete actually chats further in it.
+        await db.chatConversations.update_one(
+            {"conversation_id": conversation_id},
+            {"$set": {"checkin_seeded": True}},
+        )
 
         logger.info(f"Promoted coach check-in to conversation {conversation_id} for user {user_id}")
         return {"success": True, "conversation_id": conversation_id}

--- a/ai-coach-service/app/api/v1/exercises.py
+++ b/ai-coach-service/app/api/v1/exercises.py
@@ -1,16 +1,26 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from openai import AsyncOpenAI
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+from bson import ObjectId
 import json
 import re
 import structlog
 
 from app.config import get_settings
+from app.middleware.auth import get_current_user
 from app.models.schemas import (
     ExerciseSuggestionRequest,
     ExerciseSuggestionResponse,
     ExerciseSuggestion,
     StrainSuggestion
+)
+from app.core.agents.skills.substitute_exercise_skill import (
+    score_substitute,
+    equipment_ok,
+    _is_pain_reason,
+    _ALWAYS_AVAILABLE,
 )
 
 router = APIRouter()
@@ -305,3 +315,227 @@ async def suggest_exercise_stream(request: ExerciseSuggestionRequest):
             "X-Accel-Buffering": "no"  # Disable nginx buffering
         }
     )
+
+
+# ---------------------------------------------------------------------------
+# Substitute ranking ("Ask the Sensei" replace)
+# ---------------------------------------------------------------------------
+# One-shot endpoint that returns replacement options for an exercise being
+# swapped mid-workout. It grounds the LLM on real catalog candidates (so most
+# options carry a real id), but MAY also propose fresh exercises the caller
+# materializes before swapping. Pain/injury reasons route to a safety caution.
+
+
+class SubstituteRankRequest(BaseModel):
+    exercise_id: Optional[str] = None
+    exercise_name: Optional[str] = None
+    reason: Optional[str] = None
+    count: int = 5
+
+
+class SubstituteOption(BaseModel):
+    source: str  # "catalog" | "new"
+    id: Optional[str] = None
+    name: str
+    muscles: List[str] = []
+    secondaryMuscles: List[str] = []
+    discipline: List[str] = []
+    equipment: List[str] = []
+    difficulty: Optional[str] = None
+    strain: Optional[Dict[str, Any]] = None
+    note: Optional[str] = None
+
+
+class SubstituteRankResponse(BaseModel):
+    options: List[SubstituteOption] = []
+    routed: Optional[str] = None
+    message: Optional[str] = None
+    fallback: bool = False
+
+
+SAFETY_MESSAGE = (
+    "Since this is about pain or an injury, I won't just swap in another loaded "
+    "movement. If a clinician has cleared you to train around it, tell me which area "
+    "to avoid and I'll suggest a variation. Otherwise please rest it or check with a "
+    "professional — I can't prescribe rehab."
+)
+
+SUBSTITUTE_RANK_PROMPT = """You are a strength coach helping an athlete swap an exercise mid-workout.
+
+Exercise to replace: {original_name}
+Primary muscles: {original_muscles}
+Why they want to swap: {reason}
+
+Here are REAL exercises from their catalog that share muscles and fit their equipment,
+already ranked by stimulus match (best first):
+{candidates}
+
+Pick the {count} best replacements. Prefer catalog options (they map to real logged
+exercises). You MAY add at most 2 fresh exercises NOT in the list only if they would
+clearly serve the athlete better.
+
+Return ONLY a JSON object:
+{{"options": [
+  {{"source": "catalog", "id": "<exact id from the list>", "note": "<=12 words on why it fits"}},
+  {{"source": "new", "name": "<exercise name>", "muscles": [...], "discipline": [...],
+    "equipment": [...], "difficulty": "beginner|intermediate|advanced",
+    "strain": {{"intensity": "...", "load": "...", "duration_type": "reps", "typical_volume": "3x10"}},
+    "note": "<=12 words on why it fits"}}
+]}}
+For "catalog" options include ONLY source, id, note. Use ids EXACTLY as given; never invent an id."""
+
+
+def _candidate_to_option(doc: Dict[str, Any], note: Optional[str] = None) -> Dict[str, Any]:
+    """Project a Mongo exercise doc into a catalog option (includes strain for default sets)."""
+    return {
+        "source": "catalog",
+        "id": str(doc["_id"]),
+        "name": doc.get("name", ""),
+        "muscles": doc.get("muscles", []) or [],
+        "secondaryMuscles": doc.get("secondaryMuscles", []) or [],
+        "discipline": doc.get("discipline", []) or [],
+        "equipment": doc.get("equipment", []) or [],
+        "difficulty": doc.get("difficulty"),
+        "strain": doc.get("strain"),
+        "note": note,
+    }
+
+
+async def _load_original(db, user_oid: ObjectId, req: SubstituteRankRequest) -> Optional[Dict[str, Any]]:
+    ownership = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
+    if req.exercise_id:
+        try:
+            return await db.exercises.find_one({"_id": ObjectId(req.exercise_id), **ownership})
+        except Exception:
+            return None
+    if req.exercise_name:
+        return await db.exercises.find_one(
+            {"name": {"$regex": f"^{re.escape(req.exercise_name)}$", "$options": "i"}, **ownership}
+        )
+    return None
+
+
+@router.post("/substitute/rank", response_model=SubstituteRankResponse)
+async def substitute_rank(
+    request: SubstituteRankRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+) -> SubstituteRankResponse:
+    """Return catalog-grounded (and optionally fresh) replacement options for an exercise."""
+    from app.main import db
+
+    # Pain/injury requests never get an auto-swap.
+    if _is_pain_reason(request.reason or ""):
+        return SubstituteRankResponse(routed="safety", message=SAFETY_MESSAGE)
+
+    try:
+        user_oid = ObjectId(current_user["user_id"])
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid user.")
+
+    original = await _load_original(db, user_oid, request)
+    if not original:
+        # Nothing to ground on — return empty rather than hallucinate blindly.
+        return SubstituteRankResponse(options=[], fallback=True,
+                                      message="Couldn't find that exercise to build alternatives from.")
+
+    # Available equipment: user profile.
+    user = await db.users.find_one({"_id": user_oid}, {"profile.preferences.equipment": 1})
+    equipment_list = (((user or {}).get("profile") or {}).get("preferences") or {}).get("equipment") or []
+    available = {(e or "").lower() for e in equipment_list} | _ALWAYS_AVAILABLE
+
+    # Candidate pool: shares >=1 primary muscle, equipment-ok, ranked deterministically.
+    ownership = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
+    query = {"muscles": {"$in": original.get("muscles", [])}, "_id": {"$ne": original["_id"]}, **ownership}
+    candidates = await db.exercises.find(query).to_list(100)
+    scored = [
+        (score_substitute(original, c), c)
+        for c in candidates
+        if equipment_ok(c.get("equipment", []), available)
+    ]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    scored = [s for s in scored if s[0] > 0]
+
+    pool = [c for _, c in scored[:8]]
+    pool_by_id = {str(c["_id"]): c for c in pool}
+
+    # Deterministic fallback options (used if the LLM call fails or returns nothing usable).
+    deterministic = [_candidate_to_option(c) for c in pool[: request.count]]
+
+    if not pool:
+        return SubstituteRankResponse(options=[], fallback=True)
+
+    settings = get_settings()
+    client = AsyncOpenAI(api_key=settings.openai_api_key)
+    candidates_text = "\n".join(
+        f'- id={str(c["_id"])} | {c.get("name")} | muscles={c.get("muscles", [])} | equipment={c.get("equipment", [])}'
+        for c in pool
+    )
+    prompt = SUBSTITUTE_RANK_PROMPT.format(
+        original_name=original.get("name", ""),
+        original_muscles=", ".join(original.get("muscles", []) or []) or "n/a",
+        reason=request.reason or "wants a change",
+        candidates=candidates_text,
+        count=request.count,
+    )
+
+    try:
+        response = await client.chat.completions.create(
+            model=settings.openai_model_fast,
+            messages=[
+                {"role": "system", "content": "You are a strength coach. Respond only with valid JSON."},
+                {"role": "user", "content": prompt},
+            ],
+            max_completion_tokens=900,
+            **settings.llm_tuning_params(temperature=0.4),
+        )
+        content = response.choices[0].message.content.strip()
+        if content.startswith("```"):
+            content = content.split("```")[1]
+            if content.startswith("json"):
+                content = content[4:]
+            content = content.strip()
+        data = json.loads(content)
+
+        options: List[Dict[str, Any]] = []
+        for raw in data.get("options", [])[: request.count]:
+            source = raw.get("source")
+            note = raw.get("note")
+            if source == "catalog":
+                doc = pool_by_id.get(raw.get("id"))
+                if doc is not None:  # drop hallucinated ids
+                    options.append(_candidate_to_option(doc, note))
+            elif source == "new" and raw.get("name"):
+                strain = raw.get("strain") or {}
+                new_muscles = [m for m in raw.get("muscles", []) if m in VALID_MUSCLES]
+                if not new_muscles:
+                    # LLM returned no valid muscles — inherit the original's so the
+                    # option is materializable (muscles is required by the Exercise
+                    # model) and embeds/searches sensibly. Skip if still empty.
+                    new_muscles = [m for m in (original.get("muscles") or []) if m in VALID_MUSCLES]
+                if not new_muscles:
+                    continue
+                options.append({
+                    "source": "new",
+                    "id": None,
+                    "name": raw["name"],
+                    "muscles": new_muscles,
+                    "secondaryMuscles": [],
+                    "discipline": [d for d in raw.get("discipline", []) if d in VALID_DISCIPLINES] or ["strength"],
+                    "equipment": raw.get("equipment", []) or [],
+                    "difficulty": raw.get("difficulty") if raw.get("difficulty") in VALID_DIFFICULTIES else "beginner",
+                    "strain": {
+                        "intensity": strain.get("intensity") if strain.get("intensity") in VALID_INTENSITIES else "moderate",
+                        "load": strain.get("load") if strain.get("load") in VALID_LOADS else "moderate",
+                        "durationType": strain.get("duration_type") if strain.get("duration_type") in VALID_DURATION_TYPES else "reps",
+                        "typicalVolume": strain.get("typical_volume", "3x10"),
+                    },
+                    "note": note,
+                })
+
+        if not options:
+            return SubstituteRankResponse(options=deterministic, fallback=True)
+        return SubstituteRankResponse(options=options)
+
+    except Exception as e:
+        logger.error(f"substitute_rank LLM failure, returning deterministic pool: {e}")
+        return SubstituteRankResponse(options=deterministic, fallback=True)

--- a/ai-coach-service/app/api/v1/train_now.py
+++ b/ai-coach-service/app/api/v1/train_now.py
@@ -10,7 +10,9 @@ The AI suggestion considers:
 - Calendar context (what's scheduled this week)
 """
 
-from fastapi import APIRouter, Depends
+import asyncio
+
+from fastapi import APIRouter, Depends, Query
 from typing import Dict, Any, List, Optional
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
@@ -23,9 +25,15 @@ from app.middleware.auth import get_current_user
 from app.core.agents.data_reader import DataReaderAgent
 from app.core.agents.prompts import SYSTEM_PROMPT
 from app.core.agents.services import MemoryService
+from app.services.recommendation_service import RecommendationService
+from app.services.short_term_context_service import ShortTermContextService
 
 router = APIRouter()
 logger = structlog.get_logger()
+
+# Per-user in-process locks so concurrent cold-start requests (e.g. Dashboard
+# and TrainNow open together) don't both run a full LLM generation.
+_generation_locks: Dict[str, asyncio.Lock] = {}
 
 
 TRAIN_NOW_PROMPT = """Based on the user's profile, fitness data, calendar, and memories provided above, decide what the user should do TODAY.
@@ -264,28 +272,100 @@ def format_calendar_for_llm(calendar_data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+async def _get_user_local_date(db, user_id: str) -> tuple:
+    """Cheap lookup of the user's timezone -> (local_date 'YYYY-MM-DD', timezone).
+    UTC fallback. Used as the cache key for the persisted daily recommendation."""
+    timezone = "UTC"
+    try:
+        user = await db.users.find_one(
+            {"_id": ObjectId(user_id)},
+            {"settings.timezone": 1}
+        )
+        timezone = ((user or {}).get("settings") or {}).get("timezone") or "UTC"
+    except Exception as e:
+        logger.error(f"Error fetching timezone for {user_id}: {e}")
+    try:
+        local_now = datetime.now(ZoneInfo(timezone))
+    except Exception:
+        local_now = datetime.utcnow()
+        timezone = "UTC"
+    return local_now.strftime("%Y-%m-%d"), timezone
+
+
+def _cached_response(doc: Dict[str, Any]) -> Dict[str, Any]:
+    """Response shape for a persisted recommendation (backward compatible)."""
+    generated_at = doc.get("generatedAt")
+    return {
+        "success": True,
+        "suggestion": doc.get("suggestion"),
+        "source": "ai",
+        "cached": True,
+        "generated_at": generated_at.isoformat() + "Z" if isinstance(generated_at, datetime) else None,
+    }
+
+
 @router.get("")
 async def get_train_now_suggestion(
+    refresh: bool = Query(False),
     current_user: Dict[str, Any] = Depends(get_current_user)
 ) -> Dict[str, Any]:
     """
-    Generate a personalized workout suggestion for today.
+    Return today's workout suggestion.
 
-    This endpoint is called when there's no scheduled workout for today
-    and the cache is empty. It generates a suggestion based on:
-    - User profile and preferences
-    - Recent workout history
-    - Active training plans
-    - User memories (injuries, preferences, etc.)
+    Fast path: if a recommendation was already generated today (persisted in
+    dailyRecommendations, keyed by user-local date), return it — this is what
+    keeps the Dashboard and the TrainNow page aligned. Otherwise (or with
+    ?refresh=true) generate a fresh suggestion, persist it, and return it.
     """
     from app.main import db
 
     settings = get_settings()
+    recommendation_service = RecommendationService(db)
+
+    user_id = current_user["user_id"]
+    local_date, timezone_hint = await _get_user_local_date(db, user_id)
+
+    # Fast path: already generated today
+    if not refresh:
+        existing = await recommendation_service.get_for_date(user_id, local_date)
+        if existing and existing.get("suggestion"):
+            return _cached_response(existing)
+
+    # Serialize generation per user so concurrent cold-start requests don't
+    # both pay for an LLM call; late arrivals hit the re-check below.
+    lock = _generation_locks.setdefault(user_id, asyncio.Lock())
+    async with lock:
+        if not refresh:
+            existing = await recommendation_service.get_for_date(user_id, local_date)
+            if existing and existing.get("suggestion"):
+                return _cached_response(existing)
+        return await _generate_and_persist(
+            db, settings, current_user, user_id, local_date, timezone_hint
+        )
+
+
+async def _generate_and_persist(
+    db,
+    settings,
+    current_user: Dict[str, Any],
+    user_id: str,
+    local_date: str,
+    timezone_hint: str,
+) -> Dict[str, Any]:
+    """
+    Generate a personalized workout suggestion for today via the LLM and
+    persist it to dailyRecommendations (TTL 30 days). Considers:
+    - User profile and preferences
+    - Recent workout history
+    - Active training plans
+    - User memories (injuries, preferences, etc.)
+    - Short-term context (recent check-ins, conversation summaries)
+    """
     client = AsyncOpenAI(api_key=settings.openai_api_key)
     data_reader = DataReaderAgent(db)
     memory_service = MemoryService(db)
-
-    user_id = current_user["user_id"]
+    recommendation_service = RecommendationService(db)
+    stc_service = ShortTermContextService(db)
 
     try:
         # Build user context
@@ -369,6 +449,12 @@ CALENDAR CONTEXT:
                 memory_str += f"\n{prefix}[{category}] {content}"
             context_str += memory_str
 
+        # Add short-term context (recent check-ins + conversation summaries)
+        stc_entries = await stc_service.get_recent(user_id, limit=8)
+        stc_block = ShortTermContextService.format_for_prompt(stc_entries)
+        if stc_block:
+            context_str += f"\n\n{stc_block}"
+
         # Add external activities context
         if data_context.get("external_activities"):
             context_str += "\n\nRECENT EXTERNAL ACTIVITIES:"
@@ -450,10 +536,22 @@ CALENDAR CONTEXT:
 
             logger.info(f"Generated train-now suggestion for user {user_id}: {suggestion['name']}")
 
+        # Persist so the Dashboard shows the same suggestion and the sensei
+        # knows what it recommended (and why). Best-effort: never fails the response.
+        await recommendation_service.save(
+            user_id=user_id,
+            local_date=local_date,
+            timezone=timezone_hint,
+            suggestion=suggestion,
+            context_str=context_str,
+            model=settings.openai_model_fast,
+        )
+
         return {
             "success": True,
             "suggestion": suggestion,
-            "source": "ai"
+            "source": "ai",
+            "cached": False
         }
 
     except Exception as e:

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 from typing import Dict, Any, List, AsyncGenerator
 from openai import AsyncOpenAI
@@ -29,6 +29,8 @@ from app.core.agents.services import (
     SearchService,
     MemoryService,
 )
+from app.services.recommendation_service import RecommendationService
+from app.services.short_term_context_service import ShortTermContextService
 # Importing the skills package registers every skill via the @skill decorator.
 from app.core.agents.skills import (
     SkillContext,
@@ -95,6 +97,8 @@ class AgentOrchestrator:
             db=db,
         )
         self.memory_service = MemoryService(db)
+        self.recommendation_service = RecommendationService(db)
+        self.short_term_context = ShortTermContextService(db)
 
         # Shared context handed to every registered skill handler.
         self.skill_context = SkillContext(
@@ -142,6 +146,29 @@ class AgentOrchestrator:
         ]
         return legacy_tools + skill_definitions
 
+
+    async def _build_extra_context(self, user_id: str, local_now: datetime, today_date: str) -> str:
+        """Short-term awareness blocks appended after memories:
+        1. Recent train-now recommendations (today + yesterday) with reasoning,
+           so the sensei knows what it already suggested and stays consistent.
+        2. Short-term context entries (dashboard check-ins, conversation
+           summaries, 14-day TTL) — working memory across conversations.
+        Best-effort: returns '' on any failure."""
+        blocks = []
+        try:
+            yesterday_date = (local_now - timedelta(days=1)).strftime('%Y-%m-%d')
+            recs = await self.recommendation_service.get_recent(user_id, [today_date, yesterday_date])
+            rec_block = RecommendationService.format_for_prompt(recs, today_date)
+            if rec_block:
+                blocks.append(rec_block)
+
+            stc_entries = await self.short_term_context.get_recent(user_id, limit=8)
+            stc_block = ShortTermContextService.format_for_prompt(stc_entries)
+            if stc_block:
+                blocks.append(stc_block)
+        except Exception as e:
+            logger.error(f"Failed building extra context for {user_id}: {e}")
+        return ("\n\n" + "\n\n".join(blocks)) if blocks else ""
 
     async def process_request(
         self,
@@ -220,6 +247,9 @@ USER DATA:
                 prefix = "⚠️ " if importance == "high" else "• "
                 memory_str += f"\n{prefix}[{category}] {content}"
             context_str += memory_str
+
+        # Add recent recommendations + short-term context (working memory)
+        context_str += await self._build_extra_context(user_id, local_now, today_date)
 
         # Inject context into system prompt for consistent date awareness
         system_prompt_with_context = f"{SYSTEM_PROMPT}\n\n{context_str}"
@@ -476,6 +506,9 @@ USER DATA:
                 prefix = "⚠️ " if importance == "high" else "• "
                 memory_str += f"\n{prefix}[{category}] {content}"
             context_str += memory_str
+
+        # Add recent recommendations + short-term context (working memory)
+        context_str += await self._build_extra_context(user_id, local_now, today_date)
 
         # Build messages array with conversation history
         # IMPORTANT: Inject context into system prompt so it's always at the top

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -35,6 +35,7 @@ TOOL USAGE GUIDELINES:
 - `grep_workouts`: Search workout templates by name/goal patterns.
 - `suggest_exercises`: Recommend exercises for a muscle group / movement pattern that fit the user's equipment and avoid injured areas. Use when the user asks "what should I do for X?".
 - `substitute_exercise`: Swap an exercise for a similar-stimulus one that fits available equipment (e.g. "I don't have a cable machine"). If the reason is pain/injury it will route to a safety caution instead of swapping — respect that.
+- `find_similar_exercises`: Fetch exercises SIMILAR to a given one via semantic vector search (movement pattern, muscles, equipment). Read-only exploration for "what else is like this / what could I do instead" — returns ranked neighbours with a similarity score. Use `substitute_exercise` instead when the user wants one equipment-aware swap prescribed.
 
 WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I have?", "show me back exercises", "hamstring exercises"):
 → Use `list_exercises` with the `muscle` parameter, NOT grep_exercises!

--- a/ai-coach-service/app/core/agents/services/exercise_service.py
+++ b/ai-coach-service/app/core/agents/services/exercise_service.py
@@ -18,6 +18,115 @@ class ExerciseService:
     def __init__(self, db: AsyncIOMotorDatabase):
         self.db = db
 
+    @staticmethod
+    def _format_similar(doc: Dict[str, Any], score: Any = None) -> Dict[str, Any]:
+        out = {
+            "id": str(doc["_id"]),
+            "name": doc.get("name"),
+            "muscles": doc.get("muscles", []),
+            "equipment": doc.get("equipment", []),
+            "difficulty": doc.get("difficulty"),
+        }
+        if score is not None:
+            out["score"] = round(float(score), 4)
+        return out
+
+    @staticmethod
+    def _muscle_overlap(a: List[str], b: List[str]) -> float:
+        sa = {m.lower() for m in (a or [])}
+        sb = {m.lower() for m in (b or [])}
+        return len(sa & sb) / len(sa | sb) if sa and sb else 0.0
+
+    async def _similar_muscle_fallback(self, source: Dict[str, Any], visibility: Dict[str, Any], limit: int) -> List[Dict[str, Any]]:
+        """Deterministic fallback when there's no embedding / vector search yields nothing."""
+        muscles = source.get("muscles", []) or []
+        if not muscles:
+            return []
+        docs = await self.db.exercises.find({
+            "muscles": {"$in": muscles},
+            "_id": {"$ne": source["_id"]},
+            **visibility,
+        }).to_list(100)
+        ranked = sorted(docs, key=lambda d: self._muscle_overlap(muscles, d.get("muscles", [])), reverse=True)[:limit]
+        return [self._format_similar(d, self._muscle_overlap(muscles, d.get("muscles", []))) for d in ranked]
+
+    async def find_similar(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch exercises semantically similar to a source one via the Atlas
+        vector index (exercise_vector_index) over stored embeddings.
+
+        READ-ONLY: reuses each exercise's precomputed `embedding` (populated by the
+        Node write hook / backfill) — never generates embeddings. Falls back to
+        deterministic muscle-overlap ranking when the source has no embedding yet
+        or vector search is unavailable (index building), so it always returns
+        something useful. Visibility-scoped to common + user-owned exercises.
+        """
+        try:
+            user_oid = ObjectId(user_id)
+        except Exception:
+            return {"success": False, "message": "Invalid user."}
+
+        limit = max(1, min(int(args.get("limit") or 6), 25))
+        visibility = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
+
+        # Load the source exercise (with its embedding), scoped to what the user sees.
+        source = None
+        ex_id = args.get("exercise_id")
+        if ex_id:
+            try:
+                source = await self.db.exercises.find_one({"_id": ObjectId(ex_id), **visibility})
+            except Exception:
+                source = None
+        if source is None and args.get("exercise_name"):
+            source = await self.db.exercises.find_one({
+                "name": {"$regex": f"^{re.escape(args['exercise_name'])}$", "$options": "i"},
+                **visibility,
+            })
+        if not source:
+            return {"success": False, "message": "I couldn't find that exercise to find alternatives for."}
+
+        method = "vector"
+        similar: List[Dict[str, Any]] = []
+        embedding = source.get("embedding")
+
+        if isinstance(embedding, list) and len(embedding) > 0:
+            try:
+                docs = await self.db.exercises.aggregate([
+                    {
+                        "$vectorSearch": {
+                            "index": "exercise_vector_index",
+                            "path": "embedding",
+                            "queryVector": embedding,
+                            "numCandidates": 100,
+                            "limit": limit + 1,  # +1 to drop the source itself
+                            "filter": visibility,
+                        }
+                    },
+                    {
+                        "$project": {
+                            "name": 1, "muscles": 1, "equipment": 1, "difficulty": 1,
+                            "score": {"$meta": "vectorSearchScore"},
+                        }
+                    },
+                ]).to_list(limit + 1)
+                similar = [
+                    self._format_similar(d, d.get("score"))
+                    for d in docs if str(d["_id"]) != str(source["_id"])
+                ][:limit]
+            except Exception as e:
+                logger.warning(f"vector search unavailable, using muscle fallback: {e}")
+                similar = []
+
+        if not similar:
+            method = "muscle_overlap"
+            similar = await self._similar_muscle_fallback(source, visibility, limit)
+
+        return {
+            "success": True,
+            "method": method,
+            "source": {"id": str(source["_id"]), "name": source.get("name"), "muscles": source.get("muscles", [])},
+            "similar": similar,
+        }
+
     async def add_exercise(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Add an exercise to the user's personal exercise library"""
         try:

--- a/ai-coach-service/app/core/agents/services/search_service.py
+++ b/ai-coach-service/app/core/agents/services/search_service.py
@@ -78,6 +78,14 @@ class SearchService:
                 "createdAt", expireAfterSeconds=VIDEO_CACHE_TTL_DAYS * 86400
             )
             await self.db[VIDEO_CACHE_COLLECTION].create_index("query", unique=True)
+            # uservideocontext: looked up by (user_id, query) on every video search /
+            # "save it", and by user_id sorted on updatedAt for the "that one" fallback.
+            await self.db[USER_VIDEO_CTX_COLLECTION].create_index(
+                [("user_id", 1), ("query", 1)], unique=True
+            )
+            await self.db[USER_VIDEO_CTX_COLLECTION].create_index(
+                [("user_id", 1), ("updatedAt", -1)]
+            )
             self._video_cache_ready = True
         except Exception as e:
             logger.warning(f"Could not ensure video cache index: {e}")

--- a/ai-coach-service/app/core/agents/skills/__init__.py
+++ b/ai-coach-service/app/core/agents/skills/__init__.py
@@ -23,6 +23,7 @@ from app.core.agents.skills import schedule_plan_skill  # noqa: F401,E402
 from app.core.agents.skills import validate_plan_skill  # noqa: F401,E402
 from app.core.agents.skills import generate_plan_skill  # noqa: F401,E402
 from app.core.agents.skills import substitute_exercise_skill  # noqa: F401,E402
+from app.core.agents.skills import find_similar_exercises_skill  # noqa: F401,E402
 from app.core.agents.skills import suggest_exercises_skill  # noqa: F401,E402
 from app.core.agents.skills import review_progress_skill  # noqa: F401,E402
 from app.core.agents.skills import reschedule_session_skill  # noqa: F401,E402

--- a/ai-coach-service/app/core/agents/skills/find_similar_exercises_skill.py
+++ b/ai-coach-service/app/core/agents/skills/find_similar_exercises_skill.py
@@ -1,0 +1,42 @@
+"""
+Skill: find_similar_exercises
+
+Thin wrapper: the actual vector-search implementation lives in
+ExerciseService.find_similar (the service/"tool" layer). This skill just exposes
+it to the LLM with a description + parameter schema and delegates, mirroring how
+generate_plan_skill delegates to ctx.exercise_service.grep_exercises.
+
+READ-ONLY capability — it fetches semantic neighbours (movement pattern, muscles,
+equipment) via the shared Atlas vector index; it never generates or writes
+embeddings.
+
+Distinct from `substitute_exercise`: that skill is equipment-gated and enforces a
+pain-reason safety gate to *prescribe* one swap. This one just surfaces similar
+options for the coach to reason over.
+"""
+
+from typing import Any, Dict
+
+from app.core.agents.skills.registry import SkillContext, skill
+
+
+@skill(
+    name="find_similar_exercises",
+    description=(
+        "Fetch exercises SIMILAR to a given one via semantic vector search (movement "
+        "pattern, muscles, equipment) — the coach's read-only lookup for 'what else is "
+        "like this / what could I do instead'. Returns ranked neighbours with a "
+        "similarity score. Use substitute_exercise instead when the user wants one "
+        "equipment-aware swap prescribed."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "exercise_id": {"type": "string", "description": "ID of the source exercise."},
+            "exercise_name": {"type": "string", "description": "Name of the source exercise (if no ID)."},
+            "limit": {"type": "integer", "description": "Max neighbours to return (default 6, max 25)."},
+        },
+    },
+)
+async def find_similar_exercises(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    return await ctx.exercise_service.find_similar(user_id, args)

--- a/ai-coach-service/app/main.py
+++ b/ai-coach-service/app/main.py
@@ -9,6 +9,8 @@ import redis.asyncio as redis
 from app.config import get_settings, Settings
 from app.api.v1 import health, chat, chat_stream, conversations, documents, exercises, internal, progressions, suggestions, train_now, coach_question
 from app.services.conversation_service import ConversationService
+from app.services.recommendation_service import RecommendationService
+from app.services.short_term_context_service import ShortTermContextService
 
 logger = structlog.get_logger()
 
@@ -35,6 +37,10 @@ async def lifespan(app: FastAPI):
     # Ensure indexes for conversations collection
     conversation_service = ConversationService(db)
     await conversation_service.ensure_indexes()
+
+    # Ensure indexes for daily recommendations + short-term context (TTL collections)
+    await RecommendationService(db).ensure_indexes()
+    await ShortTermContextService(db).ensure_indexes()
     
     # Connect to Redis
     try:

--- a/ai-coach-service/app/services/recommendation_service.py
+++ b/ai-coach-service/app/services/recommendation_service.py
@@ -1,0 +1,151 @@
+"""
+RecommendationService - persists the daily "Train Now" recommendation so that:
+1. Every surface (TrainNow page, Dashboard) reads the SAME suggestion for the day.
+2. The sensei can answer "what did you suggest me today and why" from context.
+
+One document per user per user-local date, TTL 30 days (expiresAt + Mongo TTL
+index, same pattern as backend OAuth models).
+"""
+
+from typing import Dict, Any, List, Optional
+from datetime import datetime, timedelta
+import structlog
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
+
+logger = structlog.get_logger()
+
+COLLECTION_NAME = "dailyRecommendations"
+
+RECOMMENDATION_TTL_DAYS = 30
+CONTEXT_SNAPSHOT_MAX_CHARS = 8000
+
+
+class RecommendationService:
+    """CRUD for the per-day persisted train-now recommendation."""
+
+    def __init__(self, db: AsyncIOMotorDatabase):
+        self.db = db
+        self.collection = db[COLLECTION_NAME]
+
+    async def ensure_indexes(self):
+        """Create indexes for efficient querying + TTL cleanup"""
+        try:
+            # One recommendation per user per local date
+            await self.collection.create_index(
+                [("userId", 1), ("localDate", 1)],
+                unique=True,
+                name="user_local_date_unique"
+            )
+
+            # TTL: Mongo deletes the doc once expiresAt passes
+            await self.collection.create_index(
+                "expiresAt",
+                expireAfterSeconds=0,
+                name="expires_at_ttl"
+            )
+
+            logger.info(f"Indexes ensured for {COLLECTION_NAME} collection")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to create {COLLECTION_NAME} indexes: {e}")
+            return False
+
+    async def get_for_date(self, user_id: str, local_date: str) -> Optional[Dict[str, Any]]:
+        """Fetch the persisted recommendation for a user-local date (YYYY-MM-DD)."""
+        try:
+            return await self.collection.find_one({
+                "userId": ObjectId(user_id),
+                "localDate": local_date
+            })
+        except Exception as e:
+            logger.error(f"Error fetching recommendation for {user_id}/{local_date}: {e}")
+            return None
+
+    async def save(
+        self,
+        user_id: str,
+        local_date: str,
+        timezone: str,
+        suggestion: Dict[str, Any],
+        context_str: str,
+        model: str,
+    ) -> bool:
+        """Upsert today's recommendation (force-refresh overwrites). Best-effort:
+        callers must never fail the user-facing response on a persist error."""
+        now = datetime.utcnow()
+        doc = {
+            "userId": ObjectId(user_id),
+            "localDate": local_date,
+            "timezone": timezone,
+            "suggestion": suggestion,
+            "reasoning": suggestion.get("reasoning", ""),
+            "contextSnapshot": {
+                "context_str": context_str[:CONTEXT_SNAPSHOT_MAX_CHARS],
+                "model": model,
+            },
+            "source": "ai",
+            "generatedAt": now,
+            "updatedAt": now,
+            "expiresAt": now + timedelta(days=RECOMMENDATION_TTL_DAYS),
+        }
+        filter_ = {"userId": ObjectId(user_id), "localDate": local_date}
+        try:
+            try:
+                await self.collection.replace_one(filter_, {**doc, "createdAt": now}, upsert=True)
+            except DuplicateKeyError:
+                # Concurrent upsert race against the unique index — retry once,
+                # this time it's a plain replace (last-write-wins is fine).
+                await self.collection.replace_one(filter_, {**doc, "createdAt": now}, upsert=True)
+            return True
+        except Exception as e:
+            logger.error(f"Error saving recommendation for {user_id}/{local_date}: {e}")
+            return False
+
+    async def get_recent(self, user_id: str, local_dates: List[str]) -> List[Dict[str, Any]]:
+        """Fetch recommendations for a small set of local dates (e.g. today + yesterday),
+        projected down to what prompt injection needs."""
+        try:
+            cursor = self.collection.find(
+                {"userId": ObjectId(user_id), "localDate": {"$in": local_dates}},
+                {
+                    "localDate": 1,
+                    "reasoning": 1,
+                    "suggestion.type": 1,
+                    "suggestion.name": 1,
+                    "suggestion.estimated_duration": 1,
+                    "suggestion.difficulty_level": 1,
+                }
+            ).sort("localDate", -1)
+            return await cursor.to_list(len(local_dates))
+        except Exception as e:
+            logger.error(f"Error fetching recent recommendations for {user_id}: {e}")
+            return []
+
+    @staticmethod
+    def format_for_prompt(recs: List[Dict[str, Any]], today_date: str) -> str:
+        """Render recommendations as a context block for the LLM. Empty string if none."""
+        if not recs:
+            return ""
+        lines = ["TRAINING RECOMMENDATIONS YOU GAVE (Train Now — you already suggested these, be consistent with them):"]
+        for rec in recs:
+            local_date = rec.get("localDate", "")
+            label = f"TODAY ({local_date})" if local_date == today_date else local_date
+            suggestion = rec.get("suggestion") or {}
+            reasoning = (rec.get("reasoning") or "").strip()
+            if len(reasoning) > 300:
+                reasoning = reasoning[:297] + "..."
+            if suggestion.get("type") == "rest":
+                desc = "Rest Day"
+            else:
+                name = suggestion.get("name", "Workout")
+                duration = suggestion.get("estimated_duration")
+                level = suggestion.get("difficulty_level")
+                details = ", ".join(str(d) for d in [f"{duration} min" if duration else None, level] if d)
+                desc = f'Workout "{name}"' + (f" ({details})" if details else "")
+            line = f"- {label}: {desc}"
+            if reasoning:
+                line += f" Why: {reasoning}"
+            lines.append(line)
+        return "\n".join(lines)

--- a/ai-coach-service/app/services/short_term_context_service.py
+++ b/ai-coach-service/app/services/short_term_context_service.py
@@ -1,0 +1,221 @@
+"""
+ShortTermContextService - the sensei's working memory.
+
+Long-term memories (usermemories) hold durable facts; this collection holds
+SHORT-TERM context that should follow the user across conversations for a
+couple of weeks and then disappear: dashboard check-in answers and summaries
+of recently-ended conversations. Per-entry TTL of 14 days via expiresAt +
+Mongo TTL index.
+
+Injected (alongside memories) into the chat orchestrator, coach-question
+generation, and train-now generation so all three stay consistent.
+"""
+
+import asyncio
+from typing import Dict, Any, List, Optional
+from datetime import datetime, timedelta
+import structlog
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from bson import ObjectId
+
+logger = structlog.get_logger()
+
+COLLECTION_NAME = "shortTermContext"
+CONVERSATIONS_COLLECTION = "chatConversations"
+
+ENTRY_TTL_DAYS = 14
+CONTENT_MAX_CHARS = 400
+STALE_CONVERSATION_MINUTES = 30
+
+SUMMARIZE_PROMPT = (
+    "Summarize this coaching conversation in 2-3 sentences. Focus on what the "
+    "athlete reported (fatigue, soreness, injuries, mood), decisions made, and "
+    "anything the coach should remember over the next two weeks. Write in third "
+    "person ('The athlete...'). Return ONLY the summary text."
+)
+
+# Keep strong references to fire-and-forget tasks: the event loop only holds
+# weak refs, so a bare create_task() can be garbage-collected mid-run.
+_background_tasks: set = set()
+
+
+def spawn_background(coro) -> None:
+    """Fire-and-forget an async task without it being GC'd mid-run."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+class ShortTermContextService:
+    """Short-term (14-day) context entries + lazy conversation summarization."""
+
+    def __init__(self, db: AsyncIOMotorDatabase):
+        self.db = db
+        self.collection = db[COLLECTION_NAME]
+        self.conversations = db[CONVERSATIONS_COLLECTION]
+
+    async def ensure_indexes(self):
+        """Create indexes for efficient querying + TTL cleanup"""
+        try:
+            await self.collection.create_index(
+                [("userId", 1), ("createdAt", -1)],
+                name="user_created_at"
+            )
+            await self.collection.create_index(
+                "expiresAt",
+                expireAfterSeconds=0,
+                name="expires_at_ttl"
+            )
+            logger.info(f"Indexes ensured for {COLLECTION_NAME} collection")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to create {COLLECTION_NAME} indexes: {e}")
+            return False
+
+    async def add_entry(
+        self,
+        user_id: str,
+        kind: str,
+        content: str,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Insert a short-term context entry. Best-effort: never raises."""
+        try:
+            now = datetime.utcnow()
+            content = (content or "").strip()
+            if not content:
+                return False
+            if len(content) > CONTENT_MAX_CHARS:
+                content = content[:CONTENT_MAX_CHARS - 3] + "..."
+            await self.collection.insert_one({
+                "userId": ObjectId(user_id),
+                "kind": kind,
+                "content": content,
+                "meta": meta or {},
+                "createdAt": now,
+                "expiresAt": now + timedelta(days=ENTRY_TTL_DAYS),
+            })
+            return True
+        except Exception as e:
+            logger.error(f"Error adding short-term context entry for {user_id}: {e}")
+            return False
+
+    async def get_recent(self, user_id: str, limit: int = 8) -> List[Dict[str, Any]]:
+        """Most recent short-term entries, newest first."""
+        try:
+            cursor = self.collection.find(
+                {"userId": ObjectId(user_id)}
+            ).sort("createdAt", -1).limit(limit)
+            return await cursor.to_list(limit)
+        except Exception as e:
+            logger.error(f"Error fetching short-term context for {user_id}: {e}")
+            return []
+
+    @staticmethod
+    def format_for_prompt(entries: List[Dict[str, Any]]) -> str:
+        """Render entries as a context block for the LLM. Empty string if none."""
+        if not entries:
+            return ""
+        kind_labels = {"checkin": "check-in", "conversation_summary": "conversation"}
+        lines = ["RECENT CONTEXT (short-term notes from the last 14 days, newest first):"]
+        for entry in entries:
+            created = entry.get("createdAt")
+            date_str = created.strftime("%b %d") if isinstance(created, datetime) else ""
+            label = kind_labels.get(entry.get("kind"), entry.get("kind", "note"))
+            lines.append(f"- [{date_str}, {label}] {entry.get('content', '')}")
+        return "\n".join(lines)
+
+    async def summarize_stale_conversations(
+        self,
+        user_id: str,
+        openai_client,
+        settings,
+        max_convs: int = 2,
+    ) -> None:
+        """Lazily summarize recently-ended conversations into short-term context.
+
+        A conversation is "ended" once updatedAt is older than 30 minutes.
+        Race-safety: each conversation is CLAIMED atomically (summarized_at set
+        via find_one_and_update) BEFORE the LLM call, so concurrent triggers
+        (dashboard load + new chat) can't double-summarize; on failure the claim
+        is released so the next trigger retries.
+
+        Designed to run via spawn_background() — never raises.
+        """
+        try:
+            now = datetime.utcnow()
+            stale_cutoff = now - timedelta(minutes=STALE_CONVERSATION_MINUTES)
+            lookback = now - timedelta(days=ENTRY_TTL_DAYS)
+
+            candidates = await self.conversations.find(
+                {
+                    "metadata.user_id": user_id,
+                    "summarized_at": {"$exists": False},
+                    "updatedAt": {"$lt": stale_cutoff, "$gte": lookback},
+                    "messages.1": {"$exists": True},  # at least 2 messages
+                },
+                {"_id": 1}
+            ).sort("updatedAt", -1).to_list(max_convs)
+
+            for candidate in candidates:
+                # Atomic claim: only one trigger wins this conversation
+                conv = await self.conversations.find_one_and_update(
+                    {"_id": candidate["_id"], "summarized_at": {"$exists": False}},
+                    {"$set": {"summarized_at": now}},
+                )
+                if not conv:
+                    continue  # another trigger claimed it
+
+                messages = conv.get("messages", [])
+
+                # Check-ins promoted via /continue are seeded with 3 turns the
+                # user already saw — those are already covered by the "checkin"
+                # entry. Only summarize if the user actually chatted further.
+                if conv.get("checkin_seeded") and len(messages) <= 3:
+                    continue  # claim kept: nothing new to summarize
+
+                try:
+                    transcript_lines = []
+                    for msg in messages[-20:]:
+                        role = "Athlete" if msg.get("role") == "human" else "Coach"
+                        content = str(msg.get("content", ""))[:300]
+                        transcript_lines.append(f"{role}: {content}")
+                    transcript = "\n".join(transcript_lines)
+
+                    response = await openai_client.chat.completions.create(
+                        model=settings.openai_model_fast,
+                        messages=[
+                            {"role": "user", "content": f"{transcript}\n\n{SUMMARIZE_PROMPT}"},
+                        ],
+                        max_completion_tokens=150,
+                        **settings.llm_tuning_params(temperature=0.3),
+                    )
+                    summary = response.choices[0].message.content.strip()
+                    if not summary:
+                        raise ValueError("Empty summary")
+
+                    inserted = await self.add_entry(
+                        user_id,
+                        kind="conversation_summary",
+                        content=summary,
+                        meta={
+                            "conversation_id": conv.get("conversation_id"),
+                            "title": conv.get("title"),
+                        },
+                    )
+                    if not inserted:
+                        raise RuntimeError("Failed to insert summary entry")
+
+                    logger.info(
+                        f"Summarized conversation {conv.get('conversation_id')} "
+                        f"into short-term context for user {user_id}"
+                    )
+                except Exception as e:
+                    # Release the claim so a later trigger retries
+                    logger.error(f"Failed to summarize conversation {conv.get('conversation_id')}: {e}")
+                    await self.conversations.update_one(
+                        {"_id": candidate["_id"]},
+                        {"$unset": {"summarized_at": ""}},
+                    )
+        except Exception as e:
+            logger.error(f"summarize_stale_conversations failed for {user_id}: {e}")

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,11 @@ OPENAI_MODEL=gpt-4o-mini
 AI_MAX_TOKENS=2000
 AI_TEMPERATURE=0.7
 
+# Embeddings (exercise similarity / vector search). Must match the numDimensions
+# of the Atlas vectorSearch index (recreate the index if you change the model).
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIMS=1536
+
 # Google OAuth Configuration
 # Get your OAuth credentials from https://console.cloud.google.com/apis/credentials
 GOOGLE_CLIENT_ID=your-google-client-id

--- a/backend/scripts/backfillEmbeddings.js
+++ b/backend/scripts/backfillEmbeddings.js
@@ -1,0 +1,92 @@
+/**
+ * One-shot backfill: generate embeddings for exercises that don't have one yet
+ * (or whose embedText changed). New/edited exercises self-embed via the model's
+ * pre-save hook — this is only for the existing catalog and re-runs.
+ *
+ * Uses updateOne to write BOTH `embedding` and `embeddingText` together, which
+ * skips the pre-save hook (avoids a redundant second embed). Writing only
+ * `embedding` would leave a stale embeddingText and cause the next real save to
+ * re-embed needlessly.
+ *
+ * Usage:  node scripts/backfillEmbeddings.js
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Exercise = require('../src/models/Exercise');
+const { generateEmbeddings } = require('../src/services/EmbeddingService');
+
+const BATCH_SIZE = 50; // exercises per OpenAI batch request
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('MONGODB_URI not set');
+    process.exit(1);
+  }
+  if (!process.env.OPENAI_API_KEY) {
+    console.error('OPENAI_API_KEY not set — cannot generate embeddings');
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  console.log('Connected to MongoDB');
+
+  // Pull every exercise with the fields needed to build embed text, plus the
+  // stored embeddingText so we can skip ones that are already up to date.
+  const exercises = await Exercise.find({}, {
+    name: 1, muscles: 1, secondaryMuscles: 1, discipline: 1,
+    equipment: 1, difficulty: 1, embeddingText: 1
+  }).lean();
+
+  console.log(`Loaded ${exercises.length} exercises`);
+
+  // Determine which need (re)embedding by comparing the target embed text.
+  const stale = [];
+  for (const ex of exercises) {
+    const target = Exercise.buildEmbedText(ex);
+    if (ex.embeddingText !== target) {
+      stale.push({ id: ex._id, text: target });
+    }
+  }
+
+  console.log(`${stale.length} exercises need embedding (${exercises.length - stale.length} already current)`);
+
+  let done = 0;
+  let failed = 0;
+
+  for (let i = 0; i < stale.length; i += BATCH_SIZE) {
+    const batch = stale.slice(i, i + BATCH_SIZE);
+    const vectors = await generateEmbeddings(batch.map(b => b.text));
+
+    if (!vectors) {
+      console.error(`Batch ${i}-${i + batch.length} failed to embed; skipping`);
+      failed += batch.length;
+      continue;
+    }
+
+    // Write each result. Both fields together so the pre-save hook stays a no-op
+    // on the next normal save.
+    for (let j = 0; j < batch.length; j++) {
+      const vector = vectors[j];
+      if (!vector) { failed += 1; continue; }
+      // eslint-disable-next-line no-await-in-loop
+      await Exercise.updateOne(
+        { _id: batch[j].id },
+        { $set: { embedding: vector, embeddingText: batch[j].text } }
+      );
+      done += 1;
+    }
+
+    console.log(`Progress: ${done}/${stale.length} embedded`);
+  }
+
+  console.log(`Done. Embedded ${done}, failed ${failed}.`);
+  await mongoose.disconnect();
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/backend/src/controllers/exerciseController.js
+++ b/backend/src/controllers/exerciseController.js
@@ -6,7 +6,51 @@ const { validationResult } = require('express-validator');
 const getExercises = async (req, res) => {
   try {
     const { muscle, discipline, equipment, difficulty, search, page = 1, limit = 50 } = req.query;
-    
+
+    // Fast path: when there's a text query, use server-side Atlas fuzzy $search
+    // (typo tolerance + muscle/equipment matching) instead of loading the whole
+    // catalog and doing substring matching in memory. Facets are applied inside
+    // the aggregation before pagination so counts/pages stay correct.
+    if (search) {
+      try {
+        const { exercises: searchResults, total } = await ExerciseService.searchExercises({
+          userId: req.user ? req.user.id : null,
+          search,
+          muscle,
+          discipline,
+          equipment,
+          difficulty,
+          page: parseInt(page),
+          limit: parseInt(limit)
+        });
+
+        // Only trust the fast path when it actually found something. A missing or
+        // still-building Atlas index returns EMPTY rather than throwing, so a bare
+        // `return` here would surface a false "no results" during the deploy/index
+        // -build window. Zero hits → fall through to the in-memory substring path,
+        // which also covers description matches the search index doesn't have. For
+        // this catalog size the extra scan on a genuine no-match is negligible.
+        if (total > 0) {
+          return res.json({
+            success: true,
+            data: {
+              exercises: searchResults,
+              pagination: {
+                page: parseInt(page),
+                limit: parseInt(limit),
+                total,
+                pages: Math.ceil(total / limit)
+              }
+            }
+          });
+        }
+      } catch (searchErr) {
+        // Atlas Search index missing / not READY (e.g. local dev) — fall through
+        // to the in-memory substring path below so search still works offline.
+        console.warn('Atlas $search unavailable, falling back to in-memory filter:', searchErr.message);
+      }
+    }
+
     // If user is authenticated, get exercises with modifications applied
     let exercises;
     if (req.user) {
@@ -138,6 +182,41 @@ const getExercise = async (req, res) => {
   }
 };
 
+// Get exercises similar to a given one (vector search — dynamic "alternatives")
+const getSimilarExercises = async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit) || 8, 25);
+    const userId = req.user ? req.user.id : null;
+
+    // Ensure the source exists and is visible to this user first.
+    const source = req.user
+      ? await ExerciseService.getExerciseForUser(req.params.id, userId)
+      : await Exercise.findOne({ _id: req.params.id, isCommon: true }).lean();
+
+    if (!source) {
+      return res.status(404).json({
+        success: false,
+        message: 'Exercise not found'
+      });
+    }
+
+    const similar = await ExerciseService.findSimilar(req.params.id, userId, limit);
+
+    res.json({
+      success: true,
+      data: {
+        exercises: similar
+      }
+    });
+  } catch (error) {
+    console.error('Get similar exercises error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Server error getting similar exercises'
+    });
+  }
+};
+
 // Create new exercise
 const createExercise = async (req, res) => {
   try {
@@ -149,6 +228,12 @@ const createExercise = async (req, res) => {
         errors: errors.array()
       });
     }
+
+    // Never let a client set the embedding fields directly — they're derived
+    // server-side by the pre-save hook. Accepting them would let a caller poison
+    // the vector (or, with an unchanged name, slip a bad vector past the guard).
+    delete req.body.embedding;
+    delete req.body.embeddingText;
 
     const exerciseData = {
       ...req.body,
@@ -180,7 +265,13 @@ const createExercise = async (req, res) => {
 // Update exercise
 const updateExercise = async (req, res) => {
   try {
-    const exercise = await Exercise.findById(req.params.id);
+    // Client can't set derived embedding fields (see createExercise).
+    delete req.body.embedding;
+    delete req.body.embeddingText;
+
+    // Load embeddingText so the pre-save re-embed guard can compare it (it's
+    // select:false, so it isn't loaded by default).
+    const exercise = await Exercise.findById(req.params.id).select('+embeddingText');
 
     if (!exercise) {
       return res.status(404).json({
@@ -282,6 +373,7 @@ const deleteExercise = async (req, res) => {
 module.exports = {
   getExercises,
   getExercise,
+  getSimilarExercises,
   createExercise,
   updateExercise,
   deleteExercise

--- a/backend/src/mcp/tools/exerciseTools.js
+++ b/backend/src/mcp/tools/exerciseTools.js
@@ -47,6 +47,25 @@ function register(server, ctx) {
   }, withScope(scopes, READ, (args) =>
     runTool(exerciseController.getExercise, { user, params: { id: args.id } }, { transform: trimExercise })
   ));
+
+  server.registerTool('find_similar_exercises', {
+    title: 'Find similar exercises',
+    description: 'Given an exerciseId, return semantically similar exercises (swap/alternative suggestions) ranked by similarity, using vector search over muscles, movement pattern and equipment.',
+    inputSchema: {
+      id: z.string().length(24).describe('The exerciseId to find alternatives for'),
+      limit: z.number().int().min(1).max(25).optional().describe('Max alternatives to return (default 8)')
+    }
+  }, withScope(scopes, READ, (args) =>
+    runTool(
+      exerciseController.getSimilarExercises,
+      { user, params: { id: args.id }, query: { limit: args.limit } },
+      { transform: (data) => (data && Array.isArray(data.exercises)
+        // Keep `score` (similarity magnitude) so the coach can weigh how close
+        // each alternative is, not just their rank order.
+        ? { ...data, exercises: data.exercises.map(ex => ({ ...trimExercise(ex), score: ex.score })) }
+        : data) }
+    )
+  ));
 }
 
 module.exports = { register };

--- a/backend/src/models/Exercise.js
+++ b/backend/src/models/Exercise.js
@@ -1,4 +1,6 @@
 const mongoose = require('mongoose');
+const { inferMovementPattern } = require('../utils/movementPattern');
+const EmbeddingService = require('../services/EmbeddingService');
 
 const exerciseSchema = new mongoose.Schema({
   name: {
@@ -60,6 +62,22 @@ const exerciseSchema = new mongoose.Schema({
       return !this.isCommon; // Required for user exercises, not for common
     },
     index: true
+  },
+  // Semantic-search vector for "similar exercises". select:false so the 1536
+  // floats never bloat normal reads — opt in with .select('+embedding').
+  embedding: {
+    type: [Number],
+    default: undefined,
+    select: false
+  },
+  // The exact string we last embedded. select:false so it never leaks into API
+  // responses (it's internal). The pre-save guard compares against it to decide
+  // whether to re-embed, so the update controller must explicitly load it with
+  // .select('+embeddingText') — otherwise the guard misfires and re-embeds on
+  // every save.
+  embeddingText: {
+    type: String,
+    select: false
   }
 }, {
   timestamps: true
@@ -104,4 +122,41 @@ exerciseSchema.statics.findByEquipment = function(equipment) {
   return this.find({ equipment: { $in: equipment } });
 };
 
+// Build the composite text we embed for similarity. Concatenates the fields
+// that define what an exercise *is* — name, muscles, discipline, equipment,
+// difficulty — plus the inferred movement pattern so "Barbell Bench Press" and
+// "Dumbbell Bench Press" land near each other in vector space.
+function buildEmbedText(doc) {
+  const parts = [];
+  if (doc.name) parts.push(doc.name);
+  const muscles = [...(doc.muscles || []), ...(doc.secondaryMuscles || [])];
+  if (muscles.length) parts.push(`muscles: ${muscles.join(', ')}`);
+  if (doc.discipline && doc.discipline.length) parts.push(`discipline: ${doc.discipline.join(', ')}`);
+  if (doc.equipment && doc.equipment.length) parts.push(`equipment: ${doc.equipment.join(', ')}`);
+  if (doc.difficulty) parts.push(`difficulty: ${doc.difficulty}`);
+  const pattern = inferMovementPattern(doc);
+  if (pattern) parts.push(`movement: ${pattern}`);
+  return parts.join(' | ');
+}
+
+// Expose so the backfill script can compute the same text.
+exerciseSchema.statics.buildEmbedText = buildEmbedText;
+
+// Generate/refresh the embedding on write — the "on-the-fly, not a job" path.
+// Guard on embeddingText so unrelated saves (favorites, isCommon toggles) don't
+// re-embed. Fail-soft: a failed embedding leaves the doc saveable without one.
+exerciseSchema.pre('save', async function generateEmbedding() {
+  const newText = buildEmbedText(this);
+  if (!this.isNew && this.embeddingText === newText) return;
+
+  const vector = await EmbeddingService.generateEmbedding(newText);
+  if (vector) {
+    this.embedding = vector;
+    this.embeddingText = newText;
+  }
+  // If embedding failed, leave prior embedding/embeddingText untouched; the
+  // backfill script (or the next successful save) will fill it in.
+});
+
+// buildEmbedText is exposed via exerciseSchema.statics (Exercise.buildEmbedText).
 module.exports = mongoose.model('Exercise', exerciseSchema);

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -716,6 +716,78 @@ router.post('/progressions/suggest', authMiddleware, aiRateLimit, async (req, re
   }
 });
 
+// Exercise substitute ranking - "Ask the Sensei" replace options (proxies to AI Coach)
+// Forwards the Authorization header because the AI endpoint is user-scoped
+// (needs the athlete's equipment + owned exercises to ground candidates).
+router.post('/exercises/substitute/rank', authMiddleware, aiRateLimit, async (req, res) => {
+  try {
+    const { exercise_id, exercise_name, reason, count } = req.body;
+
+    if (!exercise_id && !exercise_name) {
+      return res.status(400).json({
+        success: false,
+        message: 'exercise_id or exercise_name is required'
+      });
+    }
+
+    const urlParts = new URL(`${AI_SERVICE_URL}/api/v1/exercises/substitute/rank`);
+    const isHttps = urlParts.protocol === 'https:';
+    const http = require(isHttps ? 'https' : 'http');
+
+    const body = JSON.stringify({ exercise_id, exercise_name, reason, count });
+
+    const response = await new Promise((resolve, reject) => {
+      const options = {
+        hostname: urlParts.hostname,
+        port: urlParts.port || (isHttps ? 443 : 80),
+        path: urlParts.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          ...(req.headers.authorization && { Authorization: req.headers.authorization })
+        }
+      };
+
+      const request = http.request(options, (response) => {
+        let data = '';
+        response.on('data', (chunk) => { data += chunk; });
+        response.on('end', () => {
+          if (response.statusCode === 200) {
+            try {
+              resolve(JSON.parse(data));
+            } catch (e) {
+              reject(new Error('Invalid JSON response from AI service'));
+            }
+          } else {
+            reject(new Error(`AI service returned status ${response.statusCode}: ${data}`));
+          }
+        });
+      });
+
+      // The downstream call waits on an LLM completion — cap it so a hung
+      // upstream can't hold the client connection open indefinitely.
+      request.setTimeout(30000, () => {
+        request.destroy(new Error('AI service timed out'));
+      });
+
+      request.on('error', reject);
+      request.write(body);
+      request.end();
+    });
+
+    res.json(response);
+
+  } catch (error) {
+    console.error('Substitute rank error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to get replacement options',
+      error: error.message
+    });
+  }
+});
+
 // Progression suggestion streaming endpoint - proxies to Python AI Coach service
 router.post('/progressions/suggest/stream', authMiddleware, aiRateLimit, async (req, res) => {
   try {

--- a/backend/src/routes/exercises.js
+++ b/backend/src/routes/exercises.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const {
   getExercises,
   getExercise,
+  getSimilarExercises,
   createExercise,
   updateExercise,
   deleteExercise
@@ -14,6 +15,11 @@ const { validateExercise } = require('../middleware/validation');
 // @desc    Get all exercises with optional filtering
 // @access  Public (but can show user-specific data if authenticated)
 router.get('/', optionalAuth, getExercises);
+
+// @route   GET /api/v1/exercises/:id/similar
+// @desc    Get exercises semantically similar to this one (vector search)
+// @access  Public (user-scoped results if authenticated)
+router.get('/:id/similar', optionalAuth, getSimilarExercises);
 
 // @route   GET /api/v1/exercises/:id
 // @desc    Get single exercise by ID

--- a/backend/src/routes/trainNow.js
+++ b/backend/src/routes/trainNow.js
@@ -12,10 +12,14 @@ router.get('/', authMiddleware, async (req, res) => {
     const isHttps = urlParts.protocol === 'https:';
     const http = require(isHttps ? 'https' : 'http');
 
+    // Forward the query string (e.g. ?refresh=true) to the AI service
+    const queryIndex = req.url.indexOf('?');
+    const queryString = queryIndex >= 0 ? req.url.slice(queryIndex) : '';
+
     const options = {
       hostname: urlParts.hostname,
       port: urlParts.port || (isHttps ? 443 : 80),
-      path: urlParts.pathname,
+      path: urlParts.pathname + queryString,
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/backend/src/services/EmbeddingService.js
+++ b/backend/src/services/EmbeddingService.js
@@ -1,0 +1,87 @@
+/**
+ * EmbeddingService — turns text into OpenAI embedding vectors.
+ *
+ * Used to embed exercises (on write, via the Exercise pre-save hook) and to
+ * embed ad-hoc query text. Self-managed: we own the vector and store it on the
+ * exercise document, then query it with Atlas $vectorSearch.
+ *
+ * Fail-soft by design: callers should treat a null return as "no embedding
+ * available" and never block CRUD on an embedding failure.
+ */
+
+const OpenAI = require('openai');
+
+const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || 'text-embedding-3-small';
+const EMBEDDING_DIMS = parseInt(process.env.EMBEDDING_DIMS || '1536', 10);
+
+// Lazily construct the client so the module is importable without a key
+// (e.g. in tests / local dev where embeddings are disabled).
+let client = null;
+function getClient() {
+  if (client) return client;
+  if (!process.env.OPENAI_API_KEY) return null;
+  client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  return client;
+}
+
+/**
+ * Generate an embedding for a single string.
+ * @param {string} text
+ * @returns {Promise<number[]|null>} the vector, or null on empty input / failure
+ */
+async function generateEmbedding(text) {
+  const input = (text || '').trim();
+  if (!input) return null;
+
+  const openai = getClient();
+  if (!openai) {
+    console.warn('[EmbeddingService] OPENAI_API_KEY not set — skipping embedding');
+    return null;
+  }
+
+  try {
+    const res = await openai.embeddings.create({ model: EMBEDDING_MODEL, input, dimensions: EMBEDDING_DIMS });
+    return res.data[0].embedding;
+  } catch (err) {
+    // Fail-soft: log and return null so the caller can proceed without a vector.
+    console.error('[EmbeddingService] embedding failed:', err.message);
+    return null;
+  }
+}
+
+/**
+ * Generate embeddings for many strings in one request (used by the backfill).
+ * Returns an array aligned with `texts`; individual entries are null on empty
+ * input, and the whole call returns null on API failure.
+ * @param {string[]} texts
+ * @returns {Promise<(number[]|null)[]|null>}
+ */
+async function generateEmbeddings(texts) {
+  const inputs = texts.map((t) => (t || '').trim());
+  const nonEmpty = inputs.filter(Boolean);
+  if (nonEmpty.length === 0) return inputs.map(() => null);
+
+  const openai = getClient();
+  if (!openai) {
+    console.warn('[EmbeddingService] OPENAI_API_KEY not set — skipping embeddings');
+    return null;
+  }
+
+  try {
+    // OpenAI preserves input order in the response; map back onto the originals,
+    // leaving null for the empty inputs we didn't send.
+    const res = await openai.embeddings.create({ model: EMBEDDING_MODEL, input: nonEmpty, dimensions: EMBEDDING_DIMS });
+    let i = 0;
+    return inputs.map((t) => (t ? res.data[i++].embedding : null));
+  } catch (err) {
+    console.error('[EmbeddingService] batch embedding failed:', err.message);
+    return null;
+  }
+}
+
+module.exports = {
+  generateEmbedding,
+  generateEmbeddings,
+  EMBEDDING_MODEL,
+  EMBEDDING_DIMS
+};

--- a/backend/src/services/ExerciseService.js
+++ b/backend/src/services/ExerciseService.js
@@ -177,6 +177,246 @@ class ExerciseService {
   }
   
   /**
+   * Overlay a user's modifications onto an already-fetched set of exercises.
+   * Batched (one query for all ids) — unlike getExerciseForUser which is one
+   * doc / two queries. Used by findSimilar so we don't do N+1 lookups.
+   * Mirrors the merge logic in getExercisesForUser, scoped to the passed set.
+   * @param {Array} exercises - lean exercise docs (must include _id)
+   * @param {String} userId - The user's ID
+   * @returns {Array} exercises with modifications + metadata applied
+   */
+  static async applyModifications(exercises, userId) {
+    if (!exercises || exercises.length === 0) return exercises;
+
+    const ids = exercises.map(ex => ex._id);
+    const modifications = await UserExerciseModification.find({
+      userId,
+      exerciseId: { $in: ids }
+    }).lean();
+
+    const modMap = new Map(
+      modifications.map(mod => [mod.exerciseId.toString(), mod])
+    );
+
+    return exercises.map(exercise => {
+      const result = {
+        ...exercise,
+        isCommon: exercise.isCommon || false,
+        isPrivate: !exercise.isCommon,
+        canEdit: !exercise.isCommon && exercise.createdBy?.toString() === userId.toString()
+      };
+
+      const mod = modMap.get(exercise._id.toString());
+      if (!mod) return result;
+
+      if (mod.modifications) {
+        Object.keys(mod.modifications).forEach(key => {
+          if (mod.modifications[key] !== undefined) {
+            if (key === 'strain' && typeof mod.modifications[key] === 'object') {
+              result[key] = { ...result[key], ...mod.modifications[key] };
+            } else {
+              result[key] = mod.modifications[key];
+            }
+          }
+        });
+      }
+
+      result.userMetadata = mod.metadata;
+      const hasContentModifications = mod.modifications &&
+        Object.keys(mod.modifications).some(key => mod.modifications[key] !== undefined);
+      result.isModified = hasContentModifications;
+      result.modificationId = mod._id;
+
+      return result;
+    });
+  }
+
+  /**
+   * Find exercises semantically similar to a given one via Atlas Vector Search.
+   * "Clusters" are emergent at query time — no precomputed groups. Respects
+   * visibility (common OR owned by the user) via the vector index filter fields.
+   * @param {String} exerciseId - The source exercise
+   * @param {String|null} userId - Requesting user (null = anonymous, common only)
+   * @param {Number} limit - Max alternatives to return
+   * @returns {Array} similar exercises with a `score`, modifications overlaid
+   */
+  static async findSimilar(exerciseId, userId, limit = 8) {
+    // Source embedding is select:false, so opt in explicitly.
+    const source = await Exercise.findById(exerciseId).select('+embedding').lean();
+    if (!source) return [];
+
+    const userObjectId = userId ? new mongoose.Types.ObjectId(userId) : null;
+    const visibilityFilter = userObjectId
+      ? { $or: [{ isCommon: true }, { createdBy: userObjectId }] }
+      : { isCommon: true };
+
+    // Deterministic muscle-overlap fallback. Used when this exercise has no
+    // embedding yet (pre-backfill) or when vector search is unavailable/empty
+    // (index still building). Keeps "Similar" working without embeddings and
+    // upgrades to semantic ranking transparently once vectors land. Projects the
+    // same shape as the vector path (incl. strain, so callers can build default
+    // sets from strain.typicalVolume).
+    const muscleFallback = async () => {
+      const muscles = source.muscles || [];
+      if (muscles.length === 0) return [];
+      const docs = await Exercise.find({
+        muscles: { $in: muscles },
+        _id: { $ne: source._id },
+        ...visibilityFilter
+      })
+        .select('name description muscles secondaryMuscles discipline equipment difficulty instructions strain mediaUrls isCommon createdBy')
+        .limit(50)
+        .lean();
+      const srcSet = new Set(muscles.map(m => String(m).toLowerCase()));
+      const ranked = docs
+        .map(d => ({
+          ...d,
+          score: (d.muscles || []).reduce((n, m) => n + (srcSet.has(String(m).toLowerCase()) ? 1 : 0), 0)
+        }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit);
+      return userId ? this.applyModifications(ranked, userId) : ranked;
+    };
+
+    const hasEmbedding = Array.isArray(source.embedding) && source.embedding.length > 0;
+    if (!hasEmbedding) return muscleFallback();
+
+    let results;
+    try {
+      results = await Exercise.aggregate([
+        {
+          $vectorSearch: {
+            index: 'exercise_vector_index',
+            path: 'embedding',
+            queryVector: source.embedding,
+            numCandidates: 100,
+            limit: limit + 1, // +1 so we can drop the source itself
+            filter: visibilityFilter
+          }
+        },
+        {
+          $project: {
+            name: 1, description: 1, muscles: 1, secondaryMuscles: 1, discipline: 1,
+            equipment: 1, difficulty: 1, instructions: 1, strain: 1, mediaUrls: 1,
+            isCommon: 1, createdBy: 1,
+            score: { $meta: 'vectorSearchScore' }
+          }
+        }
+      ]);
+    } catch (err) {
+      // Index not READY / vector search unavailable — degrade, don't 500.
+      console.warn('Vector search unavailable, falling back to muscle overlap:', err.message);
+      return muscleFallback();
+    }
+
+    // Drop the source exercise if it came back among its own neighbours.
+    const filtered = results
+      .filter(ex => ex._id.toString() !== exerciseId.toString())
+      .slice(0, limit);
+
+    // No semantic neighbours (e.g. sparse embeddings) — still give the user
+    // something useful.
+    if (filtered.length === 0) return muscleFallback();
+
+    // Overlay the user's modifications for display consistency (name/edits).
+    // NOTE: the embedding was built from base fields, so this only affects
+    // display — it does not change what matched in vector space.
+    return userId ? this.applyModifications(filtered, userId) : filtered;
+  }
+
+  /**
+   * Server-side fuzzy search via Atlas $search. Ranks by relevance (fuzzy on
+   * name + muscle/equipment matching), then applies visibility + facet filters
+   * BEFORE pagination so `total`/`pages` reflect the filtered set (not a
+   * post-filtered top-N slice). Throws if the Atlas Search index is absent /
+   * not READY — the controller catches this and falls back to in-memory search.
+   *
+   * Known limitation (documented, per plan): $search matches the STORED
+   * document, so a common exercise a user renamed via UserExerciseModification
+   * won't match by its overlaid name. Modifications are overlaid on results for
+   * display only. This edge case is intentionally not unioned back in.
+   *
+   * @returns {{ exercises: Array, total: Number }}
+   */
+  static async searchExercises({ userId, search, muscle, discipline, equipment, difficulty, page = 1, limit = 50 }) {
+    const userObjectId = userId ? new mongoose.Types.ObjectId(userId) : null;
+
+    // Visibility + facets, applied as a $match after $search (pre-pagination).
+    const match = {
+      $or: userObjectId
+        ? [{ isCommon: true }, { createdBy: userObjectId }]
+        : [{ isCommon: true }]
+    };
+    const and = [];
+    if (muscle) {
+      const muscles = muscle.split(',');
+      and.push({ $or: [{ muscles: { $in: muscles } }, { secondaryMuscles: { $in: muscles } }] });
+    }
+    if (discipline) {
+      match.discipline = { $in: discipline.split(',') };
+    }
+    if (difficulty) {
+      match.difficulty = difficulty;
+    }
+    if (equipment) {
+      const equipmentList = equipment.split(',');
+      if (equipmentList.includes('none')) {
+        and.push({ $or: [{ equipment: { $exists: false } }, { equipment: { $size: 0 } }] });
+      } else {
+        match.equipment = { $in: equipmentList };
+      }
+    }
+    if (and.length) match.$and = and;
+
+    const skip = (page - 1) * limit;
+
+    const [agg] = await Exercise.aggregate([
+      {
+        $search: {
+          index: 'exercise_search_index',
+          compound: {
+            should: [
+              // Prefix/typeahead on name, boosted highest.
+              { autocomplete: { query: search, path: 'name', fuzzy: { maxEdits: 2 }, score: { boost: { value: 3 } } } },
+              // Full-token fuzzy on name.
+              { text: { query: search, path: 'name', fuzzy: { maxEdits: 2 }, score: { boost: { value: 2 } } } },
+              // Match by muscle / equipment so "chest" or "barbell" find things.
+              { text: { query: search, path: ['muscles', 'secondaryMuscles', 'equipment'], fuzzy: { maxEdits: 1 } } },
+              // Description match (the old in-memory path searched description too).
+              { text: { query: search, path: 'description', fuzzy: { maxEdits: 1 } } }
+            ],
+            minimumShouldMatch: 1
+          }
+        }
+      },
+      { $match: match },
+      {
+        $facet: {
+          results: [
+            { $skip: skip },
+            { $limit: limit },
+            {
+              $project: {
+                name: 1, description: 1, muscles: 1, secondaryMuscles: 1,
+                discipline: 1, equipment: 1, difficulty: 1, instructions: 1,
+                strain: 1, mediaUrls: 1, isCommon: 1, createdBy: 1,
+                score: { $meta: 'searchScore' }
+              }
+            }
+          ],
+          totalCount: [{ $count: 'count' }]
+        }
+      }
+    ]);
+
+    const raw = agg?.results || [];
+    const total = agg?.totalCount?.[0]?.count || 0;
+    const exercises = userId ? await this.applyModifications(raw, userId) : raw;
+
+    return { exercises, total };
+  }
+
+  /**
    * Toggle favorite status for an exercise
    * @param {String} userId - The user's ID
    * @param {String} exerciseId - The exercise ID

--- a/backend/src/utils/ensureIndexes.js
+++ b/backend/src/utils/ensureIndexes.js
@@ -144,6 +144,81 @@ async function createSearchIndexes(logger) {
     // Don't fail startup if search indexes can't be created
     logger.warn('Could not create search indexes (non-fatal)', { error: err.message });
   }
+
+  // Atlas Search + Vector Search indexes for exercises (separate API from the
+  // classic B-tree/text indexes above). Non-fatal: on a cluster without Atlas
+  // Search these creations fail and the app degrades to in-memory search.
+  await createAtlasExerciseIndexes(logger);
+}
+
+/**
+ * Create the Atlas Search (fuzzy typeahead) and Vector Search (similar
+ * exercises) indexes on the exercises collection. Idempotent — skips indexes
+ * that already exist. Requires a cluster that supports Atlas Search (M0+).
+ *
+ * Note: M0/M2/M5 shared tiers cap at 3 Atlas Search indexes total; we create 2.
+ */
+async function createAtlasExerciseIndexes(logger) {
+  const { EMBEDDING_DIMS } = require('../services/EmbeddingService');
+
+  try {
+    const db = mongoose.connection.db;
+    const exercises = db.collection('exercises');
+
+    // listSearchIndexes is a distinct API from indexes(); returns a cursor.
+    let existing = [];
+    try {
+      existing = await exercises.listSearchIndexes().toArray();
+    } catch (listErr) {
+      // Older/unsupported clusters throw here — treat as "no Atlas Search".
+      logger.warn('Atlas Search not available; skipping vector/search indexes (non-fatal)', { error: listErr.message });
+      return;
+    }
+    const existingNames = new Set(existing.map(idx => idx.name));
+
+    // Vector Search index for "similar exercises".
+    if (!existingNames.has('exercise_vector_index')) {
+      await exercises.createSearchIndex({
+        name: 'exercise_vector_index',
+        type: 'vectorSearch',
+        definition: {
+          fields: [
+            { type: 'vector', path: 'embedding', numDimensions: EMBEDDING_DIMS, similarity: 'cosine' },
+            { type: 'filter', path: 'isCommon' },
+            { type: 'filter', path: 'createdBy' }
+          ]
+        }
+      });
+      logger.info('Created Atlas vectorSearch index: exercise_vector_index');
+    }
+
+    // Atlas Search index for fuzzy typeahead. `name` gets both string +
+    // autocomplete mappings so we can run text() and autocomplete() on it.
+    if (!existingNames.has('exercise_search_index')) {
+      await exercises.createSearchIndex({
+        name: 'exercise_search_index',
+        // type defaults to 'search'
+        definition: {
+          mappings: {
+            dynamic: false,
+            fields: {
+              name: [{ type: 'string' }, { type: 'autocomplete' }],
+              description: { type: 'string' },
+              muscles: { type: 'string' },
+              secondaryMuscles: { type: 'string' },
+              equipment: { type: 'string' },
+              discipline: { type: 'string' }
+            }
+          }
+        }
+      });
+      logger.info('Created Atlas search index: exercise_search_index');
+    }
+
+    logger.info('Atlas exercise search indexes verified');
+  } catch (err) {
+    logger.warn('Could not create Atlas exercise search indexes (non-fatal)', { error: err.message });
+  }
 }
 
 module.exports = {

--- a/backend/src/utils/movementPattern.js
+++ b/backend/src/utils/movementPattern.js
@@ -1,0 +1,52 @@
+/**
+ * Movement-pattern inference for exercises.
+ *
+ * The Exercise model has no movementPattern field. We infer a coarse pattern
+ * from the exercise name, falling back to its primary muscle. Pure functions —
+ * no DB. Used to enrich the text we embed so similarity carries movement
+ * semantics, not just words.
+ *
+ * Ported from ai-coach-service/app/core/agents/skills/knowledge/movement.py.
+ *
+ * Patterns are the standard primal categories used for substitution matching:
+ * push / pull / squat / hinge / carry / core / cardio.
+ */
+
+// Name keywords -> movement pattern. Order matters: earlier patterns win.
+const MOVEMENT_PATTERNS = {
+  hinge: ['deadlift', 'romanian', 'rdl', 'hip thrust', 'good morning', 'kettlebell swing', 'swing', 'hip hinge'],
+  squat: ['squat', 'lunge', 'leg press', 'step-up', 'step up', 'split squat', 'pistol'],
+  pull: ['pull-up', 'pullup', 'chin-up', 'chinup', 'row', 'lat pulldown', 'pulldown', 'curl', 'face pull', 'muscle-up'],
+  push: ['bench', 'push-up', 'pushup', 'press', 'dip', 'overhead', 'ohp', 'fly', 'pushdown', 'extension', 'handstand'],
+  carry: ['carry', 'farmer', 'suitcase', 'waiter'],
+  core: ['plank', 'crunch', 'sit-up', 'situp', 'hollow', 'leg raise', 'knee raise', 'ab wheel', 'rollout', 'russian twist'],
+  cardio: ['run', 'jog', 'sprint', 'bike', 'cycl', 'rowing', 'erg', 'burpee', 'jump rope', 'skip', 'swim', 'elliptical']
+};
+
+// Primary muscle -> pattern fallback when the name isn't recognized.
+const MUSCLE_TO_PATTERN = {
+  chest: 'push', shoulders: 'push', triceps: 'push', delts: 'push',
+  back: 'pull', lats: 'pull', biceps: 'pull', traps: 'pull', rhomboids: 'pull',
+  quads: 'squat', quadriceps: 'squat', calves: 'squat',
+  glutes: 'hinge', hamstrings: 'hinge', 'lower back': 'hinge',
+  core: 'core', abs: 'core', obliques: 'core'
+};
+
+/**
+ * Best-effort pattern from name, then primary muscle. null if unknown.
+ * @param {{ name?: string, muscles?: string[] }} exercise
+ * @returns {string|null}
+ */
+function inferMovementPattern(exercise) {
+  const name = (exercise?.name || '').toLowerCase();
+  for (const [pattern, keywords] of Object.entries(MOVEMENT_PATTERNS)) {
+    if (keywords.some((kw) => name.includes(kw))) return pattern;
+  }
+  for (const muscle of exercise?.muscles || []) {
+    const pattern = MUSCLE_TO_PATTERN[(muscle || '').toLowerCase()];
+    if (pattern) return pattern;
+  }
+  return null;
+}
+
+module.exports = { inferMovementPattern, MOVEMENT_PATTERNS, MUSCLE_TO_PATTERN };

--- a/frontend/src/api/entities/Exercise.js
+++ b/frontend/src/api/entities/Exercise.js
@@ -6,12 +6,30 @@
 import { apiService } from '../../services/api';
 
 export const Exercise = {
-  async list() {
+  async list(params = {}) {
     try {
-      const data = await apiService.exercises.list();
+      const data = await apiService.exercises.list(params);
       return Array.isArray(data) ? data : [];
     } catch (error) {
       console.error('Exercise.list error:', error);
+      return [];
+    }
+  },
+
+  // Server-side fuzzy search (Atlas $search: typo tolerance + muscle/equipment
+  // matching). Use for typeahead so we don't download the whole catalog.
+  async search(term, params = {}) {
+    if (!term) return [];
+    return this.list({ search: term, ...params });
+  },
+
+  // Semantically similar exercises (dynamic "alternatives") via vector search.
+  async similar(id, limit) {
+    try {
+      const data = await apiService.exercises.similar(id, limit);
+      return Array.isArray(data) ? data : [];
+    } catch (error) {
+      console.error('Exercise.similar error:', error);
       return [];
     }
   },

--- a/frontend/src/components/dashboard/TodayView.jsx
+++ b/frontend/src/components/dashboard/TodayView.jsx
@@ -4,6 +4,7 @@ import { createPageUrl } from "@/utils";
 import { CalendarEvent, UserGoalProgress } from "@/api/entities";
 import apiService from "@/services/api";
 import aiService from "@/services/aiService";
+import { pickTodaySession } from "@/utils/todaySession";
 import { getDisciplineColor } from "@/styles/designTokens";
 import {
   Play, Sparkles, X, ChevronRight, ArrowRight, Check, Bike, Dumbbell,
@@ -39,6 +40,8 @@ export default function TodayView() {
   const navigate = useNavigate();
   const [goals, setGoals] = useState([]);
   const [session, setSession] = useState(null);
+  const [sessionLoading, setSessionLoading] = useState(true);
+  const [sessionDone, setSessionDone] = useState(false);
   const [coach, setCoach] = useState(null);
   const [coachDismissed, setCoachDismissed] = useState(false);
   const [coachAnswer, setCoachAnswer] = useState(null);
@@ -62,32 +65,51 @@ export default function TodayView() {
       })
       .catch(() => {});
 
-    // Today's session — first not-yet-done calendar event, else cached AI suggestion
+    // Today's session — calendar first (same selection rule as the TrainNow
+    // page), then the same server-persisted AI suggestion TrainNow uses, so
+    // both surfaces always show the same thing.
     CalendarEvent.today()
-      .then((events) => {
+      .then(async (events) => {
         if (!alive) return;
-        const list = Array.isArray(events) ? events : [];
-        const next =
-          list.find((e) => (e.status || "scheduled") !== "completed") || list[0];
-        if (next) {
+        const { scheduledEvent, completedToday } = pickTodaySession(events);
+        if (scheduledEvent) {
           setSession({
-            title: next.title,
-            type: next.workoutDetails?.type || next.eventType || "Workout",
-            time: fmtTime(next.date),
+            title: scheduledEvent.title,
+            type:
+              scheduledEvent.workoutDetails?.type ||
+              scheduledEvent.eventType ||
+              "Workout",
+            time: fmtTime(scheduledEvent.date),
             duration:
-              next.workoutDetails?.durationMinutes ||
-              next.workoutDetails?.estimatedDuration ||
+              scheduledEvent.workoutDetails?.durationMinutes ||
+              scheduledEvent.workoutDetails?.estimatedDuration ||
               null,
-            exercises: next.workoutDetails?.exercises?.length || null,
-            eventId: next.id,
+            exercises: scheduledEvent.workoutDetails?.exercises?.length || null,
+            eventId: scheduledEvent.id,
           });
-        } else {
-          const cached = aiService.getCachedTodayWorkout();
-          if (cached?.suggestion) {
-            const s = cached.suggestion;
+          setSessionLoading(false);
+          return;
+        }
+        if (completedToday) {
+          setSessionDone(true);
+          setSessionLoading(false);
+          return;
+        }
+        // No calendar event — fetch (or generate) today's persisted suggestion
+        const data = await aiService.getTodayWorkout();
+        if (!alive) return;
+        if (data?.suggestion) {
+          const s = data.suggestion;
+          if (s.type === "rest") {
+            setSession({
+              rest: true,
+              title: s.name || "Rest Day",
+              reasoning: s.reasoning || null,
+            });
+          } else {
             setSession({
               title: s.name || s.title,
-              type: s.type || s.primary_disciplines?.[0] || "Workout",
+              type: s.primary_disciplines?.[0] || "Workout",
               time: null,
               duration: s.estimated_duration || s.duration_minutes || null,
               exercises: s.exercises?.length || s.blocks?.length || null,
@@ -95,8 +117,11 @@ export default function TodayView() {
             });
           }
         }
+        setSessionLoading(false);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (alive) setSessionLoading(false);
+      });
 
     // Coach question — memory-driven
     aiService
@@ -216,12 +241,56 @@ export default function TodayView() {
 
         {/* HERO SESSION */}
         <div className="tv-hero">
-          {session ? (
+          {sessionLoading ? (
+            <>
+              <div className="tv-hero-kicker" style={{ color: "var(--tv-accent)" }}>
+                <Sparkles className="tv-ico" />
+                Coach is thinking
+              </div>
+              <div className="tv-hero-title" style={{ opacity: 0.55 }}>
+                Preparing today's pick…
+              </div>
+              <div className="tv-hero-meta" style={{ opacity: 0.55 }}>
+                One moment.
+              </div>
+            </>
+          ) : sessionDone ? (
+            <>
+              <div className="tv-hero-kicker" style={{ color: "#22C55E" }}>
+                <Check className="tv-ico" />
+                Done for today
+              </div>
+              <div className="tv-hero-title">Session complete</div>
+              <div className="tv-hero-meta">
+                Nice work — recovery counts too.
+              </div>
+              <button className="tv-cta" onClick={() => navigate(createPageUrl("TrainNow"))}>
+                <Play className="tv-ico" fill="currentColor" strokeWidth={0} />
+                Train more
+              </button>
+            </>
+          ) : session?.rest ? (
+            <>
+              <div className="tv-hero-kicker" style={{ color: "#6366F1" }}>
+                <Sparkles className="tv-ico" />
+                Sensei's advice
+              </div>
+              <div className="tv-hero-title">{session.title}</div>
+              <div className="tv-hero-meta">
+                {session.reasoning || "Your body needs time to recover today."}
+              </div>
+              <button className="tv-cta" onClick={() => navigate(createPageUrl("TrainNow"))}>
+                <ChevronRight className="tv-ico" />
+                View details
+              </button>
+            </>
+          ) : session ? (
             <>
               <div className="tv-hero-kicker" style={{ color: typeColor(session.type) }}>
                 <SessionIcon type={session.type} />
                 {capitalize(session.type)}
                 {session.time ? ` · ${session.time}` : ""}
+                {session.eventId == null ? " · Today's pick" : ""}
               </div>
               <div className="tv-hero-title">{session.title}</div>
               <div className="tv-hero-meta">{sessionMeta(session)}</div>

--- a/frontend/src/components/exercise/ExerciseDetailModal.jsx
+++ b/frontend/src/components/exercise/ExerciseDetailModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { X, Dumbbell, Target, Zap, Timer, MoreVertical, Activity, TrendingUp, AlertCircle, Star, Repeat, ArrowRight, Weight, Clock, Pencil, Trash2 } from "lucide-react";
 import { getDisciplineClass } from "@/styles/designTokens";
+import { Exercise } from "@/api/entities";
 
 const intensityColors = {
   low: "bg-green-100 text-green-800",
@@ -29,17 +30,30 @@ const throttle = (func, limit) => {
   }
 };
 
-export default function ExerciseDetailModal({ exercise, onClose, onEdit, onToggleFavorite, onDelete }) {
+export default function ExerciseDetailModal({ exercise, onClose, onEdit, onToggleFavorite, onDelete, onSelectSimilar }) {
   const [isHeaderCollapsed, setIsHeaderCollapsed] = useState(false);
   const [showOptionsMenu, setShowOptionsMenu] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const scrollContainerRef = useRef(null);
   const optionsMenuRef = useRef(null);
   const [isFavorite, setIsFavorite] = useState(exercise.userMetadata?.isFavorite || false);
+  const [similar, setSimilar] = useState([]);
 
   useEffect(() => {
     setIsFavorite(exercise.userMetadata?.isFavorite || false);
   }, [exercise.userMetadata?.isFavorite]);
+
+  // Fetch real vector-similar exercises ("alternatives") at open time.
+  useEffect(() => {
+    const id = exercise.id || exercise._id;
+    if (!id) return;
+    let cancelled = false;
+    setSimilar([]);
+    Exercise.similar(id, 6).then((found) => {
+      if (!cancelled) setSimilar(found || []);
+    });
+    return () => { cancelled = true; };
+  }, [exercise.id, exercise._id]);
 
   // Throttled scroll handler
   const handleScroll = useCallback(throttle((e) => {
@@ -394,8 +408,26 @@ export default function ExerciseDetailModal({ exercise, onClose, onEdit, onToggl
               </div>
             )}
 
-            {/* Similar Exercises */}
-            {exercise.similar_exercises && exercise.similar_exercises.length > 0 && (
+            {/* Similar Exercises — real vector-search alternatives (clickable),
+                with the static AI-suggested names as a fallback. */}
+            {similar.length > 0 ? (
+              <div className="mb-8">
+                <h3 className="text-lg font-bold text-gray-900 mb-3">Similar Exercises</h3>
+                <div className="flex flex-wrap gap-2">
+                  {similar.map((simEx) => (
+                    <button
+                      key={simEx._id || simEx.id}
+                      onClick={() => onSelectSimilar && onSelectSimilar(simEx)}
+                      disabled={!onSelectSimilar}
+                      className="px-3 py-1.5 bg-orange-50 text-orange-700 rounded-xl text-xs font-bold capitalize flex items-center gap-1.5 hover:bg-orange-100 transition-colors disabled:cursor-default"
+                    >
+                      <ArrowRight className="w-3 h-3" />
+                      {simEx.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : exercise.similar_exercises && exercise.similar_exercises.length > 0 && (
               <div className="mb-8">
                 <h3 className="text-lg font-bold text-gray-900 mb-3">Similar Exercises</h3>
                 <div className="flex flex-wrap gap-2">

--- a/frontend/src/components/exercise/ExerciseSearchInput.jsx
+++ b/frontend/src/components/exercise/ExerciseSearchInput.jsx
@@ -1,0 +1,121 @@
+import { useState, useEffect, useRef } from "react";
+import { Search, Loader2, X } from "lucide-react";
+import { apiService } from "@/services/api";
+
+/**
+ * Debounced type-to-search combobox over the exercise catalog.
+ *
+ * Searches server-side via apiService.exercises.list({ search, limit }) so it never
+ * downloads the whole catalog (works at scale). Matching quality upgrades to Atlas
+ * $search transparently once the RAG search index lands — no change needed here.
+ *
+ * @param {(exercise: Object) => void} onSelect - called with the full catalog exercise
+ * @param {string} [placeholder]
+ * @param {string} [excludeId] - an exercise id to hide from results (e.g. the one being replaced)
+ * @param {boolean} [autoFocus]
+ */
+export default function ExerciseSearchInput({ onSelect, placeholder = "Search exercises...", excludeId, autoFocus }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const reqIdRef = useRef(0);
+
+  useEffect(() => {
+    const term = query.trim();
+    if (term.length < 2) {
+      setResults([]);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    const reqId = ++reqIdRef.current;
+
+    const timeoutId = setTimeout(async () => {
+      try {
+        const list = await apiService.exercises.list({ search: term, limit: 20 });
+        // Ignore out-of-order responses (a newer keystroke already fired).
+        if (reqId !== reqIdRef.current) return;
+        const filtered = (Array.isArray(list) ? list : []).filter(
+          (ex) => (ex._id || ex.id) !== excludeId
+        );
+        setResults(filtered);
+      } catch (err) {
+        if (reqId !== reqIdRef.current) return;
+        console.error("Exercise search failed:", err);
+        setError("Search failed. Try again.");
+        setResults([]);
+      } finally {
+        if (reqId === reqIdRef.current) setIsLoading(false);
+      }
+    }, 250);
+
+    return () => clearTimeout(timeoutId);
+  }, [query, excludeId]);
+
+  const handleSelect = (exercise) => {
+    setQuery("");
+    setResults([]);
+    onSelect(exercise);
+  };
+
+  const showEmpty = !isLoading && !error && query.trim().length >= 2 && results.length === 0;
+
+  return (
+    <div className="w-full">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+        <input
+          type="text"
+          value={query}
+          autoFocus={autoFocus}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={placeholder}
+          className="w-full pl-10 pr-9 py-2.5 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+        />
+        {isLoading && (
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 animate-spin" />
+        )}
+        {!isLoading && query && (
+          <button
+            onClick={() => setQuery("")}
+            className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5 text-gray-400 hover:text-gray-600"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+
+      {results.length > 0 && (
+        <ul className="mt-2 max-h-64 overflow-y-auto rounded-xl border border-gray-200 divide-y divide-gray-100">
+          {results.map((ex) => (
+            <li key={ex._id || ex.id}>
+              <button
+                onClick={() => handleSelect(ex)}
+                className="w-full text-left px-4 py-3 hover:bg-gray-50 flex items-center justify-between gap-3"
+              >
+                <div className="min-w-0">
+                  <p className="font-medium text-gray-900 truncate">{ex.name}</p>
+                  {(ex.muscles || []).length > 0 && (
+                    <p className="text-xs text-gray-500 truncate">{ex.muscles.join(", ")}</p>
+                  )}
+                </div>
+                {ex.strain?.typicalVolume && (
+                  <span className="shrink-0 text-xs text-gray-400">{ex.strain.typicalVolume}</span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showEmpty && (
+        <p className="mt-3 text-sm text-gray-500 text-center py-4">No exercises found for “{query.trim()}”.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/exercise/ReplaceExerciseModal.jsx
+++ b/frontend/src/components/exercise/ReplaceExerciseModal.jsx
@@ -1,0 +1,318 @@
+import { useState, useEffect, useRef } from "react";
+import { X, Sparkles, Search, Layers, ArrowRight, Loader2, AlertTriangle, Plus } from "lucide-react";
+import { apiService } from "@/services/api";
+import { aiService } from "@/services/aiService";
+import ExerciseSearchInput from "./ExerciseSearchInput";
+
+const TABS = [
+  { key: "similar", label: "Similar", icon: Layers },
+  { key: "sensei", label: "Ask the Sensei", icon: Sparkles },
+  { key: "search", label: "Search", icon: Search },
+];
+
+// The `reason` drives both the Sensei prompt and the safety gate (pain → caution).
+const REASONS = [
+  { key: "equipment", label: "No equipment" },
+  { key: "variety", label: "Want variety" },
+  { key: "difficulty", label: "Too hard / easy" },
+  { key: "pain", label: "Pain / injury" },
+];
+
+const REASON_TEXT = {
+  equipment: "I don't have the equipment",
+  variety: "I want variety",
+  difficulty: "It's too hard or too easy",
+  pain: "pain or injury",
+};
+
+function ExerciseResultRow({ name, subtitle, badge, onPick, disabled }) {
+  return (
+    <button
+      onClick={onPick}
+      disabled={disabled}
+      className="w-full bg-white border border-gray-200 rounded-xl p-4 hover:shadow-md hover:border-gray-300 transition-all flex items-center justify-between gap-3 text-left disabled:opacity-50"
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="font-semibold text-gray-900 truncate">{name}</h3>
+          {badge}
+        </div>
+        {subtitle && <p className="text-sm text-gray-500 truncate mt-0.5">{subtitle}</p>}
+      </div>
+      <ArrowRight className="w-4 h-4 text-gray-400 shrink-0" />
+    </button>
+  );
+}
+
+export default function ReplaceExerciseModal({ exercise, onClose, onReplace }) {
+  const [tab, setTab] = useState("similar");
+  const [reason, setReason] = useState(null);
+  const [error, setError] = useState(null);
+  const [materializingId, setMaterializingId] = useState(null);
+
+  const exerciseId = exercise?.exercise_id || null;
+  const exerciseName = exercise?.exercise_name || "";
+
+  // If there's no real id we can't query "similar" — default to Search.
+  useEffect(() => {
+    if (!exerciseId) setTab("search");
+  }, [exerciseId]);
+
+  // --- Similar tab ---
+  const [similar, setSimilar] = useState(null); // null = not loaded, [] = loaded empty
+  const [similarLoading, setSimilarLoading] = useState(false);
+
+  useEffect(() => {
+    if (tab !== "similar" || !exerciseId || similar !== null) return;
+    let cancelled = false;
+    setSimilarLoading(true);
+    apiService.exercises
+      .similar(exerciseId, 8)
+      .then((list) => { if (!cancelled) setSimilar(Array.isArray(list) ? list : []); })
+      .catch(() => { if (!cancelled) setSimilar([]); })
+      .finally(() => { if (!cancelled) setSimilarLoading(false); });
+    return () => { cancelled = true; };
+  }, [tab, exerciseId, similar]);
+
+  // --- Sensei tab ---
+  const [sensei, setSensei] = useState(null);       // { options?, routed?, message? }
+  const [senseiLoading, setSenseiLoading] = useState(false);
+  const senseiAbortRef = useRef(null);
+
+  const runSensei = () => {
+    if (senseiAbortRef.current) senseiAbortRef.current.abort();
+    const controller = new AbortController();
+    senseiAbortRef.current = controller;
+    setSenseiLoading(true);
+    setSensei(null);
+    setError(null);
+    aiService
+      .rankSubstitutes(
+        { exercise_id: exerciseId, exercise_name: exerciseName, reason: reason ? REASON_TEXT[reason] : undefined },
+        controller.signal
+      )
+      .then((res) => setSensei(res || { options: [] }))
+      .catch((err) => {
+        if (err?.name === "AbortError") return;
+        setError("The Sensei couldn't fetch options. Try again.");
+        setSensei({ options: [] });
+      })
+      .finally(() => {
+        if (senseiAbortRef.current === controller) senseiAbortRef.current = null;
+        setSenseiLoading(false);
+      });
+  };
+
+  const cancelSensei = () => {
+    if (senseiAbortRef.current) senseiAbortRef.current.abort();
+    senseiAbortRef.current = null;
+    setSenseiLoading(false);
+  };
+
+  useEffect(() => () => { if (senseiAbortRef.current) senseiAbortRef.current.abort(); }, []);
+
+  // Materialize a generated (source:"new") exercise into the catalog before swapping,
+  // so it carries a real id. Dedup by name first to avoid polluting the catalog.
+  const pickGenerated = async (opt) => {
+    setError(null);
+    setMaterializingId(opt.name);
+    try {
+      const matches = await apiService.exercises.list({ search: opt.name, limit: 5 });
+      const existing = (Array.isArray(matches) ? matches : []).find(
+        (e) => (e.name || "").toLowerCase() === (opt.name || "").toLowerCase()
+      );
+      if (existing) { onReplace(existing); return; }
+
+      const created = await apiService.exercises.create({
+        name: opt.name,
+        muscles: opt.muscles || [],
+        secondaryMuscles: opt.secondaryMuscles || [],
+        discipline: opt.discipline || ["strength"],
+        equipment: opt.equipment || [],
+        difficulty: opt.difficulty || "beginner",
+        strain: opt.strain || undefined,
+      });
+      onReplace(created);
+    } catch (err) {
+      console.error("Failed to create generated exercise:", err);
+      setError(`Couldn't add “${opt.name}”. Pick another option or search instead.`);
+    } finally {
+      setMaterializingId(null);
+    }
+  };
+
+  const pickOption = (opt) => {
+    if (opt.source === "new") return pickGenerated(opt);
+    return onReplace(opt); // catalog pick already has a real id + strain
+  };
+
+  const availableTabs = TABS.filter((t) => t.key !== "similar" || exerciseId);
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[55] flex items-end sm:items-center justify-center sm:p-4">
+      <div className="bg-white rounded-t-3xl sm:rounded-2xl shadow-2xl w-full sm:max-w-lg max-h-[92vh] flex flex-col">
+        {/* Header */}
+        <div className="p-5 border-b border-gray-100">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="text-xl font-bold text-gray-900 truncate">Replace “{exerciseName}”</h2>
+              <p className="text-sm text-gray-500 mt-0.5">Find an exercise with a similar stimulus</p>
+            </div>
+            <button onClick={onClose} className="p-2 rounded-lg hover:bg-gray-100 shrink-0">
+              <X className="w-5 h-5 text-gray-400" />
+            </button>
+          </div>
+
+          {/* Reason chips */}
+          <div className="flex flex-wrap gap-2 mt-4">
+            {REASONS.map((r) => (
+              <button
+                key={r.key}
+                onClick={() => setReason(reason === r.key ? null : r.key)}
+                className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors ${
+                  reason === r.key
+                    ? "bg-primary-600 text-white border-primary-600"
+                    : "bg-white text-gray-600 border-gray-200 hover:border-gray-300"
+                }`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-gray-100 px-2">
+          {availableTabs.map((t) => {
+            const Icon = t.icon;
+            return (
+              <button
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                className={`flex-1 flex items-center justify-center gap-1.5 py-3 text-sm font-medium border-b-2 transition-colors ${
+                  tab === t.key
+                    ? "border-primary-600 text-primary-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                <Icon className="w-4 h-4" />
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5">
+          {error && (
+            <div className="mb-4 flex items-start gap-2 text-sm text-red-700 bg-red-50 rounded-xl p-3">
+              <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {/* Similar */}
+          {tab === "similar" && (
+            <div className="space-y-3">
+              {similarLoading && (
+                <div className="space-y-3">
+                  {Array(4).fill(0).map((_, i) => (
+                    <div key={i} className="animate-pulse bg-gray-100 h-16 rounded-xl" />
+                  ))}
+                </div>
+              )}
+              {!similarLoading && similar && similar.length > 0 && similar.map((ex) => (
+                <ExerciseResultRow
+                  key={ex._id || ex.id}
+                  name={ex.name}
+                  subtitle={(ex.muscles || []).join(", ")}
+                  onPick={() => onReplace(ex)}
+                />
+              ))}
+              {!similarLoading && similar && similar.length === 0 && (
+                <p className="text-center text-gray-500 py-8 text-sm">
+                  No similar exercises found. Try “Ask the Sensei” or search below.
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Ask the Sensei */}
+          {tab === "sensei" && (
+            <div>
+              {!sensei && !senseiLoading && (
+                <div className="text-center py-8">
+                  <Sparkles className="w-10 h-10 text-primary-500 mx-auto mb-3" />
+                  <p className="text-gray-600 mb-4 text-sm">
+                    Get AI-picked alternatives{reason ? ` for “${REASONS.find((r) => r.key === reason)?.label}”` : ""}.
+                  </p>
+                  <button
+                    onClick={runSensei}
+                    className="px-5 py-2.5 bg-primary-600 text-white rounded-xl font-semibold hover:bg-primary-700"
+                  >
+                    Get options
+                  </button>
+                </div>
+              )}
+
+              {senseiLoading && (
+                <div className="text-center py-8">
+                  <Loader2 className="w-8 h-8 text-primary-500 mx-auto mb-3 animate-spin" />
+                  <p className="text-gray-500 text-sm mb-4">The Sensei is thinking…</p>
+                  <button onClick={cancelSensei} className="text-sm text-gray-500 underline">Cancel</button>
+                </div>
+              )}
+
+              {sensei?.routed === "safety" && (
+                <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-800">
+                  <AlertTriangle className="w-5 h-5 mb-2" />
+                  {sensei.message}
+                </div>
+              )}
+
+              {sensei && !sensei.routed && (sensei.options?.length > 0) && (
+                <div className="space-y-3">
+                  {sensei.options.map((opt, i) => (
+                    <ExerciseResultRow
+                      key={opt.id || `${opt.name}-${i}`}
+                      name={opt.name}
+                      subtitle={opt.note || (opt.muscles || []).join(", ")}
+                      disabled={materializingId === opt.name}
+                      badge={
+                        opt.source === "new" ? (
+                          <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 text-[11px] font-medium">
+                            <Plus className="w-3 h-3" /> New
+                          </span>
+                        ) : null
+                      }
+                      onPick={() => pickOption(opt)}
+                    />
+                  ))}
+                  <button onClick={runSensei} className="w-full text-sm text-gray-500 py-2 hover:text-gray-700">
+                    Regenerate options
+                  </button>
+                </div>
+              )}
+
+              {sensei && !sensei.routed && sensei.options?.length === 0 && !senseiLoading && (
+                <p className="text-center text-gray-500 py-8 text-sm">
+                  No options came back. Try a different reason or search below.
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Search */}
+          {tab === "search" && (
+            <ExerciseSearchInput
+              autoFocus
+              excludeId={exerciseId}
+              placeholder="Search for a replacement…"
+              onSelect={(ex) => onReplace(ex)}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/predefined/CreateWorkoutModal.jsx
+++ b/frontend/src/components/predefined/CreateWorkoutModal.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useRef } from "react";
 import { X, Plus, Trash2, GripVertical, Search, Clock, Activity, Dumbbell, ChevronDown, ChevronUp, Save } from "lucide-react";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
+import { Exercise } from "@/api/entities";
 
 // Inline Search Component for "Spotlight" feel
 const BlockSearch = ({ allExercises, onSelect }) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  const [results, setResults] = useState([]);
   const wrapperRef = useRef(null);
 
   useEffect(() => {
@@ -18,9 +20,34 @@ const BlockSearch = ({ allExercises, onSelect }) => {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const filteredExercises = searchTerm
-    ? allExercises.filter(ex => ex.name.toLowerCase().includes(searchTerm.toLowerCase())).slice(0, 5)
-    : [];
+  // Debounced server-side fuzzy search (typo tolerance + muscle/equipment
+  // matching). Falls back to in-memory substring on the pre-loaded list if the
+  // server search is unavailable or returns nothing.
+  useEffect(() => {
+    const term = searchTerm.trim();
+    if (!term) {
+      setResults([]);
+      return;
+    }
+    let cancelled = false;
+    const inMemory = () => (allExercises || [])
+      .filter(ex => ex.name.toLowerCase().includes(term.toLowerCase()))
+      .slice(0, 8);
+    const handle = setTimeout(async () => {
+      try {
+        const found = await Exercise.search(term, { limit: 8 });
+        if (!cancelled) setResults(found.length ? found : inMemory());
+      } catch {
+        if (!cancelled) setResults(inMemory());
+      }
+    }, 200);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [searchTerm, allExercises]);
+
+  const filteredExercises = results;
 
   return (
     <div ref={wrapperRef} className="relative w-full">
@@ -44,7 +71,7 @@ const BlockSearch = ({ allExercises, onSelect }) => {
           {filteredExercises.length > 0 ? (
             filteredExercises.map(ex => (
               <button
-                key={ex.id}
+                key={ex.id || ex._id}
                 onClick={() => {
                   onSelect(ex);
                   setSearchTerm("");
@@ -144,7 +171,7 @@ export default function CreateWorkoutModal({ exercises, onClose, onSave, editWor
   const handleSelectExercise = (blockIndex, exercise) => {
     const newBlocks = [...workout.blocks];
     const newExercise = {
-      exercise_id: exercise.id,
+      exercise_id: exercise.id || exercise._id,
       exercise_name: exercise.name,
       volume: "3x8",
       rest: "60s",

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -122,7 +122,6 @@ export default function Auth() {
 
       // Pre-fetch personalized suggestions in background (don't await)
       aiService.prefetchChatSuggestions(data.data.token);
-      aiService.prefetchTodayWorkout(data.data.token);
 
       navigate('/');
     } catch (error) {
@@ -175,7 +174,6 @@ export default function Auth() {
 
       // Pre-fetch personalized suggestions in background (don't await)
       aiService.prefetchChatSuggestions(registerData.data.token);
-      aiService.prefetchTodayWorkout(registerData.data.token);
 
       navigate('/');
     } catch (error) {

--- a/frontend/src/pages/AuthCallback.jsx
+++ b/frontend/src/pages/AuthCallback.jsx
@@ -35,7 +35,6 @@ export default function AuthCallback() {
             localStorage.setItem('authUser', JSON.stringify(data.data.user));
             // Pre-fetch suggestions in background
             aiService.prefetchChatSuggestions(token);
-            aiService.prefetchTodayWorkout(token);
             navigate('/Dashboard');
           } else {
             throw new Error('Failed to fetch profile');

--- a/frontend/src/pages/Documentation.jsx
+++ b/frontend/src/pages/Documentation.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FileText, Code, Database, Bot, Zap, Target, Calendar, TrendingUp } from "lucide-react";
+import { FileText, Code, Database, Bot, Zap, Target, Calendar, TrendingUp, MessageCircle } from "lucide-react";
 
 export default function Documentation() {
   return (

--- a/frontend/src/pages/Exercises.jsx
+++ b/frontend/src/pages/Exercises.jsx
@@ -247,6 +247,7 @@ export default function Exercises() {
           onEdit={handleEditExercise}
           onToggleFavorite={handleToggleFavorite}
           onDelete={handleDeleteExercise}
+          onSelectSimilar={(ex) => setViewExercise(ex)}
         />
       )}
     </div>

--- a/frontend/src/pages/Layout.jsx
+++ b/frontend/src/pages/Layout.jsx
@@ -116,6 +116,17 @@ export default function Layout({ children }) {
     return () => window.removeEventListener('storage', checkActive);
   }, [location.pathname]); // Re-check on route change
 
+  // The scrollable <main> persists across routes (Layout is a layout route),
+  // so the previous page's scroll position would otherwise carry over
+  useEffect(() => {
+    if (mainContentRef.current) {
+      // 'instant' overrides the container's scroll-smooth class
+      mainContentRef.current.scrollTo({ top: 0, behavior: 'instant' });
+    }
+    lastScrollY.current = 0;
+    setIsNavVisible(true);
+  }, [location.pathname]);
+
   useEffect(() => {
     const handleScroll = throttle(() => {
       if (!mainContentRef.current) return;
@@ -340,7 +351,7 @@ export default function Layout({ children }) {
                 className="flex flex-col items-center justify-end gap-1 min-w-[56px] h-full"
               >
                 <div className="w-12 h-12 rounded-full bg-primary-500 text-white flex items-center justify-center shadow-lg shadow-primary-500/40 -mt-5 active:scale-95 transition-transform">
-                  <Dumbbell className="w-5 h-5" strokeWidth={2.2} />
+                  <Zap className="w-5 h-5" strokeWidth={2.2} />
                 </div>
                 <span className="text-[10px] font-semibold text-primary-500 whitespace-nowrap">Train now</span>
               </Link>

--- a/frontend/src/pages/LiveWorkout.jsx
+++ b/frontend/src/pages/LiveWorkout.jsx
@@ -1,13 +1,22 @@
 import { useState, useEffect, useRef } from "react";
 import { WorkoutLog } from "@/api/entities";
-import { ArrowLeft, Square, Play, Pause, Plus, Minus, Check, X, Save, Trash2 } from "lucide-react";
+import { ArrowLeft, Square, Play, Pause, Plus, Minus, Check, X, Save, Trash2, MoreVertical, RefreshCw, ArrowUp, ArrowDown, Undo2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import {
   getActiveWorkout,
   saveWorkoutProgress,
   clearActiveWorkout,
-  startWorkoutSession
+  startWorkoutSession,
+  buildSessionExercise
 } from "@/utils/workoutSession";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import ReplaceExerciseModal from "@/components/exercise/ReplaceExerciseModal";
+import ExerciseSearchInput from "@/components/exercise/ExerciseSearchInput";
 
 // Format seconds to MM:SS
 const formatTime = (seconds) => {
@@ -261,47 +270,110 @@ function SwipeableSetRow({ setData, setIndex, onUpdate, onComplete }) {
   );
 }
 
-// Swipeable Exercise Card - swipe right to complete all sets
-function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComplete, onCompleteAll }) {
+// Swipeable Exercise Card
+// - swipe RIGHT to complete all sets (existing behavior)
+// - swipe LEFT to reveal quick Replace / Delete actions
+// - long-press (or the kebab button) opens the full action sheet
+function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComplete, onCompleteAll, onOpenMenu, onReplace, onDelete }) {
   const [translateX, setTranslateX] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
+  const [revealed, setRevealed] = useState(false);
   const startXRef = useRef(0);
-  const SWIPE_THRESHOLD = 100;
+  const startYRef = useRef(0);
+  const suppressSwipeRef = useRef(false);
+  const longPressTimerRef = useRef(null);
+  const COMPLETE_THRESHOLD = 100;   // swipe-right distance to complete all
+  const REVEAL_THRESHOLD = 60;      // swipe-left distance to snap actions open
+  const REVEAL_WIDTH = 148;         // how far the card slides left to show 2 buttons
+  const LONG_PRESS_MS = 450;
+  const MOVE_SLOP = 10;             // px of movement that cancels a long-press
 
   const completedSets = exercise.sets.filter(s => s.is_completed).length;
   const totalSets = exercise.sets.length;
   const isFullyComplete = completedSets === totalSets;
 
-  const handleStart = (clientX) => {
-    setIsDragging(true);
-    startXRef.current = clientX;
+  const cancelLongPress = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
   };
 
-  const handleMove = (clientX) => {
+  const handleStart = (clientX, clientY) => {
+    setIsDragging(true);
+    startXRef.current = clientX;
+    startYRef.current = clientY;
+    suppressSwipeRef.current = false;
+    // Start the long-press timer; any real drag (handleMove) cancels it.
+    cancelLongPress();
+    longPressTimerRef.current = setTimeout(() => {
+      suppressSwipeRef.current = true;
+      setIsDragging(false);
+      setTranslateX(0);
+      if (navigator.vibrate) navigator.vibrate(30);
+      onOpenMenu(exerciseIndex);
+    }, LONG_PRESS_MS);
+  };
+
+  const handleMove = (clientX, clientY) => {
     if (!isDragging) return;
     const diff = clientX - startXRef.current;
-    // Only allow swiping right
-    const newTranslate = Math.max(0, Math.min(diff, 150));
-    setTranslateX(newTranslate);
+    // Cancel the long-press on movement in EITHER axis — a finger sliding
+    // vertically while scrolling the list shouldn't trigger the action sheet.
+    const diffY = clientY == null ? 0 : clientY - startYRef.current;
+    if (Math.abs(diff) > MOVE_SLOP || Math.abs(diffY) > MOVE_SLOP) cancelLongPress();
+    // Right = complete (capped 150). Left = reveal actions (capped REVEAL_WIDTH).
+    const base = revealed ? -REVEAL_WIDTH : 0;
+    const next = Math.max(-REVEAL_WIDTH, Math.min(base + diff, 150));
+    setTranslateX(next);
   };
 
   const handleEnd = () => {
+    cancelLongPress();
     setIsDragging(false);
-    if (translateX > SWIPE_THRESHOLD) {
+    if (suppressSwipeRef.current) { setTranslateX(revealed ? -REVEAL_WIDTH : 0); return; }
+    if (translateX > COMPLETE_THRESHOLD) {
       onCompleteAll(exerciseIndex);
       if (navigator.vibrate) navigator.vibrate([50, 30, 50]);
+      setRevealed(false);
+      setTranslateX(0);
+    } else if (translateX < -REVEAL_THRESHOLD) {
+      setRevealed(true);
+      setTranslateX(-REVEAL_WIDTH);
+    } else {
+      setRevealed(false);
+      setTranslateX(0);
     }
-    setTranslateX(0);
   };
+
+  const closeReveal = () => { setRevealed(false); setTranslateX(0); };
 
   return (
     <div className="relative overflow-hidden rounded-3xl shadow-sm">
-      {/* Swipe background */}
+      {/* Swipe-right background: complete all */}
       <div className="absolute inset-0 bg-green-500 flex items-center pl-6">
         <div className="flex items-center gap-2 text-white">
           <Check className="w-8 h-8" />
           <span className="font-semibold">Complete All</span>
         </div>
+      </div>
+
+      {/* Swipe-left background: quick actions */}
+      <div className="absolute inset-y-0 right-0 flex items-stretch">
+        <button
+          onClick={() => { closeReveal(); onReplace(exerciseIndex); }}
+          className="w-[74px] bg-blue-600 text-white flex flex-col items-center justify-center gap-1"
+        >
+          <RefreshCw className="w-5 h-5" />
+          <span className="text-xs font-medium">Replace</span>
+        </button>
+        <button
+          onClick={() => { closeReveal(); onDelete(exerciseIndex); }}
+          className="w-[74px] bg-red-600 text-white flex flex-col items-center justify-center gap-1"
+        >
+          <Trash2 className="w-5 h-5" />
+          <span className="text-xs font-medium">Delete</span>
+        </button>
       </div>
 
       {/* Card content */}
@@ -313,25 +385,34 @@ function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComp
           transform: `translateX(${translateX}px)`,
           transition: isDragging ? 'none' : 'transform 0.2s ease-out',
         }}
-        onTouchStart={(e) => handleStart(e.touches[0].clientX)}
-        onTouchMove={(e) => handleMove(e.touches[0].clientX)}
+        onTouchStart={(e) => handleStart(e.touches[0].clientX, e.touches[0].clientY)}
+        onTouchMove={(e) => handleMove(e.touches[0].clientX, e.touches[0].clientY)}
         onTouchEnd={handleEnd}
-        onMouseDown={(e) => { e.preventDefault(); handleStart(e.clientX); }}
-        onMouseMove={(e) => isDragging && handleMove(e.clientX)}
+        onMouseDown={(e) => { e.preventDefault(); handleStart(e.clientX, e.clientY); }}
+        onMouseMove={(e) => isDragging && handleMove(e.clientX, e.clientY)}
         onMouseUp={handleEnd}
         onMouseLeave={() => isDragging && handleEnd()}
       >
         {/* Exercise Header */}
         <div className={`p-4 ${isFullyComplete ? 'bg-green-50' : 'bg-white'}`}>
-          <div className="flex items-center justify-between mb-1">
-            <h3 className="text-lg font-bold text-gray-900">{exercise.exercise_name}</h3>
-            <div className={`px-2 py-1 rounded-full text-xs font-semibold ${
+          <div className="flex items-center justify-between mb-1 gap-2">
+            <h3 className="text-lg font-bold text-gray-900 flex-1 min-w-0">{exercise.exercise_name}</h3>
+            <div className={`px-2 py-1 rounded-full text-xs font-semibold shrink-0 ${
               isFullyComplete
                 ? 'bg-green-500 text-white'
                 : 'bg-gray-100 text-gray-600'
             }`}>
               {completedSets}/{totalSets}
             </div>
+            <button
+              onClick={(e) => { e.stopPropagation(); onOpenMenu(exerciseIndex); }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onTouchStart={(e) => e.stopPropagation()}
+              aria-label="Exercise options"
+              className="shrink-0 -mr-1 p-1.5 rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            >
+              <MoreVertical className="w-5 h-5" />
+            </button>
           </div>
           {exercise.notes && (
             <p className="text-sm text-gray-500">{exercise.notes}</p>
@@ -391,6 +472,20 @@ export default function LiveWorkout() {
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
   const [workoutStartTime] = useState(new Date());
   const [isSaving, setIsSaving] = useState(false);
+
+  // Exercise-modification UI state
+  const [menuIndex, setMenuIndex] = useState(null);        // action sheet target
+  const [replaceIndex, setReplaceIndex] = useState(null);  // Replace modal target
+  const [addContext, setAddContext] = useState(null);      // { index, position } for Add above/below
+  const [confirmDelete, setConfirmDelete] = useState(null); // { index, exercise } pending delete confirm
+  const [undoState, setUndoState] = useState(null);        // { exercise, index } for the undo snackbar
+  const undoTimerRef = useRef(null);
+
+  // Clear the undo-snackbar timeout on unmount so it can't fire setUndoState
+  // after the component is gone.
+  useEffect(() => () => {
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+  }, []);
 
   // Calculate workout stats for feedback modal
   const getWorkoutStats = () => {
@@ -520,6 +615,78 @@ export default function LiveWorkout() {
     setWorkout(newWorkout);
   };
 
+  // --- Exercise modification handlers ---
+
+  // Re-normalize the cosmetic `order` field to match array position.
+  const withOrder = (exercises) => exercises.map((e, i) => ({ ...e, order: i }));
+
+  const requestDeleteExercise = (exIndex) => {
+    setMenuIndex(null);
+    setConfirmDelete({ index: exIndex, exercise: workout.exercises[exIndex] });
+  };
+
+  const performDeleteExercise = (exIndex) => {
+    const removed = workout.exercises[exIndex];
+    const nextExercises = withOrder(workout.exercises.filter((_, i) => i !== exIndex));
+    setWorkout({ ...workout, exercises: nextExercises });
+    setConfirmDelete(null);
+    // Offer an undo for a few seconds (restores the exercise with its logged sets).
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    setUndoState({ exercise: removed, index: exIndex });
+    undoTimerRef.current = setTimeout(() => setUndoState(null), 6000);
+    if (navigator.vibrate) navigator.vibrate(40);
+  };
+
+  const handleUndoDelete = () => {
+    if (!undoState) return;
+    const { exercise, index } = undoState;
+    const insertAt = Math.min(index, workout.exercises.length);
+    const nextExercises = withOrder([
+      ...workout.exercises.slice(0, insertAt),
+      exercise,
+      ...workout.exercises.slice(insertAt),
+    ]);
+    setWorkout({ ...workout, exercises: nextExercises });
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    setUndoState(null);
+  };
+
+  // Replace preserves already-logged work: it swaps identity and keeps the existing
+  // sets array (counts + completion). Only when the old exercise had no sets do we
+  // regenerate defaults from the new exercise's strain.
+  const handleReplaceExercise = (exIndex, picked) => {
+    const built = buildSessionExercise(picked, exIndex);
+    const old = workout.exercises[exIndex];
+    // Session exercises ALWAYS have a sets array, so "has sets" is always true.
+    // We only want to preserve actually-logged work; otherwise adopt the new
+    // exercise's own generated defaults (e.g. swapping Plank 3×60s → Bench Press
+    // shouldn't leave Bench Press with a 60-second target).
+    const hasLoggedWork = old.sets && old.sets.some(
+      s => s.is_completed || Number(s.reps) > 0 || Number(s.weight) > 0
+    );
+    const nextExercise = {
+      ...built,
+      notes: old.notes || '',
+      sets: hasLoggedWork ? old.sets : built.sets,
+    };
+    const nextExercises = workout.exercises.map((e, i) => (i === exIndex ? nextExercise : e));
+    setWorkout({ ...workout, exercises: withOrder(nextExercises) });
+    setReplaceIndex(null);
+    if (navigator.vibrate) navigator.vibrate(30);
+  };
+
+  const handleAddExercise = (exIndex, position, picked) => {
+    const insertAt = position === 'above' ? exIndex : exIndex + 1;
+    const nextExercises = withOrder([
+      ...workout.exercises.slice(0, insertAt),
+      buildSessionExercise(picked, insertAt),
+      ...workout.exercises.slice(insertAt),
+    ]);
+    setWorkout({ ...workout, exercises: nextExercises });
+    setAddContext(null);
+    if (navigator.vibrate) navigator.vibrate(30);
+  };
+
   // Check if all exercises are complete
   const isWorkoutComplete = workout?.exercises?.every(ex =>
     ex.sets.every(s => s.is_completed)
@@ -639,6 +806,9 @@ export default function LiveWorkout() {
             onSetUpdate={handleSetUpdate}
             onSetComplete={handleSetComplete}
             onCompleteAll={handleCompleteAllSets}
+            onOpenMenu={setMenuIndex}
+            onReplace={setReplaceIndex}
+            onDelete={requestDeleteExercise}
           />
         ))}
       </div>
@@ -657,6 +827,118 @@ export default function LiveWorkout() {
           Done Workout
         </button>
       </div>
+
+      {/* Per-exercise action sheet (long-press / kebab) */}
+      <Drawer open={menuIndex !== null} onOpenChange={(open) => !open && setMenuIndex(null)}>
+        <DrawerContent className="pb-6">
+          <DrawerHeader>
+            <DrawerTitle className="truncate">
+              {menuIndex !== null ? workout.exercises[menuIndex]?.exercise_name : ''}
+            </DrawerTitle>
+          </DrawerHeader>
+          <div className="px-4 space-y-1">
+            <button
+              onClick={() => { const i = menuIndex; setMenuIndex(null); setReplaceIndex(i); }}
+              className="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl hover:bg-gray-100 text-left"
+            >
+              <RefreshCw className="w-5 h-5 text-blue-600" />
+              <span className="font-medium text-gray-900">Replace exercise</span>
+            </button>
+            <button
+              onClick={() => { const i = menuIndex; setMenuIndex(null); setAddContext({ index: i, position: 'above' }); }}
+              className="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl hover:bg-gray-100 text-left"
+            >
+              <ArrowUp className="w-5 h-5 text-gray-700" />
+              <span className="font-medium text-gray-900">Add exercise above</span>
+            </button>
+            <button
+              onClick={() => { const i = menuIndex; setMenuIndex(null); setAddContext({ index: i, position: 'below' }); }}
+              className="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl hover:bg-gray-100 text-left"
+            >
+              <ArrowDown className="w-5 h-5 text-gray-700" />
+              <span className="font-medium text-gray-900">Add exercise below</span>
+            </button>
+            <button
+              onClick={() => requestDeleteExercise(menuIndex)}
+              className="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl hover:bg-red-50 text-left"
+            >
+              <Trash2 className="w-5 h-5 text-red-600" />
+              <span className="font-medium text-red-600">Delete exercise</span>
+            </button>
+          </div>
+        </DrawerContent>
+      </Drawer>
+
+      {/* Delete confirmation */}
+      {confirmDelete && (
+        <div className="fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4">
+          <div className="bg-white rounded-2xl p-6 w-full max-w-sm shadow-2xl">
+            <h3 className="text-lg font-bold text-gray-900 mb-2">Delete exercise?</h3>
+            <p className="text-sm text-gray-600 mb-5">
+              Remove <span className="font-semibold">{confirmDelete.exercise?.exercise_name}</span> from
+              this workout? You can undo right after.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setConfirmDelete(null)}
+                className="flex-1 py-3 rounded-xl font-semibold bg-gray-100 text-gray-700"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => performDeleteExercise(confirmDelete.index)}
+                className="flex-1 py-3 rounded-xl font-semibold bg-red-600 text-white"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Undo snackbar */}
+      {undoState && (
+        <div className="fixed bottom-40 left-0 right-0 px-4 z-[60] flex justify-center">
+          <div className="bg-gray-900 text-white rounded-full pl-5 pr-2 py-2 shadow-lg flex items-center gap-3 max-w-sm w-full">
+            <span className="text-sm flex-1 truncate">Deleted “{undoState.exercise?.exercise_name}”</span>
+            <button
+              onClick={handleUndoDelete}
+              className="flex items-center gap-1.5 bg-white/15 hover:bg-white/25 rounded-full px-3 py-1.5 text-sm font-semibold"
+            >
+              <Undo2 className="w-4 h-4" /> Undo
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Replace exercise modal (Similar / Ask the Sensei / Search) */}
+      {replaceIndex !== null && (
+        <ReplaceExerciseModal
+          exercise={workout.exercises[replaceIndex]}
+          onClose={() => setReplaceIndex(null)}
+          onReplace={(picked) => handleReplaceExercise(replaceIndex, picked)}
+        />
+      )}
+
+      {/* Add exercise picker (above / below) */}
+      <Drawer open={addContext !== null} onOpenChange={(open) => !open && setAddContext(null)}>
+        <DrawerContent className="pb-6">
+          <DrawerHeader>
+            <DrawerTitle>
+              {addContext?.position === 'above' ? 'Add exercise above' : 'Add exercise below'}
+            </DrawerTitle>
+          </DrawerHeader>
+          <div className="px-4">
+            {addContext && (
+              <ExerciseSearchInput
+                autoFocus
+                placeholder="Search to add an exercise..."
+                onSelect={(ex) => handleAddExercise(addContext.index, addContext.position, ex)}
+              />
+            )}
+          </div>
+        </DrawerContent>
+      </Drawer>
     </div>
   );
 }

--- a/frontend/src/pages/TrainNow.jsx
+++ b/frontend/src/pages/TrainNow.jsx
@@ -8,6 +8,7 @@ import {
 import { Link, useNavigate } from "react-router-dom";
 import { createPageUrl } from "@/utils";
 import { getDisciplineClass } from "@/styles/designTokens";
+import { pickTodaySession } from "@/utils/todaySession";
 import WorkoutDetailModal from "../components/predefined/WorkoutDetailModal";
 import { aiService } from "@/services/aiService";
 import {
@@ -36,7 +37,7 @@ const getWorkoutImage = (workout) => {
 };
 
 // Quick start card - prominent CTA
-function QuickStartCard({ workout, onStart, isFromCalendar, isLoading, reasoning }) {
+function QuickStartCard({ workout, onStart, isFromCalendar, isLoading, reasoning, completedToday, onRegenerate }) {
   if (isLoading) {
     return (
       <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary-500 to-indigo-700 p-6 text-white">
@@ -53,6 +54,35 @@ function QuickStartCard({ workout, onStart, isFromCalendar, isLoading, reasoning
             <div className="h-4 bg-white/20 rounded w-20" />
           </div>
           <div className="h-12 bg-white/30 rounded-xl" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!workout && completedToday) {
+    // Already trained today — celebrate instead of re-serving a suggestion
+    return (
+      <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-emerald-500 to-teal-700 p-6 text-white">
+        <div className="absolute top-0 right-0 w-32 h-32 bg-white/10 rounded-full -translate-y-1/2 translate-x-1/2" />
+        <div className="absolute bottom-0 left-0 w-24 h-24 bg-white/5 rounded-full translate-y-1/2 -translate-x-1/2" />
+        <div className="relative z-10">
+          <div className="flex items-center gap-2 mb-3">
+            <Flame className="w-5 h-5 text-emerald-100" />
+            <span className="text-sm font-medium text-emerald-100">Done for Today</span>
+          </div>
+          <h3 className="text-xl font-bold mb-2">Session Complete</h3>
+          <p className="text-sm text-emerald-100 mb-4">
+            Nice work — you've already trained today. Feeling like more?
+          </p>
+          {onRegenerate && (
+            <button
+              onClick={onRegenerate}
+              className="w-full bg-white text-emerald-700 font-semibold py-3 rounded-xl flex items-center justify-center gap-2 hover:bg-emerald-50 transition-colors"
+            >
+              <Sparkles className="w-5 h-5" />
+              Get another workout
+            </button>
+          )}
         </div>
       </div>
     );
@@ -127,6 +157,16 @@ function QuickStartCard({ workout, onStart, isFromCalendar, isLoading, reasoning
             <Sparkles className="w-5 h-5" />
             Talk to Sensei
           </Link>
+
+          {onRegenerate && (
+            <button
+              onClick={onRegenerate}
+              className="w-full mt-2 bg-white/10 text-white/90 font-medium py-2.5 rounded-xl flex items-center justify-center gap-2 hover:bg-white/20 transition-colors text-sm"
+            >
+              <Flame className="w-4 h-4" />
+              I want to train anyway
+            </button>
+          )}
         </div>
       </div>
     );
@@ -169,6 +209,16 @@ function QuickStartCard({ workout, onStart, isFromCalendar, isLoading, reasoning
           <Play className="w-5 h-5" />
           Start Now
         </button>
+
+        {!isFromCalendar && onRegenerate && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onRegenerate(); }}
+            className="w-full mt-2 bg-white/10 text-white/90 font-medium py-2.5 rounded-xl flex items-center justify-center gap-2 hover:bg-white/20 transition-colors text-sm"
+          >
+            <Sparkles className="w-4 h-4" />
+            New suggestion
+          </button>
+        )}
       </div>
     </div>
   );
@@ -258,11 +308,12 @@ export default function TrainNow() {
   const [workoutToView, setWorkoutToView] = useState(null);
   const [coachPrompt, setCoachPrompt] = useState("");
 
-  // Today's workout suggestion state (3-tier: calendar -> cache -> AI)
+  // Today's workout suggestion state (calendar -> persisted daily AI suggestion)
   const [todaySuggestion, setTodaySuggestion] = useState(null);
   const [suggestionLoading, setSuggestionLoading] = useState(true);
   const [isFromCalendar, setIsFromCalendar] = useState(false);
   const [suggestionReasoning, setSuggestionReasoning] = useState(null);
+  const [completedToday, setCompletedToday] = useState(false);
 
   // Active workout state (for resume/conflict handling)
   const [activeWorkout, setActiveWorkout] = useState(null);
@@ -307,56 +358,45 @@ export default function TrainNow() {
   };
 
   /**
-   * 3-tier loading for today's workout suggestion:
-   * 1. Always check calendar first (source of truth)
-   * 2. If no calendar event, check cache
-   * 3. If no cache, fetch from AI
+   * 2-tier loading for today's workout suggestion (aligned with the Dashboard):
+   * 1. Calendar first (source of truth) — shared selection rule (pickTodaySession)
+   * 2. Otherwise the server-persisted daily AI suggestion (generated once per
+   *    day, same document the Dashboard reads)
+   * @param {boolean} refresh - skip the calendar/completed checks and force a
+   *   fresh AI generation (replaces today's persisted recommendation)
    */
-  const loadTodaySuggestion = async () => {
-    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-    console.log('🏋️ [TrainNow] Starting workout suggestion load...');
-    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  const loadTodaySuggestion = async (refresh = false) => {
     setSuggestionLoading(true);
     const token = localStorage.getItem('authToken');
-    console.log('🔑 [TrainNow] Auth token:', token ? `${token.substring(0, 20)}...` : 'null');
 
     if (!token) {
-      console.log('❌ [TrainNow] No auth token found, skipping suggestion load');
+      console.log('[TrainNow] No auth token found, skipping suggestion load');
       setSuggestionLoading(false);
       return;
     }
 
     try {
-      // Step 1: Always check calendar first (with cache-busting)
-      console.log('\n📅 [TrainNow] STEP 1: Checking calendar...');
-      const calendarResponse = await fetch(`${API_BASE_URL}/api/v1/calendar/today?_t=${Date.now()}`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Cache-Control': 'no-cache'
-        }
-      });
+      if (!refresh) {
+        // Step 1: Always check calendar first
+        const calendarResponse = await fetch(`${API_BASE_URL}/api/v1/calendar/today?_t=${Date.now()}`, {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Cache-Control': 'no-cache'
+          }
+        });
 
-      console.log('📅 [TrainNow] Calendar response status:', calendarResponse.status);
+        if (calendarResponse.ok) {
+          const calendarData = await calendarResponse.json();
+          // Calendar returns { success: true, data: { events: [...] } }
+          const events = calendarData.data?.events || calendarData.data || [];
+          const { scheduledEvent, completedToday: doneToday } = pickTodaySession(events);
+          setCompletedToday(doneToday);
 
-      if (calendarResponse.ok) {
-        const calendarData = await calendarResponse.json();
-        console.log('📅 [TrainNow] Calendar data:', JSON.stringify(calendarData, null, 2));
-
-        // Calendar returns { success: true, data: { events: [...] } }
-        const events = calendarData.data?.events || calendarData.data || [];
-        console.log('📅 [TrainNow] Events array:', events.length, 'items');
-
-        if (calendarData.success && events.length > 0) {
-          const todayWorkout = events.find(
-            e => e.type === 'workout' && e.status === 'scheduled'
-          );
-
-          if (todayWorkout) {
-            console.log('✅ [TrainNow] SELECTED: Calendar workout -', todayWorkout.title);
-            console.log('📋 [TrainNow] Calendar workout details:', JSON.stringify(todayWorkout.workoutDetails, null, 2));
+          if (calendarData.success && scheduledEvent?.type === 'workout') {
+            console.log('[TrainNow] Using calendar workout -', scheduledEvent.title);
 
             // Convert calendar exercise format to the format expected by parseWorkoutToSessionData
-            const calendarExercises = todayWorkout.workoutDetails?.exercises || [];
+            const calendarExercises = scheduledEvent.workoutDetails?.exercises || [];
             const convertedExercises = calendarExercises.map(ex => ({
               exercise_name: ex.exerciseName || ex.exercise_name,
               volume: ex.targetSets && ex.targetReps ? `${ex.targetSets}x${ex.targetReps}` : null,
@@ -365,91 +405,51 @@ export default function TrainNow() {
               notes: ex.notes || ''
             }));
 
-            const workoutFromCalendar = {
-              id: todayWorkout._id,
-              name: todayWorkout.title,
-              estimated_duration: todayWorkout.workoutDetails?.estimatedDuration || 45,
-              primary_disciplines: [todayWorkout.workoutDetails?.type || 'strength'],
-              blocks: todayWorkout.workoutTemplateId?.blocks || [],
+            setTodaySuggestion({
+              id: scheduledEvent._id,
+              name: scheduledEvent.title,
+              estimated_duration: scheduledEvent.workoutDetails?.estimatedDuration || 45,
+              primary_disciplines: [scheduledEvent.workoutDetails?.type || 'strength'],
+              blocks: scheduledEvent.workoutTemplateId?.blocks || [],
               exercises: convertedExercises, // Include exercises from calendar event
-              calendarEventId: todayWorkout._id
-            };
-
-            console.log('📋 [TrainNow] Converted workout object:', JSON.stringify(workoutFromCalendar, null, 2));
-            setTodaySuggestion(workoutFromCalendar);
+              calendarEventId: scheduledEvent._id
+            });
             setIsFromCalendar(true);
             setSuggestionLoading(false);
-            console.log('🏁 [TrainNow] Done - using calendar workout');
             return;
-          } else {
-            console.log('📅 [TrainNow] No scheduled workout found in calendar events');
           }
-        } else {
-          console.log('📅 [TrainNow] Calendar returned empty or no data');
+
+          if (doneToday && !scheduledEvent) {
+            // Already trained today — show the completed state instead of
+            // re-serving this morning's suggestion. "Train more" regenerates.
+            setTodaySuggestion(null);
+            setIsFromCalendar(false);
+            setSuggestionLoading(false);
+            return;
+          }
         }
-      } else {
-        console.log('⚠️ [TrainNow] Calendar API failed with status:', calendarResponse.status);
       }
 
-      // Step 2: No calendar event, check cache
-      console.log('\n📦 [TrainNow] STEP 2: Checking cache...');
-      const cached = aiService.getCachedTodayWorkout();
-      console.log('📦 [TrainNow] Cache result:', cached);
-
-      if (cached?.suggestion) {
-        console.log('✅ [TrainNow] SELECTED: Cached suggestion -', cached.suggestion.name);
-        setTodaySuggestion(cached.suggestion);
-        setSuggestionReasoning(cached.suggestion.reasoning);
+      // Step 2: Server-persisted daily suggestion (same one the Dashboard shows)
+      const data = await aiService.getTodayWorkout(refresh);
+      if (data?.suggestion) {
+        console.log('[TrainNow] Using AI suggestion -', data.suggestion.name, data.cached ? '(persisted)' : '(fresh)');
+        setTodaySuggestion(data.suggestion);
+        setSuggestionReasoning(data.suggestion.reasoning);
         setIsFromCalendar(false);
-        setSuggestionLoading(false);
-        console.log('🏁 [TrainNow] Done - using cached suggestion');
-        return;
+        if (refresh) setCompletedToday(false);
       } else {
-        console.log('📦 [TrainNow] No valid cache found, proceeding to AI...');
-      }
-
-      // Step 3: No cache, fetch from AI
-      console.log('\n🤖 [TrainNow] STEP 3: Fetching from AI...');
-      console.log('🤖 [TrainNow] Calling:', `${API_BASE_URL}/api/v1/train-now`);
-
-      const aiResponse = await fetch(`${API_BASE_URL}/api/v1/train-now`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
-
-      console.log('🤖 [TrainNow] AI response status:', aiResponse.status);
-
-      if (aiResponse.ok) {
-        const aiData = await aiResponse.json();
-        console.log('🤖 [TrainNow] AI response:', JSON.stringify(aiData, null, 2));
-
-        if (aiData.success && aiData.suggestion) {
-          console.log('✅ [TrainNow] SELECTED: AI suggestion -', aiData.suggestion.name);
-          localStorage.setItem('todayWorkoutSuggestion', JSON.stringify({
-            suggestion: aiData.suggestion,
-            source: aiData.source,
-            timestamp: Date.now()
-          }));
-          setTodaySuggestion(aiData.suggestion);
-          setSuggestionReasoning(aiData.suggestion.reasoning);
-          setIsFromCalendar(false);
-          console.log('🏁 [TrainNow] Done - using AI suggestion');
-        } else {
-          console.log('⚠️ [TrainNow] AI returned no suggestion:', aiData.error || 'Unknown error');
-          console.log('🏁 [TrainNow] Done - NO WORKOUT TO SHOW');
-        }
-      } else {
-        const errorText = await aiResponse.text();
-        console.log('❌ [TrainNow] AI request failed:', aiResponse.status, errorText);
-        console.log('🏁 [TrainNow] Done - AI FAILED');
+        console.log('[TrainNow] No AI suggestion available');
       }
     } catch (error) {
-      console.error('❌ [TrainNow] Exception:', error);
-      console.log('🏁 [TrainNow] Done - EXCEPTION');
+      console.error('[TrainNow] Error loading suggestion:', error);
     }
 
     setSuggestionLoading(false);
-    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   };
+
+  // Force a fresh AI generation (replaces today's persisted recommendation)
+  const regenerateSuggestion = () => loadTodaySuggestion(true);
 
   // Get workouts by category
   const getWorkoutsByDiscipline = (discipline) => {
@@ -692,13 +692,15 @@ I want to start training RIGHT NOW but I'm not sure what to do. Help me decide w
             </div>
           )}
 
-          {/* Featured / Quick Start - 3-tier: calendar -> cache -> AI */}
+          {/* Featured / Quick Start - calendar -> persisted daily AI suggestion */}
           <QuickStartCard
             workout={featuredWorkout}
             onStart={startWorkout}
             isFromCalendar={isFromCalendar}
             isLoading={suggestionLoading}
             reasoning={suggestionReasoning}
+            completedToday={completedToday}
+            onRegenerate={regenerateSuggestion}
           />
 
           {/* Ask Sensei Section - Compact */}

--- a/frontend/src/services/aiService.js
+++ b/frontend/src/services/aiService.js
@@ -317,117 +317,32 @@ class AIService {
   }
 
   /**
-   * Pre-fetch today's workout suggestion and cache it in localStorage
-   * Always fetches a fresh suggestion on login (clears old cache first)
-   * @param {string} token - Auth token (optional, uses stored token if not provided)
-   * @returns {Promise<Object|null>} Workout suggestion or null
+   * Get today's workout suggestion from the server.
+   * The AI service persists one recommendation per user per day (MongoDB,
+   * 30-day TTL), so after the first generation of the day this is a fast
+   * read — and every surface (Dashboard, TrainNow) sees the SAME suggestion.
+   * @param {boolean} refresh - force a fresh generation (replaces today's doc)
+   * @returns {Promise<{suggestion: Object, source: string, cached?: boolean}|null>}
    */
-  async prefetchTodayWorkout(token = null) {
-    console.log('🚀 [Prefetch] prefetchTodayWorkout called');
-    const authToken = token || this.getAuthToken();
-    if (!authToken) {
-      console.warn('[Prefetch] No auth token available for prefetching today workout');
-      return null;
-    }
-
-    // Always clear old cache on login to get fresh suggestion
-    console.log('🔄 [Prefetch] Clearing old workout cache on login...');
-    this.clearCachedTodayWorkout();
+  async getTodayWorkout(refresh = false) {
+    const token = this.getAuthToken();
+    if (!token) return null;
 
     try {
-      // Skip calendar check - always fetch fresh AI suggestion on login
-      console.log('🤖 [Prefetch] Fetching fresh AI suggestion...');
-      const response = await fetch(`${this.baseURL}/api/v1/train-now`, {
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
+      const url = `${this.baseURL}/api/v1/train-now${refresh ? '?refresh=true' : ''}`;
+      const response = await fetch(url, {
+        headers: { 'Authorization': `Bearer ${token}` }
       });
-
-      console.log('🤖 [Prefetch] AI response status:', response.status);
-
-      if (response.ok) {
-        const data = await response.json();
-        console.log('🤖 [Prefetch] AI response:', {
-          success: data.success,
-          hasSuggestion: !!data.suggestion,
-          suggestionName: data.suggestion?.name,
-          error: data.error
-        });
-
-        if (data.success && data.suggestion) {
-          // Cache suggestion with timestamp
-          localStorage.setItem('todayWorkoutSuggestion', JSON.stringify({
-            suggestion: data.suggestion,
-            source: data.source,
-            timestamp: Date.now()
-          }));
-          console.log('✅ [Prefetch] Cached today\'s workout:', data.suggestion.name);
-          return data.suggestion;
-        } else {
-          console.log('⚠️ [Prefetch] AI returned no suggestion:', data.error || 'No error message');
-        }
-      } else {
-        const errorText = await response.text();
-        console.log('❌ [Prefetch] AI request failed:', response.status, errorText);
+      if (!response.ok) return null;
+      const data = await response.json();
+      if (data.success && data.suggestion) {
+        return { suggestion: data.suggestion, source: data.source, cached: data.cached };
       }
       return null;
     } catch (error) {
-      console.error('❌ [Prefetch] Error pre-fetching today workout:', error);
+      console.error('Error fetching today workout:', error);
       return null;
     }
-  }
-
-  /**
-   * Get cached today's workout suggestion from localStorage
-   * Returns null if cache is stale (older than 1 hour) or missing
-   * @returns {Object|null} Cached suggestion or null
-   */
-  getCachedTodayWorkout() {
-    console.log('📦 [Cache] getCachedTodayWorkout called');
-    try {
-      const cached = localStorage.getItem('todayWorkoutSuggestion');
-      console.log('📦 [Cache] Raw localStorage value:', cached ? `${cached.substring(0, 100)}...` : 'null');
-
-      if (!cached) {
-        console.log('📦 [Cache] No cache found in localStorage');
-        return null;
-      }
-
-      const parsed = JSON.parse(cached);
-      const { suggestion, source, timestamp } = parsed;
-      const ONE_HOUR = 60 * 60 * 1000;
-      const age = Date.now() - timestamp;
-      const ageMinutes = Math.round(age / 60000);
-
-      console.log('📦 [Cache] Parsed cache:', {
-        hasSuggestion: !!suggestion,
-        suggestionName: suggestion?.name,
-        source,
-        ageMinutes,
-        isStale: age >= ONE_HOUR
-      });
-
-      // Check if cache is still fresh (less than 1 hour old)
-      if (age < ONE_HOUR && suggestion) {
-        console.log('✅ [Cache] Returning valid cache:', suggestion.name);
-        return { suggestion, source };
-      }
-
-      // Cache is stale, clear it
-      console.log('⚠️ [Cache] Cache is stale, clearing...');
-      localStorage.removeItem('todayWorkoutSuggestion');
-      return null;
-    } catch (error) {
-      console.error('❌ [Cache] Error reading cache:', error);
-      return null;
-    }
-  }
-
-  /**
-   * Clear cached today's workout (call on logout or when calendar changes)
-   */
-  clearCachedTodayWorkout() {
-    localStorage.removeItem('todayWorkoutSuggestion');
   }
 
   /**
@@ -513,12 +428,35 @@ class AIService {
   }
 
   /**
+   * Ask the Sensei for exercise replacement options (one-shot, no conversation).
+   * Returns catalog picks and/or fresh (source:"new") suggestions the caller can
+   * materialize before swapping. When reason is pain/injury the server may route
+   * to a safety caution instead of options.
+   * @param {{ exercise_id?: string, exercise_name?: string, reason?: string, count?: number }} params
+   * @returns {Promise<{ options?: Array, routed?: string, message?: string, fallback?: boolean }>}
+   */
+  async rankSubstitutes({ exercise_id, exercise_name, reason, count = 5 } = {}, signal) {
+    return this.request('/api/v1/ai/exercises/substitute/rank', {
+      method: 'POST',
+      body: JSON.stringify({ exercise_id, exercise_name, reason, count }),
+      ...(signal ? { signal } : {})
+    });
+  }
+
+  /**
    * Clear all cached data (call on logout)
    */
   clearAllCache() {
     this.clearCachedSuggestions();
-    this.clearCachedTodayWorkout();
   }
+}
+
+// One-time cleanup: the suggestion is now persisted server-side (MongoDB),
+// remove the legacy localStorage cache left behind by older versions.
+try {
+  localStorage.removeItem('todayWorkoutSuggestion');
+} catch {
+  /* ignore storage errors */
 }
 
 // Export singleton instance

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -91,13 +91,26 @@ class APIService {
 
   // Exercise endpoints
   exercises = {
-    list: async () => {
-      const response = await this.request('/exercises');
+    // Optional params: { search, muscle, discipline, equipment, difficulty, page, limit }.
+    // When `search` is present the backend does the matching (server-side), so the
+    // typeahead does not download the whole catalog. Falls back to substring today;
+    // upgrades to Atlas $search transparently once the search index lands.
+    list: async (params = {}) => {
+      const query = new URLSearchParams(
+        Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== '')
+      ).toString();
+      const response = await this.request(`/exercises${query ? `?${query}` : ''}`);
       // Backend returns { exercises: [...], pagination: {...} }
       // Extract just the exercises array
       return response.exercises || response;
     },
     get: (id) => this.request(`/exercises/${id}`),
+    // Semantically similar exercises (swap/alternative suggestions) via vector search.
+    similar: async (id, limit) => {
+      const query = limit ? `?limit=${limit}` : '';
+      const response = await this.request(`/exercises/${id}/similar${query}`);
+      return response.exercises || response || [];
+    },
     create: (data) => this.request('/exercises', {
       method: 'POST',
       body: JSON.stringify(data)

--- a/frontend/src/utils/todaySession.js
+++ b/frontend/src/utils/todaySession.js
@@ -1,0 +1,32 @@
+/**
+ * Single source of truth for picking "today's session" from calendar events.
+ * Shared by the Dashboard hero (TodayView) and the TrainNow page so both
+ * surfaces always agree on what today looks like.
+ */
+
+const DONE_STATUSES = ["completed", "cancelled", "skipped"];
+
+/**
+ * @param {Array} events - today's calendar events
+ * @returns {{ scheduledEvent: Object|null, completedToday: boolean }}
+ *   scheduledEvent — the pending event to surface: prefers a workout, but
+ *   falls back to any other pending event (e.g. a race/competition day) so
+ *   it isn't hidden behind an AI suggestion.
+ *   completedToday — whether a workout was already completed today.
+ */
+export function pickTodaySession(events) {
+  const list = Array.isArray(events) ? events : [];
+
+  const pending = list.filter(
+    (e) => !DONE_STATUSES.includes(e.status || "scheduled")
+  );
+
+  const scheduledEvent =
+    pending.find((e) => e.type === "workout") || pending[0] || null;
+
+  const completedToday = list.some(
+    (e) => e.type === "workout" && e.status === "completed"
+  );
+
+  return { scheduledEvent, completedToday };
+}

--- a/frontend/src/utils/workoutSession.js
+++ b/frontend/src/utils/workoutSession.js
@@ -279,4 +279,47 @@ export function parseWorkoutToSessionData(workout) {
   return sessionData;
 }
 
-export { ACTIVE_WORKOUT_KEY, ACTIVE_WORKOUT_TTL };
+/**
+ * Build a single live-session exercise from a catalog/generated exercise object.
+ * Used when replacing or inserting an exercise mid-workout.
+ *
+ * Guarantees the same set shape as parseWorkoutToSessionData so logging/stats stay
+ * consistent. exercise_id is a real 24-hex ObjectId or null (never a fabricated
+ * string) — a null id logs to WorkoutLog without breaking, matching the existing gate.
+ *
+ * Default sets come from the catalog's strain.typicalVolume (camelCase — note the
+ * backend field is typicalVolume, NOT typical_volume); falls back to 3x10 / 90s rest.
+ *
+ * @param {Object} exercise - a catalog exercise ({ id|_id, name, strain })
+ * @param {number} [order=0]
+ * @returns {WorkoutExercise}
+ */
+export function buildSessionExercise(exercise, order = 0) {
+  const rawId = exercise?.id || exercise?._id;
+  const typicalVolume = exercise?.strain?.typicalVolume;
+  const parsedVolume = parseVolume(typicalVolume);
+
+  const numSets = parsedVolume?.numSets || 3;
+  const numReps = parsedVolume?.numReps || 10;
+
+  const sets = [];
+  for (let i = 0; i < numSets; i++) {
+    sets.push({
+      target_reps: numReps,
+      reps: 0,
+      weight: 0,
+      rest_seconds: 90,
+      is_completed: false
+    });
+  }
+
+  return {
+    exercise_id: isValidObjectId(rawId) ? rawId : null,
+    exercise_name: exercise?.name || exercise?.exercise_name || 'Exercise',
+    notes: '',
+    order,
+    sets
+  };
+}
+
+export { ACTIVE_WORKOUT_KEY, ACTIVE_WORKOUT_TTL, isValidObjectId };


### PR DESCRIPTION
## Summary
Adds semantic **exercise similarity** (embeddings + Atlas Vector Search) and upgrades exercise search, plus review-driven bug fixes across the replace-exercise flow and a new Sensei capability.

### Exercise similarity / RAG
- `embedding` (1536-dim, `select:false`) + `embeddingText` on the Exercise model, generated on write via a `pre('save')` hook (auto-embeds new/edited exercises — no batch job).
- Composite embed text: name + muscles + equipment + discipline + inferred **movement pattern** (`movementPattern.js`, ported from the Python `movement.py`).
- `ExerciseService.findSimilar` → Atlas `$vectorSearch` on `exercise_vector_index`, visibility-filtered, with a deterministic muscle-overlap fallback when embeddings/index aren't available.
- `GET /exercises/:id/similar` + `find_similar_exercises` MCP tool + a "Similar exercises" surface in the detail modal.
- One-shot `backfillEmbeddings.js`. Atlas vector + search indexes created idempotently in `ensureIndexes.js`.

### Fuzzy search
- Server-side Atlas `$search` (typo tolerance + muscle/equipment/description matching) with facets applied pre-pagination; falls back to in-memory substring when the index is missing/building or returns empty.
- Typeahead + entity layer wired to server search.

### Sensei (in-app AI coach)
- New read-only `find_similar_exercises` skill delegating to `ExerciseService.find_similar` (queries the shared vector index; never writes embeddings).

### Review fixes
- Replace flow: `keepSets` → logged-work check; long-press cancels on vertical scroll; undo-timer unmount cleanup.
- Embeddings: strip `embedding`/`embeddingText` from request bodies; `embeddingText` no longer leaks in responses; `dimensions` passed to OpenAI; wider projections.
- Python substitute/rank: generated options inherit muscles when empty; Node proxy gets a 30s timeout.

## Verification
- Vector index READY & queryable; all 63 exercises embedded; `findSimilar` verified end-to-end against production (pull→pull, squat→squat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)