### PR TITLE
fix(exercises): prevent blank screen when opening exercise detail

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,11 +2,14 @@ import './App.css'
 import Pages from "@/pages/index.jsx"
 import { Toaster } from "@/components/ui/toaster"
 import { ThemeProvider } from "@/contexts/ThemeContext"
+import ErrorBoundary from "@/components/ErrorBoundary"
 
 function App() {
   return (
     <ThemeProvider>
-      <Pages />
+      <ErrorBoundary>
+        <Pages />
+      </ErrorBoundary>
       <Toaster />
     </ThemeProvider>
   )

--- a/frontend/src/api/mongodb-entities.js
+++ b/frontend/src/api/mongodb-entities.js
@@ -38,6 +38,16 @@ export const Exercise = {
     }
   },
   findById: async (id) => Exercise.get(id),
+  // Semantically similar exercises (swap/alternative suggestions) via vector search.
+  // Never throws — the callers use this on modal open and a failure must not crash the app.
+  similar: async (id, limit) => {
+    try {
+      return normalizeArray(await apiService.exercises.similar(id, limit));
+    } catch (error) {
+      console.error('Exercise.similar error:', error);
+      return [];
+    }
+  },
   toggleFavorite: async (id, isFavorite) => apiService.exercises.toggleFavorite(id, isFavorite),
   customize: async (id, modifications) => apiService.exercises.customize(id, modifications),
   removeCustomization: async (id) => apiService.exercises.removeCustomization(id)

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+/**
+ * App-level error boundary. Without this, any uncaught render-phase throw
+ * unmounts the entire SPA and leaves a blank white page. This contains the
+ * failure to a friendly fallback and gives the user a way to recover.
+ */
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("ErrorBoundary caught an error:", error, info);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-gray-50 p-6">
+          <div className="max-w-md w-full text-center bg-white rounded-2xl shadow-lg p-8">
+            <h1 className="text-xl font-bold text-gray-900 mb-2">Something went wrong</h1>
+            <p className="text-sm text-gray-600 mb-6">
+              An unexpected error occurred. You can try again, and if it keeps
+              happening please reload the page.
+            </p>
+            <div className="flex gap-3 justify-center">
+              <button
+                onClick={this.handleReset}
+                className="bg-gray-900 hover:bg-gray-800 text-white px-5 py-2.5 rounded-xl font-semibold transition-colors"
+              >
+                Try again
+              </button>
+              <button
+                onClick={() => window.location.reload()}
+                className="bg-white hover:bg-gray-50 text-gray-700 border border-gray-200 px-5 py-2.5 rounded-xl font-semibold transition-colors"
+              >
+                Reload
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/exercise/ExerciseDetailModal.jsx
+++ b/frontend/src/components/exercise/ExerciseDetailModal.jsx
@@ -51,6 +51,8 @@ export default function ExerciseDetailModal({ exercise, onClose, onEdit, onToggl
     setSimilar([]);
     Exercise.similar(id, 6).then((found) => {
       if (!cancelled) setSimilar(found || []);
+    }).catch(() => {
+      if (!cancelled) setSimilar([]);
     });
     return () => { cancelled = true; };
   }, [exercise.id, exercise._id]);


### PR DESCRIPTION
## Problem
Clicking any exercise on the Exercises tab blanked the entire app.

Console: `TypeError: Exercise.similar is not a function`.

The detail modal calls `Exercise.similar()` on mount, but the entity actually used app-wide (`mongodb-entities.js`, via the `@/api/entities` barrel) had no such method. The throw happened during render, and with no ErrorBoundary React 18 unmounted the whole SPA → blank white page.

## Fix
- Add `Exercise.similar()` to `mongodb-entities.js`, delegating to the existing `apiService.exercises.similar` and normalizing `_id`→`id`; returns `[]` on failure.
- Guard the caller in `ExerciseDetailModal` with a `.catch` fallback.
- Add an app-level `ErrorBoundary` so a future render throw shows a recoverable fallback instead of a blank page.

## Verification
- `vite build` passes.
- Manual: open several exercises → detail modal opens, no blank screen, no console error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)