### PR TITLE
TOR-24: Feedback issues are created without the Feedback Inbox project

### DIFF
--- a/backend/src/services/LinearService.js
+++ b/backend/src/services/LinearService.js
@@ -109,6 +109,12 @@ class LinearService {
 
       const labelId = await this.findLabelIdForCategory(category);
 
+      if (!process.env.LINEAR_FEEDBACK_PROJECT_ID) {
+        console.warn(
+          'LINEAR_FEEDBACK_PROJECT_ID not set — feedback issue will be created without a project'
+        );
+      }
+
       const input = {
         teamId: process.env.LINEAR_TEAM_ID,
         title,


### PR DESCRIPTION
## What changed

`LinearService.createFeedbackIssue` now logs a `console.warn` when `LINEAR_FEEDBACK_PROJECT_ID` is unset, instead of silently creating the feedback issue without a project. One 6-line change in `backend/src/services/LinearService.js`.

The root-cause fix is operational, not code: `LINEAR_FEEDBACK_PROJECT_ID=b19c1213-952d-494c-8688-0ef85d734430` must be set on the Render service `synergyfit-api` (`srv-d27e3l6uk2gs73e2l1mg`). **That env change is still pending** — the automated session was not permitted to modify the production service, so a human needs to set it (Render dashboard → synergyfit-api → Environment).

## Verification

- Stub-API run with the env var **unset**: the new warning `LINEAR_FEEDBACK_PROJECT_ID not set — feedback issue will be created without a project` is printed and issue creation still succeeds (no regression).
- Stub-API run with the env var **set**: `issueCreate` input contains `projectId: b19c1213-952d-494c-8688-0ef85d734430`.
- Confirmed via Linear API (read-only) that this id is the live **Feedback Inbox** project.
- `npm test --prefix backend`: 9/9 pass. Lint: ESLint v9/legacy-config mismatch predates this change (does not run on `origin/main` either); no new findings on the changed file.

## Acceptance criteria

- [ ] Feedback submitted in production lands in the Feedback Inbox project — **pending the Render env var** (human action above); code path verified to send `projectId` once set
- [x] A missing or rejected project configuration is observable in logs, not silent (new warn for missing; existing `console.error` retry log covers rejected)
- [x] No regression: feedback issues are still created even when project routing fails

Linear: https://linear.app/torii-fitness/issue/TOR-24/feedback-issues-are-created-without-the-feedback-inbox-project

🤖 Generated with [Claude Code](https://claude.com/claude-code)