### PR TITLE
pm-triage: tickets describe the problem only, never a suggested fix

### DIFF
--- a/.claude/skills/pm-triage/SKILL.md
+++ b/.claude/skills/pm-triage/SKILL.md
@@ -124,7 +124,10 @@ Read-only debugging only — never "fix" anything from this skill.
 For each ticket, `save_issue` (create) with:
 - `team`: Torii, `project`: per classification, `state`: Todo
 - `title`: imperative and specific ("Fix dashboard content unreachable below Progression on mobile"), no `[Feedback]` prefix
-- `description`: follow [TICKET-TEMPLATE.md](TICKET-TEMPLATE.md) exactly
+- `description`: follow [TICKET-TEMPLATE.md](TICKET-TEMPLATE.md) exactly. Describe the
+  **problem and how to reproduce it only — never suggest a fix**, solution direction, or
+  implementation approach. Code pointers say where the problem lives, not what to change.
+  If the feedback text itself proposes a fix, record the underlying problem, not the proposal.
 - `labels`: one type label (`Bug` / `Feature Request` / `UI/UX` / `Performance` / …) **plus** `claude-ready` or `needs-human`
 - `estimate`: points per [COMPLEXITY.md](COMPLEXITY.md) (1/2/3/5/8). If estimates are not
   enabled on the team yet, the save may drop the field — still record the points in the
@@ -147,6 +150,7 @@ End with a markdown table: feedback issue → created tickets (id, project, esti
 ## Rules
 
 - Never merge anything; never change code in this skill — triage only.
+- Tickets state the problem + reproduction, never a suggested fix or implementation approach.
 - Never delete or archive issues.
 - One ticket = one independently shippable change. Split aggressively.
 - Write tickets so a fresh Claude Code session can implement them from the body alone

--- a/.claude/skills/pm-triage/TICKET-TEMPLATE.md
+++ b/.claude/skills/pm-triage/TICKET-TEMPLATE.md
@@ -4,6 +4,13 @@ Every ticket description created by `/pm-triage` uses exactly these sections, in
 order. Omit a section only where marked optional. Use real newlines, GitHub-flavored
 markdown, and repo-relative file paths.
 
+**Problem only — no fixes.** The description states what is wrong and how to reproduce
+it. Never add a "Suggested fix" section, propose a solution direction, or hint at an
+implementation approach — not in any section. Code pointers locate the problem; they do
+not say what to change. Acceptance criteria describe the observable outcome, not the
+implementation. If the feedback text proposes a fix, ticket the underlying problem, not
+the proposal.
+
 ```markdown
 ## Source
 [TOR-nn](https://linear.app/torii-fitness/issue/TOR-nn) — reported by <name>, page `<page>`, <date>.


### PR DESCRIPTION
Follow-up to #100 — this commit was pushed to the branch just after the PR merged.

Adds the "problem only — no fixes" policy to the pm-triage skill and TICKET-TEMPLATE.md: ticket descriptions state what is wrong and how to reproduce it, never a suggested fix or implementation direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)