### PR TITLE
Fix dark-mode flash on first paint on /settings (TOR-18)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,17 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Torii</title>
+  <script>
+    (function () {
+      try {
+        var theme = localStorage.getItem('theme');
+        if (theme !== 'light' && theme !== 'dark') {
+          theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        document.documentElement.classList.add(theme);
+      } catch (e) { }
+    })();
+  </script>
 </head>
 
 <body>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -92,6 +92,7 @@ button:focus-visible {
 
 @layer base {
   :root {
+    color-scheme: light;
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
     --card: 0 0% 100%;
@@ -128,6 +129,7 @@ button:focus-visible {
   }
 
   .dark {
+    color-scheme: dark;
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
     --card: 0 0% 3.9%;


### PR DESCRIPTION
## Summary
Fixes [TOR-18](https://linear.app/torii-fitness/issue/TOR-18/feedbackbug-settings): on iPhone Safari with OS dark mode enabled, the profile/settings page first painted with a dark background and then snapped to light mode.

**Root cause:** the `light`/`dark` class was applied to `<html>` only in a post-mount `useEffect` in `ThemeContext.jsx`, with no pre-paint theme bootstrap in `index.html`. Before React mounted, Safari rendered the first paint following the OS appearance (dark); React then applied the stored `light` theme — the visible dark→light flash.

## Changes
- `frontend/index.html`: render-blocking inline script in `<head>` that applies the resolved theme class before first paint, mirroring `ThemeProvider`'s resolution logic exactly (`localStorage['theme']` → `prefers-color-scheme: dark` → `light`). The existing `useEffect` is idempotent, so no context changes needed.
- `frontend/src/index.css`: `color-scheme: light` on `:root` and `color-scheme: dark` on `.dark`, so UA-rendered surfaces (form controls, iOS overscroll background) follow the applied theme instead of the OS setting.

## Verification
Playwright (Chromium, emulated `prefers-color-scheme`), recording the `<html>` class timeline via a MutationObserver from document start:
- **OS dark + stored `light` (the reported bug):** first class ever applied is `light`, before React mounts; no class flip afterward; computed `color-scheme: light`.
- **OS dark + no stored theme:** first class is `dark` (OS preference honored from first paint).
- **OS light + stored `dark`:** first class is `dark`.

Also verified `npm run build` succeeds and the inline script is preserved in `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)