### PR TITLE
Fix dark loading flash on Settings pages in light theme (TOR-18 follow-up)

### DIFF
--- a/frontend/src/pages/MemoriesSettings.jsx
+++ b/frontend/src/pages/MemoriesSettings.jsx
@@ -199,7 +199,7 @@ export default function MemoriesSettings() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-white dark:bg-gray-900 flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary-400" />
       </div>
     );

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -427,7 +427,7 @@ export default function Settings() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-white dark:bg-gray-900 flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary-400" />
       </div>
     );


### PR DESCRIPTION
## Summary

Follow-up to #105 — TOR-18 still reproduced. The remaining flash is a different root cause: the loading-state wrapper on the Settings page (and the Memories settings sub-page) hardcodes `bg-gray-900` with no `dark:` gate, so while the profile fetch is in flight the content area paints dark regardless of theme, then flips to light once data loads. #105's inline-script fix correctly sets the `<html>` class (header/nav were already light in the user's screenshots) but can't help an element whose background ignores the theme class.

Fix: make the loading wrapper match the loaded wrapper — `bg-white dark:bg-gray-900` — in:

- `frontend/src/pages/Settings.jsx`
- `frontend/src/pages/MemoriesSettings.jsx`

These were the only two pages with a full-screen hardcoded-dark loading state (other spinners live inside theme-aware containers; the chat `ConversationSidebar` is intentionally always dark).

Linear: [TOR-18](https://linear.app/torii-fitness/issue/TOR-18/feedbackbug-settings)

## Verification

Ran the local stack and drove it with Playwright, delaying the profile/API GETs so the loading state stays visible:

- `/Settings`, stored light theme → loading wrapper computed background `rgb(255, 255, 255)`, no flip after load
- `/Settings`, stored dark theme → `rgb(17, 24, 39)` (gray-900) during load and after
- `/Settings/Memories` → same results in both themes
- User's exact repro (OS `prefers-color-scheme: dark` + stored light theme) → `<html>` class `light`, loading background white

🤖 Generated with [Claude Code](https://claude.com/claude-code)