### PR TITLE
TOR-79: enforce admin role on ai-coach /conversations/admin/* + scope progressions GET /:id

### DIFF
--- a/ai-coach-service/app/api/v1/conversations.py
+++ b/ai-coach-service/app/api/v1/conversations.py
@@ -15,7 +15,7 @@ from app.models.schemas import (
     FeedbackResponse,
     PaginatedFeedbackResponse
 )
-from app.middleware.auth import get_current_user
+from app.middleware.auth import get_current_user, require_admin
 from app.services.conversation_service import ConversationService
 
 router = APIRouter()
@@ -252,13 +252,12 @@ async def get_all_feedbacks(
     limit: int = Query(50, ge=1, le=200, description="Items per page"),
     rating: Optional[str] = Query(None, description="Filter by rating"),
     user_id: Optional[str] = Query(None, description="Filter by user_id"),
-    current_user: dict = Depends(get_current_user)
+    current_user: dict = Depends(require_admin)
 ) -> Any:
     """
     Get all feedbacks with pagination (Admin only).
 
     Returns paginated feedback entries with previews.
-    TODO: Add admin role check
     """
     try:
         service = get_conversation_service(request)
@@ -280,13 +279,12 @@ async def get_all_feedbacks(
 async def admin_get_conversation(
     conversation_id: str,
     request: Request,
-    current_user: dict = Depends(get_current_user)
+    current_user: dict = Depends(require_admin)
 ) -> Any:
     """
     Get any conversation by ID (Admin only).
 
     Admin can access any conversation regardless of owner.
-    TODO: Add admin role check
     """
     try:
         service = get_conversation_service(request)
@@ -313,12 +311,10 @@ async def admin_get_user_history(
     request: Request,
     limit: int = Query(50, ge=1, le=100),
     skip: int = Query(0, ge=0),
-    current_user: dict = Depends(get_current_user)
+    current_user: dict = Depends(require_admin)
 ) -> Any:
     """
     Get conversation history for any user (Admin only).
-
-    TODO: Add admin role check
     """
     try:
         service = get_conversation_service(request)

--- a/ai-coach-service/app/middleware/auth.py
+++ b/ai-coach-service/app/middleware/auth.py
@@ -1,8 +1,12 @@
-from fastapi import Depends, HTTPException, status
+from bson import ObjectId
+from bson.errors import InvalidId
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import JWTError, jwt
 from typing import Optional, Dict, Any
 from app.config import get_settings
+
+ADMIN_ROLES = ("admin", "superAdmin")
 
 security = HTTPBearer(auto_error=False)
 
@@ -50,6 +54,35 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED, 
             detail=f"Invalid token: {str(e)}"
         )
+
+
+async def require_admin(
+    request: Request,
+    current_user: Dict[str, Any] = Depends(get_current_user)
+) -> Dict[str, Any]:
+    """Allow only users whose DB role is admin/superAdmin.
+
+    The Node-issued JWT carries no role claim, so the role is looked up
+    per-request in Mongo (mirrors backend/src/middleware/admin.js).
+    """
+    try:
+        user_oid = ObjectId(current_user["user_id"])
+    except (InvalidId, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required"
+        )
+
+    user = await request.app.state.db.users.find_one(
+        {"_id": user_oid}, {"role": 1}
+    )
+    if not user or user.get("role") not in ADMIN_ROLES:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required"
+        )
+
+    return current_user
 
 
 async def get_optional_user(

--- a/backend/src/routes/progressions.js
+++ b/backend/src/routes/progressions.js
@@ -51,7 +51,14 @@ router.get('/', optionalAuth, async (req, res) => {
 // @access  Public (but shows user data if authenticated)
 router.get('/:id', optionalAuth, async (req, res) => {
   try {
-    const progression = await Progression.findById(req.params.id)
+    const userId = req.user?.id;
+
+    // Scope like the list route: common progressions + user's own
+    const query = userId
+      ? { _id: req.params.id, $or: [{ isCommon: true }, { createdBy: userId }] }
+      : { _id: req.params.id, isCommon: true };
+
+    const progression = await Progression.findOne(query)
       .populate('steps.exerciseId', 'name difficulty muscles strain mediaUrls')
       .lean();
 


### PR DESCRIPTION
## Summary

Fixes [TOR-79](https://linear.app/torii-fitness/issue/TOR-79/enforce-admin-role-on-ai-coach-service-conversationsadmin-endpoints) (Urgent): the three ai-coach-service admin endpoints (`GET /api/v1/conversations/admin/feedbacks`, `.../admin/conversations/{id}`, `.../admin/user/{user_id}/history`) were gated only by JWT validity — any authenticated user could read any other user's conversations, chat history, and feedback.

Also fixes a second cross-user leak found in the same audit: backend `GET /api/v1/progressions/:id` did a bare `findById` under `optionalAuth`, exposing private progressions to anyone with the ID.

## Changes

- **`ai-coach-service/app/middleware/auth.py`** — new `require_admin` dependency. The Node-issued JWT carries no role claim (`{id, email, username}` only), so the role is looked up per-request in Mongo (`users.find_one` with a `{role: 1}` projection), mirroring `backend/src/middleware/admin.js`: only `admin`/`superAdmin` pass; missing user, missing role, or invalid ObjectId all fail closed with 403.
- **`ai-coach-service/app/api/v1/conversations.py`** — the three admin handlers now use `Depends(require_admin)`; the three `TODO: Add admin role check` comments are gone. Regular per-user endpoints untouched.
- **`backend/src/routes/progressions.js`** — `GET /:id` now uses the same scoped query as the list route (`isCommon: true` OR `createdBy: userId`); non-owned private progressions hit the existing 404 path, common progressions stay public.

Note: nothing in the repo currently calls the admin endpoints (no frontend/backend consumer), so the gate carries zero regression risk for real consumers.

## Verification

Ran both services from this branch against a throwaway scratch DB (`tor79-verify` — dropped afterwards), with two freshly registered throwaway users:

- Non-admin on all 3 admin endpoints → **403, 403, 403**
- Same user with `role: superAdmin` → **200, 404 (nonexistent conversation id, passes gate), 200**
- Role reverted → admin endpoint back to **403**; regular `GET /conversations/history` still **200**
- Progressions: private → owner **200**, other user **404**, unauthenticated **404**; common → **200** for other user and unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)