### PR TITLE
TOR-10: Strip console.log output from production frontend builds

### DIFF
--- a/frontend/src/components/chat/ActionButtons.jsx
+++ b/frontend/src/components/chat/ActionButtons.jsx
@@ -151,11 +151,8 @@ export function ActionButtons({ actions, disabled }) {
         notes: 'AI-generated workout'
       };
 
-      console.log('Creating calendar event with data:', calendarEventData);
-
       try {
-        const result = await CalendarEvent.create(calendarEventData);
-        console.log('Workout saved to calendar for', workoutDate, 'Result:', result);
+        await CalendarEvent.create(calendarEventData);
       } catch (calendarError) {
         console.error('Failed to save to calendar:', calendarError);
         // Show error to user but still continue to start workout
@@ -326,11 +323,6 @@ export function parseActionButtons(content) {
       if (endIdx !== -1) {
         workoutStr = attributesStr.substring(startIdx, endIdx + 1);
       }
-    }
-
-    // Log for debugging
-    if (workoutStr) {
-      console.log('Extracted workout string:', workoutStr.substring(0, 100) + '...');
     }
 
     if (workoutStr) {

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -101,10 +101,6 @@ const planningSchema = {
 };
 
 export default function Chat() {
-  // Log when component mounts
-  console.log('🤖 Chat component mounted!');
-  console.log('🔍 Checking localStorage for pendingChatPrompt:', localStorage.getItem('pendingChatPrompt'));
-
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
   const [isThinking, setIsThinking] = useState(false);
@@ -167,38 +163,26 @@ export default function Chat() {
         }
 
         setIsDataLoaded(true);
-        console.log('✅ Data loaded, isDataLoaded set to true');
 
         // Check for pending prompt from localStorage (e.g., from WorkoutSelectionModal)
         // Do this AFTER setting isDataLoaded to ensure we're ready to process
         const storedPrompt = localStorage.getItem('pendingChatPrompt');
         const storedTime = localStorage.getItem('pendingChatPromptTime');
 
-        console.log('📋 Checking localStorage:', {
-          hasPrompt: !!storedPrompt,
-          hasTime: !!storedTime,
-          promptPreview: storedPrompt?.substring(0, 50)
-        });
-
         if (storedPrompt && storedTime) {
           // Only process if the prompt was set within the last 10 seconds (to avoid stale prompts)
           const promptAge = Date.now() - parseInt(storedTime, 10);
-          console.log('⏱️ Prompt age:', promptAge, 'ms');
 
           if (promptAge < 10000) {
-            console.log('✅ Found valid pending prompt, setting autoSendPending=true');
             localStorage.removeItem('pendingChatPrompt');
             localStorage.removeItem('pendingChatPromptTime');
             pendingPromptRef.current = storedPrompt;
             setAutoSendPending(true);
           } else {
-            console.log('⚠️ Prompt too old, cleaning up');
             // Clean up stale prompts
             localStorage.removeItem('pendingChatPrompt');
             localStorage.removeItem('pendingChatPromptTime');
           }
-        } else {
-          console.log('ℹ️ No pending prompt found in localStorage');
         }
 
       } catch (error) {
@@ -242,11 +226,8 @@ export default function Chat() {
 
   // Handle auto-send for pending prompts (from WorkoutSelectionModal or other sources)
   useEffect(() => {
-    console.log('Auto-send effect:', { autoSendPending, isDataLoaded, isThinking, hasPendingPrompt: !!pendingPromptRef.current });
-
     if (autoSendPending && isDataLoaded && !isThinking && pendingPromptRef.current) {
       const promptToSend = pendingPromptRef.current;
-      console.log('Processing pending prompt:', promptToSend.substring(0, 50) + '...');
       pendingPromptRef.current = null;
       setAutoSendPending(false);
 
@@ -269,7 +250,6 @@ export default function Chat() {
 
       // Small delay to ensure state is updated before processing
       setTimeout(() => {
-        console.log('Calling processMessageAsync...');
         processMessageAsync(promptToSend);
       }, 100);
     }

--- a/frontend/src/pages/ChatWithStreaming.jsx
+++ b/frontend/src/pages/ChatWithStreaming.jsx
@@ -105,10 +105,6 @@ const MARKDOWN_COMPONENTS = {
 };
 
 export default function ChatWithStreaming() {
-  // Log for debugging auto-send feature
-  console.log('🤖 ChatWithStreaming mounted!');
-  console.log('🔍 Checking localStorage for pendingChatPrompt:', localStorage.getItem('pendingChatPrompt')?.substring(0, 50));
-
   // State
   const [user, setUser] = useState(null);
   const [authToken, setAuthToken] = useState(null);
@@ -171,26 +167,17 @@ export default function ChatWithStreaming() {
           const storedPrompt = localStorage.getItem('pendingChatPrompt');
           const storedTime = localStorage.getItem('pendingChatPromptTime');
 
-          console.log('📋 Checking localStorage for pending prompt:', {
-            hasPrompt: !!storedPrompt,
-            hasTime: !!storedTime,
-            promptPreview: storedPrompt?.substring(0, 50)
-          });
-
           if (storedPrompt && storedTime) {
             const promptAge = Date.now() - parseInt(storedTime, 10);
-            console.log('⏱️ Prompt age:', promptAge, 'ms');
 
             // Only process if the prompt was set within the last 30 seconds
             if (promptAge < 30000) {
-              console.log('✅ Found valid pending prompt, setting pendingAutoSend');
               hasProcessedPendingRef.current = true;
               // Clear localStorage immediately to prevent re-processing
               localStorage.removeItem('pendingChatPrompt');
               localStorage.removeItem('pendingChatPromptTime');
               setPendingAutoSend(storedPrompt);
             } else {
-              console.log('⚠️ Prompt too old, cleaning up');
               localStorage.removeItem('pendingChatPrompt');
               localStorage.removeItem('pendingChatPromptTime');
             }
@@ -230,8 +217,6 @@ export default function ChatWithStreaming() {
   useEffect(() => {
     const processPendingMessage = async () => {
       if (pendingAutoSend && authToken && !isStreaming && !isLoadingHistory) {
-        console.log('🚀 Processing pending auto-send message:', pendingAutoSend.substring(0, 50) + '...');
-
         // Extract clean display message from the full prompt
         // The full prompt has context for AI, but we show a cleaner version to user
         let displayMessage = pendingAutoSend;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -26,6 +26,8 @@ export default defineConfig(({ mode }) => ({
       },
     },
   },
+  // Strip debug logging from production bundles; console.error/warn are kept
+  esbuild: mode === 'production' ? { pure: ['console.log', 'console.debug'] } : {},
   // Production build optimizations
   build: {
     target: 'es2015',


### PR DESCRIPTION
## What changed

- [frontend/vite.config.js](frontend/vite.config.js): added `esbuild: { pure: ['console.log', 'console.debug'] }` for production mode only, so esbuild minification drops those calls from prod bundles while keeping `console.error`/`console.warn`.
- Deleted the noisy emoji debug logs at source (per TOR-9's dependency on them being out of the render path):
  - `frontend/src/pages/ChatWithStreaming.jsx` — 7 logs removed
  - `frontend/src/pages/Chat.jsx` — 11 logs removed
  - `frontend/src/components/chat/ActionButtons.jsx` — 3 logs removed

## Verification

- `npm run build` (production): succeeded; `grep -o 'console\.log\|console\.debug' dist/assets/*.js` → **0** occurrences; `console.error` (120) and `console.warn` (19) still present in bundles.
- `vite build --mode development`: the remaining 24 `console.log` calls (non-chat files) still present — dev behavior unchanged; the `pure` option only applies when `mode === 'production'`.
- Lint gate: eslint on the 4 changed files, before vs after (line-number-insensitive diff): 57 findings → 57 findings, **no new findings** (all pre-existing on origin/main).

## Acceptance criteria

- [x] Production build contains no `console.log`/`console.debug` output (verified by grepping `dist/`); `console.error`/`console.warn` kept.
- [x] Noisy emoji debug logs in the chat pages deleted at source.
- [x] Dev mode behavior unchanged.
- [x] No regression in error reporting — `console.error`/`console.warn` calls remain in the prod bundle.

Linear: https://linear.app/torii-fitness/issue/TOR-10/strip-consolelog-output-from-production-frontend-builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)