### PR TITLE
Fix profile save failing for users with unset weight/height/gender

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -207,14 +207,20 @@ const updateProfile = async (req, res) => {
     if (address !== undefined) updateData.address = address;
     if (profilePicture !== undefined) updateData.profilePicture = profilePicture;
     if (profile) {
+      // Clients send '' for unset weight/height/gender, which would fail the
+      // Number cast / gender enum. '' never means anything in this sub-schema,
+      // so drop those keys instead of letting them wedge the whole update.
+      const cleanProfile = Object.fromEntries(
+        Object.entries(profile).filter(([, value]) => value !== '')
+      );
       // Deep merge profile preferences
       const existingProfile = req.user.profile ? (req.user.profile.toObject ? req.user.profile.toObject() : req.user.profile) : {};
       updateData.profile = {
         ...existingProfile,
-        ...profile,
+        ...cleanProfile,
         preferences: {
           ...(existingProfile.preferences || {}),
-          ...(profile.preferences || {})
+          ...(cleanProfile.preferences || {})
         }
       };
     }
@@ -249,6 +255,12 @@ const updateProfile = async (req, res) => {
     });
   } catch (error) {
     console.error('Update profile error:', error);
+    if (error.name === 'ValidationError' || error.name === 'CastError') {
+      return res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
     res.status(500).json({
       success: false,
       message: 'Server error updating profile'

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -22,6 +22,7 @@ export default function Settings() {
   const { theme, toggleTheme, isDark } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState(null);
   const [user, setUser] = useState(null);
   const [editingField, setEditingField] = useState(null);
   const [newGoal, setNewGoal] = useState('');
@@ -153,8 +154,20 @@ export default function Settings() {
     }
   };
 
+  // Unset weight/height/gender live in form state as '' — the schema wants
+  // Number/enum there, so empty values must be omitted, not sent as ''.
+  const buildProfilePayload = () => {
+    const { weight, height, gender, ...rest } = formData.profile;
+    const profile = { ...rest };
+    if (weight !== '') profile.weight = Number(weight);
+    if (height !== '') profile.height = Number(height);
+    if (gender !== '') profile.gender = gender;
+    return profile;
+  };
+
   const handleSave = async () => {
     setIsSaving(true);
+    setSaveMessage(null);
     try {
       const token = localStorage.getItem('authToken');
       const response = await fetch(`${import.meta.env.VITE_API_URL || 'http://localhost:5001'}/api/v1/auth/profile`, {
@@ -169,7 +182,7 @@ export default function Settings() {
           dateOfBirth: formData.dateOfBirth || null,
           address: formData.address,
           profilePicture: formData.profilePicture,
-          profile: formData.profile,
+          profile: buildProfilePayload(),
           settings: formData.settings
         })
       });
@@ -181,9 +194,13 @@ export default function Settings() {
         localStorage.setItem('authUser', JSON.stringify({ ...authUser, ...data.data.user }));
         setUser(data.data.user);
         setEditingField(null);
+      } else {
+        const data = await response.json().catch(() => null);
+        setSaveMessage({ type: 'error', text: data?.message || 'Failed to save changes. Please try again.' });
       }
     } catch (error) {
       console.error('Error saving profile:', error);
+      setSaveMessage({ type: 'error', text: 'Failed to save changes. Please try again.' });
     } finally {
       setIsSaving(false);
     }
@@ -228,6 +245,13 @@ export default function Settings() {
     const current = formData.profile[key] || [];
     commitProfile({ ...formData.profile, [key]: current.filter((x) => x !== value) });
   };
+
+  const renderSaveMessage = () => saveMessage && (
+    <div className="mt-2 p-3 rounded-lg flex items-center gap-2 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400">
+      <AlertCircle className="w-5 h-5 flex-shrink-0" />
+      <span className="text-sm">{saveMessage.text}</span>
+    </div>
+  );
 
   // Plain render function (NOT a nested component — that would remount the input
   // and drop focus on each keystroke).
@@ -497,6 +521,7 @@ export default function Settings() {
                       {isSaving ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : 'Save'}
                     </button>
                   </div>
+                  {renderSaveMessage()}
                 </div>
               ) : (
                 <button
@@ -580,6 +605,7 @@ export default function Settings() {
                         {isSaving ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : 'Save'}
                       </button>
                     </div>
+                    {renderSaveMessage()}
                   </div>
                 ) : (
                   <button
@@ -1041,6 +1067,7 @@ export default function Settings() {
 
         {/* Save All Changes Button */}
         <div className="mt-8 pb-4">
+          {saveMessage && <div className="mb-4">{renderSaveMessage()}</div>}
           <button
             onClick={handleSave}
             disabled={isSaving}


### PR DESCRIPTION
## Problem

User report: phone number on the profile (Settings) page won't save.

Root cause: `handleSave` sends the whole fitness profile on every save, with unset weight/height/gender as **empty strings** (they're initialized to `''` from `userData.profile?.weight || ''`). The backend merges that into the update and runs it with `runValidators: true`, where mongoose rejects it — `''` fails the `Number` cast for weight/height and the gender enum. The PUT returns 500, and the frontend's `if (response.ok)` has no else, so the failure is completely silent. Net effect: **any user with an incomplete fitness profile can't save anything on the Settings page** — phone is just where it gets noticed.

## Changes

**Frontend (`frontend/src/pages/Settings.jsx`)**
- `buildProfilePayload()`: omit empty weight/height/gender from the PUT payload; send weight/height as numbers.
- Failed saves now show a red error banner (inline under the field editor's Save button, and above the bottom "Save Changes" button) instead of failing silently.

**Backend (`backend/src/controllers/authController.js`)**
- `updateProfile` drops empty-string profile keys before the deep merge, so old clients / other callers can't wedge the update the same way.
- Validation/cast errors now return 400 with the mongoose message instead of a generic 500.

## Verification (local stack against the fixed code, pm-test account)

- Replayed the exact old-client payload (`profile: {weight:"", height:"", gender:"", ...}` + phone) via curl: **old controller → HTTP 500**, fixed controller → **HTTP 200** with phone persisted and weight/height/gender untouched.
- Full UI flow via Playwright (isolated headless Chromium): login → Settings → edit Phone → Save → PUT 200 → reload → phone shown. Screenshot-verified.
- Forced the PUT to fail (route abort): the new error banner renders under the Save button.
- Probes: invalid gender enum via API → 400 with a clear mongoose message; numeric weight saves and persists; `weight: ""` after a value was set → value preserved (no clobber).

Note: clearing an already-set weight/height/gender still isn't possible from this page (empty string now means "leave unchanged"). That was equally impossible before (it 500'd); left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)