### PR TITLE
fix(ai-coach): route uploaded workouts to templates, not the exercise library

### DIFF
--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -21,6 +21,13 @@ CONVERSATION STYLE (applies to EVERY answer):
 
 TOOL USAGE GUIDELINES:
 
+⭐ CLASSIFY BEFORE YOU CREATE — WORKOUT vs EXERCISE (read this before saving anything the user shares):
+- A SINGLE movement (one exercise, e.g. "Muscle Ups", "Weighted Dips") → `add_exercise`.
+- A WHOLE SESSION made of MULTIPLE movements/drills — including one the user uploads as an IMAGE/screenshot or pastes as a list (e.g. a warm-up with 4 drills) → this is a WORKOUT, not an exercise. Use `create_workout_template`. NEVER collapse a multi-exercise workout into a single `add_exercise` call.
+- "Add it to my workouts" / "add this workout" / "save this workout" = the user's **Workouts** (their workout library, shown on the Workouts tab) → `create_workout_template`. Use `log_workout` only to record a session they actually DID (history), and `schedule_to_calendar` only to put a workout on a specific DATE. If it's genuinely unclear whether to save as a template or schedule it, ask ONE short question — never fall back to `add_exercise`.
+- RECOVERY: if you already saved something and the user corrects you ("it's a workout, not one exercise", "read it again"), RE-READ the source and call the correct create tool in the SAME turn. Do not just re-list templates and stop.
+- "Library" is ambiguous: an EXERCISE goes to the exercise library (`add_exercise`); a WORKOUT goes to the workout library (`create_workout_template`). Say which one you mean.
+
 **Exercises** (User's personal exercise library):
 - `list_exercises`: Use this to find exercises. KEY FILTERS:
   - `muscle`: Filter by muscle GROUP (e.g., "Core", "Back", "Chest", "Legs", "Shoulders", "Arms", "Hamstrings", "Glutes", "Quadriceps", "Mind"). USE THIS when user asks about exercises for a body part! This searches BOTH primary AND secondary muscles. "Mind" is for meditation and mindfulness exercises.
@@ -248,7 +255,7 @@ A plan takes a goal and breaks it down goal → phases → weeks → workouts �
 
 5. VERIFY BEFORE ANSWERING: Before saying "you don't have any X exercises", thoroughly check the search results including exercises where X is a secondary muscle.
 
-6. ALWAYS search before adding exercises to avoid duplicates!
+6. ALWAYS search before adding an exercise — search by the exercise's OWN name (not just its component parts) to avoid duplicates. If a same-named exercise already exists (common or yours), REUSE it; do not create a copy. A tool result of `already_exists` / `created: false` means an exercise was REUSED — it does NOT mean the user's request is done. If they asked to add a WORKOUT, you still owe them a `create_workout_template` call.
 
 7. ONLY report exercises that actually exist in the database - NEVER hallucinate or make up exercises!
 

--- a/ai-coach-service/app/core/agents/services/exercise_service.py
+++ b/ai-coach-service/app/core/agents/services/exercise_service.py
@@ -9,6 +9,8 @@ from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorDatabase
 import structlog
 
+from app.core.dedup import existing_exercise_reuse_response
+
 logger = structlog.get_logger()
 
 
@@ -130,6 +132,16 @@ class ExerciseService:
     async def add_exercise(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Add an exercise to the user's personal exercise library"""
         try:
+            # Dedup guard: never create a second exercise with a name the user already
+            # has (a common exercise OR one they created). Prevents exact-name,
+            # case-insensitive duplicates even if the model skipped the "search first"
+            # step. created=False + the hint keep the model from treating a reuse as a
+            # completed request (e.g. it should still create_workout_template for a workout).
+            reuse = await existing_exercise_reuse_response(self.db, user_id, args["name"])
+            if reuse:
+                logger.info(f"add_exercise dedup: reused '{args['name']}' for user {user_id}")
+                return reuse
+
             # Build strain object with defaults
             strain_input = args.get("strain", {})
             strain = {

--- a/ai-coach-service/app/core/agents/tool_definitions/exercise_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/exercise_tools.py
@@ -13,7 +13,7 @@ def get_exercise_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "add_exercise",
-                "description": "Add a new exercise to the user's personal exercise library. Use this when a user mentions they can do an exercise or wants to track a specific movement.",
+                "description": "Add a new SINGLE exercise (one movement) to the user's personal exercise library. Use this when a user mentions they can do an exercise or wants to track a specific movement. NOT for a multi-exercise workout — a whole session with several drills is a WORKOUT, use create_workout_template instead. Always search by the exercise's own name first to avoid duplicates.",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/ai-coach-service/app/core/agents/tool_definitions/workout_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/workout_tools.py
@@ -13,7 +13,7 @@ def get_workout_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "create_workout_template",
-                "description": "Create a reusable workout template (PredefinedWorkout) that can be used in training plans. Workouts are organized into blocks (Warm-up, Main Work, Finisher, etc.).",
+                "description": "Create a reusable workout template (PredefinedWorkout). THIS is what appears under the user's 'Workouts' tab / workout library. Use it whenever the user wants to add or save a whole WORKOUT — one made of multiple exercises/drills — including a workout they upload as an image/screenshot or paste as a list. Do NOT use add_exercise for a multi-exercise workout. Workouts are organized into blocks (Warm-up, Main Work, Finisher, etc.).",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/ai-coach-service/app/core/dedup.py
+++ b/ai-coach-service/app/core/dedup.py
@@ -1,0 +1,38 @@
+"""Shared dedup helper for the exercise-creation tool paths.
+
+Both write paths that can insert an exercise (ExerciseService.add_exercise and the
+MCP McpTools._add_exercise) use this so the reuse message + workout hint can never
+drift between them.
+"""
+import re
+from typing import Any, Dict, Optional
+
+from bson import ObjectId
+
+
+async def existing_exercise_reuse_response(db, user_id: str, name: str) -> Optional[Dict[str, Any]]:
+    """Return a "reuse, don't duplicate" tool response if an exercise with this exact
+    (case-insensitive) name already exists for the user — a common one OR one they
+    created. Returns None when the name is new (caller should insert).
+
+    ``created=False`` is deliberate: reusing an existing exercise is NOT the same as
+    completing the user's request. When a workout template shares the name, the hint
+    steers a mis-classified "add my workout" request to create_workout_template.
+    """
+    name_regex = {"$regex": f"^{re.escape(name)}$", "$options": "i"}
+    visibility = {"$or": [{"isCommon": True}, {"createdBy": ObjectId(user_id)}]}
+    existing = await db.exercises.find_one({"name": name_regex, **visibility})
+    if not existing:
+        return None
+    template = await db.predefinedworkouts.find_one({"name": name_regex, **visibility}, {"_id": 1})
+    return {
+        "success": True,
+        "already_exists": True,
+        "created": False,
+        "exercise_id": str(existing["_id"]),
+        "message": f"'{existing['name']}' already exists — reused it, did NOT create anything new.",
+        "hint": (
+            "A workout template with this name also exists; if the user asked to add a "
+            "WORKOUT, call create_workout_template instead of adding an exercise."
+        ) if template else None,
+    }

--- a/ai-coach-service/app/core/mcp/tools.py
+++ b/ai-coach-service/app/core/mcp/tools.py
@@ -5,6 +5,8 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 from bson import ObjectId
 from datetime import datetime
 
+from app.core.dedup import existing_exercise_reuse_response
+
 logger = structlog.get_logger()
 
 
@@ -195,6 +197,13 @@ class FitnessCRUDTools:
     async def _add_exercise(self, params: Dict[str, Any], user_id: str) -> Dict[str, Any]:
         """Add a new exercise directly"""
         try:
+            # Dedup guard (shared with ExerciseService.add_exercise): never create a
+            # second exercise with a name the user already has. A reused exercise
+            # (created=False) does NOT mean the user's request is complete.
+            reuse = await existing_exercise_reuse_response(self.db, user_id, params["name"])
+            if reuse:
+                return reuse
+
             exercise_data = {
                 "name": params["name"],
                 "description": params["description"],

--- a/ai-coach-service/tests/test_add_exercise_dedup.py
+++ b/ai-coach-service/tests/test_add_exercise_dedup.py
@@ -1,0 +1,72 @@
+"""
+Deterministic tests for the add_exercise dedup guard.
+
+Regression cover for the bug where the coach created a duplicate 'Scapula Warm Up 2'
+exercise even though a common one already existed. The guard must:
+  - never insert a second exercise with an existing (case-insensitive) name,
+  - report created=False so the model can't read a reuse as task-complete,
+  - surface a hint toward create_workout_template when a same-named template exists.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.agents.services.exercise_service import ExerciseService
+
+USER_ID = "6a50b08cfc7515275d6e0e68"
+
+
+def _service(existing_exercise=None, existing_template=None):
+    db = MagicMock()
+    db.exercises.find_one = AsyncMock(return_value=existing_exercise)
+    db.predefinedworkouts.find_one = AsyncMock(return_value=existing_template)
+    db.exercises.insert_one = AsyncMock(
+        return_value=MagicMock(inserted_id="710000000000000000000099")
+    )
+    return ExerciseService(db), db
+
+
+@pytest.mark.asyncio
+async def test_reuses_existing_exercise_and_does_not_insert():
+    existing = {"_id": "710000000000000000000003", "name": "Scapula Warm Up 2"}
+    svc, db = _service(existing_exercise=existing)
+
+    res = await svc.add_exercise(USER_ID, {"name": "scapula warm up 2", "muscles": ["Shoulders"]})
+
+    assert res["success"] is True
+    assert res["already_exists"] is True
+    assert res["created"] is False
+    assert res["exercise_id"] == "710000000000000000000003"
+    db.exercises.insert_one.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hint_points_to_template_when_name_matches_a_workout():
+    existing = {"_id": "710000000000000000000003", "name": "Scapula Warm Up 2"}
+    template = {"_id": "720000000000000000000001"}
+    svc, _ = _service(existing_exercise=existing, existing_template=template)
+
+    res = await svc.add_exercise(USER_ID, {"name": "Scapula Warm Up 2", "muscles": ["Shoulders"]})
+
+    assert res["created"] is False
+    assert res["hint"] and "create_workout_template" in res["hint"]
+
+
+@pytest.mark.asyncio
+async def test_no_hint_when_no_matching_template():
+    existing = {"_id": "710000000000000000000003", "name": "Scapula Warm Up 2"}
+    svc, _ = _service(existing_exercise=existing, existing_template=None)
+
+    res = await svc.add_exercise(USER_ID, {"name": "Scapula Warm Up 2", "muscles": ["Shoulders"]})
+
+    assert res["hint"] is None
+
+
+@pytest.mark.asyncio
+async def test_creates_when_name_is_new():
+    svc, db = _service(existing_exercise=None)
+
+    res = await svc.add_exercise(USER_ID, {"name": "Brand New Move", "muscles": ["Core"]})
+
+    assert res["success"] is True
+    assert res.get("already_exists") is None  # not a dedup response
+    db.exercises.insert_one.assert_called_once()


### PR DESCRIPTION
## Problem
A user uploaded an image of a multi-drill warm-up workout ("Scapula Warm Up 2") and asked "Can you add it to my workouts?". The coach saved it as a **single exercise** (`add_exercise`) — creating a duplicate in the `exercises` collection — and **never** called `create_workout_template`, so nothing appeared under the **Workouts** tab (which reads `predefinedworkouts`). After the user corrected it, the coach only re-listed templates and created nothing.

**Not a crash.** Verified from ai-coach Render logs + MongoDB (conv `a850c196…`, user `6a50b08c…`): every call returned `200 OK`; the only creation was `add_exercise`. A pure tool-selection failure by `gpt-5.4-mini`. Confirmed the image reaches the model as **real vision** (`documents.py:168-184`, `image_url`), so prompt wording is a valid lever.

## Reproduction (offline harness, no prod writes)
Real `SYSTEM_PROMPT` + tool schemas, agentic tool loop with canned results:

| case | baseline | after fix |
|---|---|---|
| ambiguously-named ("Scapula Warm Up 2") | `create_workout_template` **1/10** | **10/10** |
| novel-titled multi-drill workout | 10/10 | 10/10 |

The failure mode is **ambiguously-named** items that read like a single exercise; clearly-titled workouts already routed fine. The prompt fix takes the ambiguous case to 10/10.

## Changes
- **`prompts.py`**: "CLASSIFY BEFORE YOU CREATE" block (single movement → `add_exercise`; multi-drill session/image → `create_workout_template`); de-ambiguated "library"/"my workouts" vocabulary; correction-recovery rule; stronger principle #6 (search by own name; `already_exists`/`created:false` ≠ task done).
- **tool descriptions**: sharpen `create_workout_template` / `add_exercise` to remove overlap.
- **dedup guard** (shared `app/core/dedup.py`, used by both live write paths — `ExerciseService.add_exercise` and `mcp/tools._add_exercise`): reuse an existing same-name exercise instead of duplicating; return `created: false` + a hint toward `create_workout_template` so a reuse can't be read as task-complete.
- **tests**: 4 deterministic dedup tests.

## Verification
- `pytest` — 33 passed (4 new dedup + existing exercise/workout suites); no regressions.
- Classification hit-rate measured 10× before/after (table above).

## Known limitations / follow-ups (out of scope)
- Classification remains **model-driven** (no pure-deterministic backstop — that judgment needs the model); mitigated by the sharpened prompt/tools since the model gets real vision.
- **Not** exercised end-to-end through the real image + a deployed/staging instance (harness is a proxy using reconstructed text + canned tool results).
- Dedup is app-level find-then-insert (small TOCTOU window; a unique index would be race-proof).
- Stray duplicate `Scapula Warm Up 2` exercise still exists in prod; AI-created exercises skip the Mongoose embedding hook; reflection `trigger_tools` addition was dropped (inert while reflection is disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)