### PR TITLE
TOR-14: Fix AI coach date confusion in calendar tools

### DIFF
--- a/ai-coach-service/app/core/agents/date_utils.py
+++ b/ai-coach-service/app/core/agents/date_utils.py
@@ -1,0 +1,63 @@
+"""
+Date helpers for user-local "today" resolution and relative-day labeling.
+
+Calendar events are stored at midnight UTC representing a calendar day, so a
+naive midnight datetime of the user's LOCAL calendar day can be compared and
+queried against stored dates directly. What must be timezone-aware is only the
+resolution of "today" into that calendar day.
+"""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from bson import ObjectId
+import structlog
+
+logger = structlog.get_logger()
+
+
+async def get_user_today(db, user_id: str, now: datetime | None = None) -> tuple[datetime, str]:
+    """Resolve the user's local calendar day -> (naive midnight datetime, timezone name).
+
+    Looks up users.settings.timezone; falls back to UTC on missing/invalid
+    timezone or lookup error. `now` is injectable for tests (aware or naive UTC).
+    """
+    timezone = "UTC"
+    try:
+        user = await db.users.find_one(
+            {"_id": ObjectId(user_id)},
+            {"settings.timezone": 1}
+        )
+        timezone = ((user or {}).get("settings") or {}).get("timezone") or "UTC"
+    except Exception as e:
+        logger.error(f"Error fetching timezone for {user_id}: {e}")
+
+    try:
+        tz = ZoneInfo(timezone)
+    except Exception:
+        tz = ZoneInfo("UTC")
+        timezone = "UTC"
+
+    if now is None:
+        local_now = datetime.now(tz)
+    elif now.tzinfo is None:
+        local_now = now.replace(tzinfo=ZoneInfo("UTC")).astimezone(tz)
+    else:
+        local_now = now.astimezone(tz)
+
+    return datetime(local_now.year, local_now.month, local_now.day), timezone
+
+
+def relative_day_label(target: date, today: date) -> str:
+    """Label a calendar day relative to today: 'today', 'tomorrow', 'yesterday',
+    'in N days', 'N days ago'."""
+    delta = (target - today).days
+    if delta == 0:
+        return "today"
+    if delta == 1:
+        return "tomorrow"
+    if delta == -1:
+        return "yesterday"
+    if delta > 0:
+        return f"in {delta} days"
+    return f"{-delta} days ago"

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -210,7 +210,7 @@ class AgentOrchestrator:
             local_time_str = local_now.strftime('%A, %B %d, %Y at %I:%M %p')
             today_date = local_now.strftime('%Y-%m-%d')
         except Exception:
-            local_now = datetime.now()
+            local_now = datetime.now(ZoneInfo('UTC'))
             local_time_str = local_now.strftime('%A, %B %d, %Y at %I:%M %p') + ' (UTC)'
             today_date = local_now.strftime('%Y-%m-%d')
 
@@ -475,7 +475,7 @@ USER DATA:
             local_time_str = local_now.strftime('%A, %B %d, %Y at %I:%M %p')
             today_date = local_now.strftime('%Y-%m-%d')
         except Exception:
-            local_now = datetime.now()
+            local_now = datetime.now(ZoneInfo('UTC'))
             local_time_str = local_now.strftime('%A, %B %d, %Y at %I:%M %p') + ' (UTC)'
             today_date = local_now.strftime('%Y-%m-%d')
 

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -181,6 +181,9 @@ When user asks to add/schedule a workout for a specific date:
 3. The `schedule_to_calendar` tool creates the calendar event directly - it does NOT need a template first
 4. If for today, ask if they want to start training now
 
+DATE DISCIPLINE (CRITICAL):
+`get_calendar_events` results include `today` (the user's local date) and a `relativeDay` label on every event ("today", "tomorrow", "yesterday", "in N days", "N days ago"). ALWAYS use these labels when telling the user what is scheduled today/tomorrow/yesterday — NEVER recompute relative days from raw YYYY-MM-DD dates yourself. If no event has `relativeDay: "today"`, then nothing is scheduled today — say so plainly.
+
 IMPORTANT PRINCIPLES:
 
 1. **GROUND IN THE USER'S REAL DATA FIRST** (CRITICAL - DO NOT SKIP):

--- a/ai-coach-service/app/core/agents/services/calendar_service.py
+++ b/ai-coach-service/app/core/agents/services/calendar_service.py
@@ -4,9 +4,12 @@ Calendar service - handles calendar scheduling operations
 
 from typing import Dict, Any
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorDatabase
 import structlog
+
+from app.core.agents.date_utils import get_user_today, relative_day_label
 
 logger = structlog.get_logger()
 
@@ -20,12 +23,16 @@ class CalendarService:
     async def schedule_to_calendar(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Schedule a workout or event to the user's calendar"""
         try:
+            # Resolve relative dates against the user's LOCAL calendar day —
+            # server UTC can be a different day than the user's.
+            today, _ = await get_user_today(self.db, user_id)
+
             # Parse date - handle 'today', 'tomorrow', or ISO date
             date_str = args.get("date", "")
             if date_str.lower() == "today":
-                event_date = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+                event_date = today
             elif date_str.lower() == "tomorrow":
-                event_date = (datetime.utcnow() + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+                event_date = today + timedelta(days=1)
             else:
                 try:
                     event_date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
@@ -170,8 +177,7 @@ class CalendarService:
                     duration = workout_details.get("estimatedDuration", 45)
                     response_msg += f"\n\n**{exercise_count} exercises** | **~{duration} min**"
 
-                # Check if it's today
-                today = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+                # Check if it's today (user-local)
                 if event_date.date() == today.date():
                     response_msg += "\n\n**This is for today!** Would you like to start training now?"
 
@@ -181,6 +187,8 @@ class CalendarService:
                     "message": response_msg,
                     "event_id": str(result.inserted_id),
                     "date": formatted_date,
+                    "dateISO": event_date.strftime("%Y-%m-%d"),
+                    "relativeDay": relative_day_label(event_date.date(), today.date()),
                     "is_today": event_date.date() == today.date()
                 }
             else:
@@ -193,25 +201,36 @@ class CalendarService:
     async def get_calendar_events(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Get user's calendar events for a date range"""
         try:
+            # "Today" must be the user's LOCAL calendar day, not server UTC —
+            # stored event dates are midnight UTC representing calendar days.
+            today, tz_name = await get_user_today(self.db, user_id)
+
             # Parse dates
             start_str = args.get("startDate")
             end_str = args.get("endDate")
 
-            if start_str:
+            def parse_naive(date_str: str) -> datetime:
                 try:
-                    start_date = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+                    parsed = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                    if parsed.tzinfo is not None:
+                        parsed = parsed.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+                    return parsed
                 except Exception:
-                    start_date = datetime.strptime(start_str, "%Y-%m-%d")
+                    return datetime.strptime(date_str, "%Y-%m-%d")
+
+            if start_str:
+                start_date = parse_naive(start_str)
             else:
-                start_date = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+                # Include yesterday so "I missed yesterday's workout" questions
+                # see the missed session.
+                start_date = today - timedelta(days=1)
 
             if end_str:
-                try:
-                    end_date = datetime.fromisoformat(end_str.replace("Z", "+00:00"))
-                except Exception:
-                    end_date = datetime.strptime(end_str, "%Y-%m-%d")
-            else:
+                end_date = parse_naive(end_str)
+            elif start_str:
                 end_date = start_date + timedelta(days=7)
+            else:
+                end_date = today + timedelta(days=7)
 
             # Build query
             query = {
@@ -228,12 +247,25 @@ class CalendarService:
             # Fetch events (Mongoose uses lowercase, no underscore for collection name)
             events = await self.db.calendarevents.find(query).sort("date", 1).to_list(100)
 
+            today_str = today.strftime("%Y-%m-%d")
+            queried_range = {
+                "start": start_date.strftime("%Y-%m-%d"),
+                "end": end_date.strftime("%Y-%m-%d")
+            }
+
             if not events:
                 start_fmt = start_date.strftime("%B %d")
                 end_fmt = end_date.strftime("%B %d, %Y")
                 return {
                     "success": True,
-                    "message": f"No events scheduled from {start_fmt} to {end_fmt}.",
+                    "message": (
+                        f"No events scheduled from {start_fmt} to {end_fmt}. "
+                        f"(Today is {today_str}, {today.strftime('%A')}, timezone {tz_name}.)"
+                    ),
+                    "today": today_str,
+                    "dayOfWeek": today.strftime("%A"),
+                    "timezone": tz_name,
+                    "queriedRange": queried_range,
                     "events": []
                 }
 
@@ -258,6 +290,8 @@ class CalendarService:
                     "id": str(event["_id"]),
                     "date": event["date"].strftime("%Y-%m-%d"),
                     "dayOfWeek": event["date"].strftime("%A"),
+                    "relativeDay": relative_day_label(event["date"].date(), today.date()),
+                    "isToday": event["date"].date() == today.date(),
                     "title": event.get("title", "Untitled"),
                     "type": event.get("type", "workout"),
                     "status": event.get("status", "scheduled"),
@@ -271,7 +305,10 @@ class CalendarService:
             workout_count = sum(1 for e in formatted_events if e["type"] == "workout")
             rest_count = sum(1 for e in formatted_events if e["type"] == "rest")
 
-            summary = f"Found **{len(formatted_events)} events** from {start_date.strftime('%B %d')} to {end_date.strftime('%B %d')}:"
+            summary = (
+                f"Today is {today_str} ({today.strftime('%A')}). "
+                f"Found **{len(formatted_events)} events** from {start_date.strftime('%B %d')} to {end_date.strftime('%B %d')}:"
+            )
             if workout_count > 0:
                 summary += f"\n- **{workout_count}** workout(s)"
             if rest_count > 0:
@@ -280,6 +317,10 @@ class CalendarService:
             return {
                 "success": True,
                 "message": summary,
+                "today": today_str,
+                "dayOfWeek": today.strftime("%A"),
+                "timezone": tz_name,
+                "queriedRange": queried_range,
                 "events": formatted_events
             }
 

--- a/ai-coach-service/app/core/agents/skills/example_skill.py
+++ b/ai-coach-service/app/core/agents/skills/example_skill.py
@@ -26,18 +26,20 @@ from app.core.agents.skills.registry import SkillContext, skill
         "Get the user's scheduled calendar events for a date range, including each "
         "workout's full exercise list (names, target sets/reps, notes). Use this to "
         "check what workouts are already planned and reason about specific exercises "
-        "— you do NOT need to ask the user for their plan."
+        "— you do NOT need to ask the user for their plan. The result echoes `today` "
+        "(the user's local date) and labels every event with `relativeDay` "
+        "(today/tomorrow/yesterday/in N days) — trust those labels."
     ),
     parameters={
         "type": "object",
         "properties": {
             "startDate": {
                 "type": "string",
-                "description": "Start date in ISO format (YYYY-MM-DD). Default: today",
+                "description": "Start date in ISO format (YYYY-MM-DD). Default: yesterday (user-local), so recently missed sessions are included",
             },
             "endDate": {
                 "type": "string",
-                "description": "End date in ISO format (YYYY-MM-DD). Default: 7 days from start",
+                "description": "End date in ISO format (YYYY-MM-DD). Default: 7 days from today",
             },
             "type": {
                 "type": "string",

--- a/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
@@ -19,7 +19,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                     "properties": {
                         "date": {
                             "type": "string",
-                            "description": "Date in ISO format (YYYY-MM-DD). Use 'today' or 'tomorrow' for relative dates."
+                            "description": "Date in ISO format (YYYY-MM-DD). Use 'today' or 'tomorrow' for relative dates (resolved in the user's timezone)."
                         },
                         "title": {
                             "type": "string",
@@ -72,17 +72,17 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "get_calendar_events",
-                "description": "Get the user's scheduled calendar events for a date range. Use this to check what workouts are already planned.",
+                "description": "Get the user's scheduled calendar events for a date range. Use this to check what workouts are already planned. The result echoes `today` (the user's local date) and labels every event with `relativeDay` (today/tomorrow/yesterday/in N days) — trust those labels.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "startDate": {
                             "type": "string",
-                            "description": "Start date in ISO format (YYYY-MM-DD). Default: today"
+                            "description": "Start date in ISO format (YYYY-MM-DD). Default: yesterday (user-local), so recently missed sessions are included"
                         },
                         "endDate": {
                             "type": "string",
-                            "description": "End date in ISO format (YYYY-MM-DD). Default: 7 days from start"
+                            "description": "End date in ISO format (YYYY-MM-DD). Default: 7 days from today"
                         },
                         "type": {
                             "type": "string",

--- a/ai-coach-service/tests/test_calendar_service.py
+++ b/ai-coach-service/tests/test_calendar_service.py
@@ -1,0 +1,183 @@
+"""
+Tests for CalendarService date handling (TOR-14).
+
+The incident: on 2026-07-13 (user tz Asia/Jerusalem) the coach called a Jul 14
+event "today" and Jul 12 events "today". Root causes: tool results carried bare
+absolute dates with no relative anchoring, and the default range was computed
+with utcnow() (excluding yesterday's missed session).
+"""
+from datetime import date, datetime
+
+import pytest
+from bson import ObjectId
+from unittest.mock import AsyncMock, MagicMock
+
+import app.core.agents.services.calendar_service as calendar_service_module
+from app.core.agents.date_utils import get_user_today, relative_day_label
+from app.core.agents.services.calendar_service import CalendarService
+
+USER_ID = str(ObjectId())
+TODAY = datetime(2026, 7, 13)  # the incident day, user-local
+
+
+# --------------------------- relative_day_label ---------------------------
+
+class TestRelativeDayLabel:
+    @pytest.mark.parametrize("target,expected", [
+        (date(2026, 7, 13), "today"),
+        (date(2026, 7, 14), "tomorrow"),
+        (date(2026, 7, 12), "yesterday"),
+        (date(2026, 7, 16), "in 3 days"),
+        (date(2026, 7, 11), "2 days ago"),
+    ])
+    def test_labels(self, target, expected):
+        assert relative_day_label(target, date(2026, 7, 13)) == expected
+
+
+# --------------------------- get_user_today ---------------------------
+
+def _db_with_timezone(tz):
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value={"settings": {"timezone": tz}})
+    return db
+
+
+class TestGetUserToday:
+    async def test_local_date_wins_at_utc_boundary(self):
+        # 22:30 UTC on Jul 12 is already Jul 13 in Jerusalem (UTC+3).
+        db = _db_with_timezone("Asia/Jerusalem")
+        today, tz = await get_user_today(db, USER_ID, now=datetime(2026, 7, 12, 22, 30))
+        assert today == datetime(2026, 7, 13)
+        assert tz == "Asia/Jerusalem"
+
+    async def test_utc_user_keeps_utc_date(self):
+        db = _db_with_timezone("UTC")
+        today, tz = await get_user_today(db, USER_ID, now=datetime(2026, 7, 12, 22, 30))
+        assert today == datetime(2026, 7, 12)
+        assert tz == "UTC"
+
+    async def test_invalid_timezone_falls_back_to_utc(self):
+        db = _db_with_timezone("Not/AZone")
+        today, tz = await get_user_today(db, USER_ID, now=datetime(2026, 7, 12, 22, 30))
+        assert today == datetime(2026, 7, 12)
+        assert tz == "UTC"
+
+    async def test_lookup_error_falls_back_to_utc(self):
+        db = MagicMock()
+        db.users.find_one = AsyncMock(side_effect=RuntimeError("boom"))
+        today, tz = await get_user_today(db, USER_ID, now=datetime(2026, 7, 13, 10, 50))
+        assert today == datetime(2026, 7, 13)
+        assert tz == "UTC"
+
+
+# --------------------------- get_calendar_events ---------------------------
+
+def _event(oid_hex_suffix, day, title):
+    return {
+        "_id": ObjectId("6a51000000000000000000" + oid_hex_suffix),
+        "date": day,
+        "title": title,
+        "type": "workout",
+        "status": "scheduled",
+    }
+
+
+def _db_with_events(events):
+    db = MagicMock()
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.to_list = AsyncMock(return_value=events)
+    db.calendarevents.find = MagicMock(return_value=cursor)
+    return db
+
+
+@pytest.fixture
+def anchor_today(monkeypatch):
+    """Pin the user-local today to the incident date."""
+    monkeypatch.setattr(
+        calendar_service_module, "get_user_today",
+        AsyncMock(return_value=(TODAY, "Asia/Jerusalem")),
+    )
+
+
+class TestGetCalendarEvents:
+    async def test_incident_regression_relative_labels(self, anchor_today):
+        # Calendar shape from the incident: 2 events yesterday, 1 tomorrow, none today.
+        events = [
+            _event("01", datetime(2026, 7, 12), "Strength and Conditioning (Jul 12)"),
+            _event("02", datetime(2026, 7, 12), "20-Min Bodyweight Core (Jul 12)"),
+            _event("03", datetime(2026, 7, 14), "Endurance 1 (Jul 14)"),
+        ]
+        db = _db_with_events(events)
+        service = CalendarService(db)
+
+        result = await service.get_calendar_events(USER_ID, {})
+
+        assert result["success"] is True
+        assert result["today"] == "2026-07-13"
+        assert result["timezone"] == "Asia/Jerusalem"
+        assert result["message"].startswith("Today is 2026-07-13")
+
+        labels = {e["title"]: e["relativeDay"] for e in result["events"]}
+        assert labels["Strength and Conditioning (Jul 12)"] == "yesterday"
+        assert labels["20-Min Bodyweight Core (Jul 12)"] == "yesterday"
+        assert labels["Endurance 1 (Jul 14)"] == "tomorrow"
+        assert not any(e["isToday"] for e in result["events"])
+
+    async def test_default_range_includes_yesterday(self, anchor_today):
+        db = _db_with_events([])
+        service = CalendarService(db)
+
+        result = await service.get_calendar_events(USER_ID, {})
+
+        query = db.calendarevents.find.call_args[0][0]
+        assert query["date"]["$gte"] == datetime(2026, 7, 12)  # yesterday
+        assert query["date"]["$lte"] == datetime(2026, 7, 20)  # today + 7
+        assert result["queriedRange"] == {"start": "2026-07-12", "end": "2026-07-20"}
+
+    async def test_explicit_start_keeps_seven_day_window(self, anchor_today):
+        db = _db_with_events([])
+        service = CalendarService(db)
+
+        await service.get_calendar_events(USER_ID, {"startDate": "2026-07-01"})
+
+        query = db.calendarevents.find.call_args[0][0]
+        assert query["date"]["$gte"] == datetime(2026, 7, 1)
+        assert query["date"]["$lte"] == datetime(2026, 7, 8)
+
+    async def test_empty_result_states_today(self, anchor_today):
+        db = _db_with_events([])
+        service = CalendarService(db)
+
+        result = await service.get_calendar_events(USER_ID, {})
+
+        assert result["events"] == []
+        assert result["today"] == "2026-07-13"
+        assert "Today is 2026-07-13" in result["message"]
+
+
+# --------------------------- schedule_to_calendar ---------------------------
+
+class TestScheduleToCalendar:
+    async def test_today_resolves_user_local(self, monkeypatch):
+        # Pin user-local today to Jul 13 even though "server UTC" would say Jul 12.
+        monkeypatch.setattr(
+            calendar_service_module, "get_user_today",
+            AsyncMock(return_value=(TODAY, "Asia/Jerusalem")),
+        )
+        db = MagicMock()
+        insert_result = MagicMock()
+        insert_result.inserted_id = ObjectId()
+        db.calendarevents.insert_one = AsyncMock(return_value=insert_result)
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID, {"date": "today", "title": "Recovery Walk", "type": "event"}
+        )
+
+        assert result["success"] is True
+        stored = db.calendarevents.insert_one.call_args[0][0]
+        assert stored["date"] == datetime(2026, 7, 13)  # user-local midnight
+        assert result["is_today"] is True
+        assert result["relativeDay"] == "today"
+        assert result["dateISO"] == "2026-07-13"


### PR DESCRIPTION
## Problem (TOR-14)

On 2026-07-13 the coach told a user "Today you've got Endurance 1" (a **Jul 14** event) and then "two workouts scheduled for today ... both on **Jul 12**" — self-contradictory, and both wrong. Verified against the production `chatConversations` / `calendarevents` collections: Jul 12 had 2 events, Jul 13 none, Jul 14 one.

## Root cause

- The system prompt injects the correct user-local "Today's date", but `get_calendar_events` returned only bare `YYYY-MM-DD` + weekday per event — no relative anchoring — so the LLM (gpt-5.4-mini, reasoning effort "none") did the date arithmetic itself and got it wrong.
- The tool's default range used `datetime.utcnow()` (not the user's timezone) and started at today, so turn 1's result **excluded the missed Jul 12 session** and contained only the Jul 14 event, which the model mislabeled "today".
- `schedule_to_calendar` also resolved 'today'/'tomorrow' via `utcnow()`.

## Fix (ai-coach-service only; storage convention unchanged)

- New `app/core/agents/date_utils.py`: `get_user_today` (user-local calendar day from `users.settings.timezone`, UTC fallback, injectable `now` for tests) and `relative_day_label`.
- `get_calendar_events`: anchors on user-local today; default range widened to **yesterday → today+7d**; result echoes `today`, `dayOfWeek`, `timezone`, `queriedRange`; every event gets `relativeDay` ("today"/"tomorrow"/"yesterday"/"in N days"/"N days ago") and `isToday`; summary opens with "Today is ...".
- `schedule_to_calendar`: 'today'/'tomorrow' and the is-today check resolve in the user's timezone; response includes `dateISO` + `relativeDay`.
- Tool/skill descriptions (live skill in `example_skill.py` + legacy `calendar_tools.py`) document the new fields and default range.
- `prompts.py`: DATE DISCIPLINE rule — always use the tool's relative labels, never recompute from raw dates.
- `orchestrator.py`: timezone-fallback timestamp now actually UTC (was naive server-local labeled "(UTC)").

## Tests

New `tests/test_calendar_service.py` (14 tests): incident regression (Jul 12×2 / Jul 14 events with today=Jul 13 → labeled yesterday/tomorrow, none today), default range includes yesterday, UTC-boundary timezone resolution, invalid-tz/lookup-error fallbacks, user-local 'today' scheduling. Full suite: **279 passed**.

## Follow-up (out of scope)

Other skills still resolve "today" via `utcnow()`: `reschedule_session_skill.py`, `schedule_plan_skill.py` (has a TODO), `review_progress_skill.py`, `update_calendar_workout_skill.py` — they can adopt `get_user_today` in a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)