### PR TITLE
TOR-16: Swipe gestures too sensitive — vertical scroll triggers card actions

### DIFF
--- a/frontend/src/components/common/SwipeableCard.jsx
+++ b/frontend/src/components/common/SwipeableCard.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import { Trash2, Pencil } from 'lucide-react';
 
 const SWIPE_THRESHOLD = 60; // Pixels to trigger action reveal
+const AXIS_LOCK_SLOP = 10; // Movement before the gesture is locked to an axis
 
 export default function SwipeableCard({
   children,
@@ -21,19 +22,32 @@ export default function SwipeableCard({
   const [isDragging, setIsDragging] = useState(false);
   const [isActionsRevealed, setIsActionsRevealed] = useState(false);
   const startXRef = useRef(0);
+  const startYRef = useRef(0);
   const currentXRef = useRef(0);
+  const axisRef = useRef(null); // null = undecided, 'x' = swiping, 'y' = scrolling
   const containerRef = useRef(null);
 
-  const handleStart = (clientX) => {
+  const handleStart = (clientX, clientY) => {
     setIsDragging(true);
     startXRef.current = clientX;
+    startYRef.current = clientY;
+    axisRef.current = null;
     currentXRef.current = translateX;
   };
 
-  const handleMove = (clientX) => {
+  const handleMove = (clientX, clientY) => {
     if (!isDragging) return;
 
     const diff = clientX - startXRef.current;
+    // Lock the gesture to one axis on first significant movement, so a
+    // vertical scroll with slight horizontal drift never drags the card.
+    if (axisRef.current === null) {
+      const diffY = clientY - startYRef.current;
+      if (Math.abs(diff) < AXIS_LOCK_SLOP && Math.abs(diffY) < AXIS_LOCK_SLOP) return;
+      axisRef.current = Math.abs(diff) > Math.abs(diffY) ? 'x' : 'y';
+    }
+    if (axisRef.current === 'y') return;
+
     let newTranslate = currentXRef.current + diff;
 
     // Only allow swiping left (negative values)
@@ -59,11 +73,11 @@ export default function SwipeableCard({
   };
 
   const handleTouchStart = (e) => {
-    handleStart(e.touches[0].clientX);
+    handleStart(e.touches[0].clientX, e.touches[0].clientY);
   };
 
   const handleTouchMove = (e) => {
-    handleMove(e.touches[0].clientX);
+    handleMove(e.touches[0].clientX, e.touches[0].clientY);
   };
 
   const handleTouchEnd = () => {
@@ -72,11 +86,11 @@ export default function SwipeableCard({
 
   const handleMouseDown = (e) => {
     e.preventDefault();
-    handleStart(e.clientX);
+    handleStart(e.clientX, e.clientY);
   };
 
   const handleMouseMove = (e) => {
-    handleMove(e.clientX);
+    handleMove(e.clientX, e.clientY);
   };
 
   const handleMouseUp = () => {
@@ -168,6 +182,7 @@ export default function SwipeableCard({
         style={{
           transform: `translateX(${translateX}px)`,
           transition: isDragging ? 'none' : 'transform 0.2s ease-out',
+          touchAction: 'pan-y',
         }}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}

--- a/frontend/src/pages/LiveWorkout.jsx
+++ b/frontend/src/pages/LiveWorkout.jsx
@@ -280,6 +280,7 @@ function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComp
   const [revealed, setRevealed] = useState(false);
   const startXRef = useRef(0);
   const startYRef = useRef(0);
+  const axisRef = useRef(null); // null = undecided, 'x' = swiping, 'y' = scrolling
   const suppressSwipeRef = useRef(false);
   const longPressTimerRef = useRef(null);
   const COMPLETE_THRESHOLD = 100;   // swipe-right distance to complete all
@@ -303,6 +304,7 @@ function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComp
     setIsDragging(true);
     startXRef.current = clientX;
     startYRef.current = clientY;
+    axisRef.current = null;
     suppressSwipeRef.current = false;
     // Start the long-press timer; any real drag (handleMove) cancels it.
     cancelLongPress();
@@ -322,6 +324,13 @@ function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComp
     // vertically while scrolling the list shouldn't trigger the action sheet.
     const diffY = clientY == null ? 0 : clientY - startYRef.current;
     if (Math.abs(diff) > MOVE_SLOP || Math.abs(diffY) > MOVE_SLOP) cancelLongPress();
+    // Lock the gesture to one axis on first significant movement — a vertical
+    // scroll with slight horizontal drift must not drag the card (TOR-16).
+    if (axisRef.current === null) {
+      if (Math.abs(diff) < MOVE_SLOP && Math.abs(diffY) < MOVE_SLOP) return;
+      axisRef.current = Math.abs(diff) > Math.abs(diffY) ? 'x' : 'y';
+    }
+    if (axisRef.current === 'y') return;
     // Right = complete (capped 150). Left = reveal actions (capped REVEAL_WIDTH).
     const base = revealed ? -REVEAL_WIDTH : 0;
     const next = Math.max(-REVEAL_WIDTH, Math.min(base + diff, 150));
@@ -384,6 +393,7 @@ function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComp
         style={{
           transform: `translateX(${translateX}px)`,
           transition: isDragging ? 'none' : 'transform 0.2s ease-out',
+          touchAction: 'pan-y',
         }}
         onTouchStart={(e) => handleStart(e.touches[0].clientX, e.touches[0].clientY)}
         onTouchMove={(e) => handleMove(e.touches[0].clientX, e.touches[0].clientY)}


### PR DESCRIPTION
## What changed

Swipeable cards tracked only the touch's X coordinate with no axis-locking, so any horizontal drift during a vertical scroll dragged the card — and past the threshold, revealed/triggered actions (the reported accidental "mark as done" / delete).

This adds a decide-once axis lock to both swipe implementations: on the first movement beyond a 10px slop, the gesture is classified as horizontal or vertical by comparing |dx| vs |dy|. Vertical gestures no longer move the card at all. Also sets `touch-action: pan-y` on the swipeable content so the browser keeps native vertical scrolling.

- `frontend/src/components/common/SwipeableCard.jsx` — shared component used on **/predefinedworkouts** (reported page) and /exercises
- `frontend/src/pages/LiveWorkout.jsx` (`SwipeableExerciseCard`) — swipe-right "Complete All" (the actual "mark as done") and swipe-left Replace/Delete

No threshold changes; deliberate horizontal swipes behave exactly as before.

## Verification

- `npm run build` (frontend): ✅ passes
- ESLint on both changed files: 43 findings before and after — all pre-existing, **no new findings**
- End-to-end gesture test: mounted the real `SwipeableCard` via the Vite dev server in headless Chromium (mobile emulation, `hasTouch`) and drove it with real CDP touch events:
  - Vertical scroll with 40px horizontal drift → card does not move ✅
  - Diagonal scroll with **70px** horizontal drift (would have crossed the old 60px threshold and revealed actions) → card does not move ✅
  - Deliberate horizontal left-swipe → actions reveal at −160px exactly as before ✅
  - Tap on content with actions revealed → closes as before ✅

## Acceptance criteria

- [x] Scrolling vertically over swipeable cards no longer reveals/triggers swipe actions
- [x] Deliberate horizontal swipes still work unchanged (reveal Edit/Delete; LiveWorkout Complete-All/Replace/Delete)

Linear: https://linear.app/torii-fitness/issue/TOR-16/feedbackui-ux-predefinedworkouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)