### PR TITLE
TOR-17: Fix /predefinedworkouts heading flicker (Predefined Workouts → Workouts)

### DIFF
--- a/frontend/src/pages/PredefinedWorkouts.jsx
+++ b/frontend/src/pages/PredefinedWorkouts.jsx
@@ -246,7 +246,7 @@ export default function PredefinedWorkouts() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <h1 className="text-3xl font-bold text-gray-900">Predefined Workouts</h1>
+        <h1 className="text-3xl font-bold text-gray-900">Workouts</h1>
         <div className="flex items-center justify-center h-64">
           <div className="text-center">
             <div className="w-12 h-12 border-4 border-gray-200 border-t-accent rounded-full animate-spin mx-auto mb-4"></div>


### PR DESCRIPTION
## What changed

One-line fix in `frontend/src/pages/PredefinedWorkouts.jsx`: the loading-state placeholder `<h1>` said **"Predefined Workouts"** while the loaded view's `<h1>` says **"Workouts"**, so the page heading visibly swapped once data finished loading. The loading heading now reads "Workouts" too, matching the loaded view (identical classes, so layout is unchanged).

Linear: [TOR-17](https://linear.app/torii-fitness/issue/TOR-17/feedbackbug-predefinedworkouts)

## Verification

- `npm run build --prefix frontend` — ✅ built cleanly
- Playwright against the local dev stack (frontend :5174, backend :5001), logged in as a throwaway dev user, sampled all `<h1>` text every 80ms while navigating to `/PredefinedWorkouts`:
  - During loading spinner (t≈50ms): heading = "Workouts" ✅
  - After data loaded (t≈1.8s): heading = "Workouts" ✅ — no text swap
- `grep` confirms no remaining user-visible "Predefined Workouts" heading; the remaining occurrences in `Chat.jsx` are LLM prompt text / internal route references, intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)