### PR TITLE
Sensei calendar workouts always linked to a workout template + Start-session routing fix

### DIFF
--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -181,7 +181,7 @@ CALENDAR WORKFLOW:
 When user asks to add/schedule a workout for a specific date:
 1. Design the workout and get user approval
 2. Call `schedule_to_calendar` with the workout details (title, date, workoutDetails with exercises)
-3. The `schedule_to_calendar` tool creates the calendar event directly - it does NOT need a template first
+3. `workoutDetails` with the FULL exercise list is REQUIRED for workout/deload events — never schedule a bare title. The tool creates the calendar event directly (it does NOT need a template first): it saves the planned workout to the user's workout library and links the event to it automatically
 4. If for today, ask if they want to start training now
 
 DATE DISCIPLINE (CRITICAL):

--- a/ai-coach-service/app/core/agents/services/calendar_service.py
+++ b/ai-coach-service/app/core/agents/services/calendar_service.py
@@ -46,6 +46,20 @@ class CalendarService:
             workout_details = args.get("workoutDetails", {})
             notes = args.get("notes", "")
 
+            # Hard gate: a workout on the calendar must be a planned session
+            # backed by a library template — never a bare title. Returning a
+            # tool error here makes the agent plan the exercises and retry.
+            if event_type in ("workout", "deload") and not workout_details.get("exercises"):
+                return {
+                    "success": False,
+                    "error": "missing_workout_details",
+                    "message": (
+                        "A workout calendar event must include workoutDetails.exercises. "
+                        "Plan the session first (exercise names, targetSets, targetReps, muscles), "
+                        "then call schedule_to_calendar again with the full workoutDetails."
+                    ),
+                }
+
             # Add date to title to make it unique and identifiable
             date_suffix = event_date.strftime("%b %d")
             title_with_date = f"{title} ({date_suffix})"
@@ -54,7 +68,7 @@ class CalendarService:
             exercises = []
 
             # If this is a workout event with details, first save it to user's workout library
-            if event_type == "workout" and workout_details:
+            if event_type in ("workout", "deload") and workout_details:
                 # Build the blocks structure; the shared resolver fills in real
                 # exercise ids (exact → fuzzy → vector → create) so neither the
                 # PredefinedWorkout nor the CalendarEvent can carry a null id.
@@ -128,7 +142,7 @@ class CalendarService:
                 event_data["workoutTemplateId"] = workout_template_id
 
             # Add workout details to calendar event
-            if event_type == "workout" and workout_details:
+            if event_type in ("workout", "deload") and workout_details:
                 event_data["workoutDetails"] = {
                     "type": workout_details.get("workoutType", "strength"),
                     "estimatedDuration": workout_details.get("estimatedDuration", 45),
@@ -146,7 +160,7 @@ class CalendarService:
                 response_msg = f"Scheduled **{title_with_date}** for **{formatted_date}**!"
                 if workout_template_id:
                     response_msg += "\n\n**Saved to your workout library** - you can reuse this workout anytime!"
-                if event_type == "workout" and exercise_count > 0:
+                if event_type in ("workout", "deload") and exercise_count > 0:
                     duration = workout_details.get("estimatedDuration", 45)
                     response_msg += f"\n\n**{exercise_count} exercises** | **~{duration} min**"
 

--- a/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 import structlog
 from bson import ObjectId
 
+from app.core.agents.services.exercise_resolver import ExerciseResolver
 from app.core.agents.skills.registry import SkillContext, skill
 
 logger = structlog.get_logger()
@@ -127,8 +128,11 @@ def _resolve_workout_content(workout: Dict[str, Any], template_map: Dict[str, An
                 "exercises": exercises,
                 "template_id": workout.get("predefinedWorkoutId"),
             }
-        # Referenced template is missing — degrade gracefully.
-        return {"title": "Workout", "type": "strength", "duration": 45, "exercises": [], "template_id": None}
+        # Referenced template is missing — nothing to schedule. Flagged so
+        # _build_events drops the slot instead of inserting an orphan event
+        # with an empty exercise list.
+        return {"title": "Workout", "type": "strength", "duration": 45, "exercises": [],
+                "template_id": None, "missing_template": True}
 
     # Custom inline workout
     custom = workout.get("customWorkout") or {}
@@ -136,12 +140,15 @@ def _resolve_workout_content(workout: Dict[str, Any], template_map: Dict[str, An
     for ex in custom.get("exercises", []) or []:
         sets_arr = ex.get("sets", []) or []
         first = sets_arr[0] if sets_arr and isinstance(sets_arr[0], dict) else {}
-        exercises.append({
+        entry = {
             "exerciseName": ex.get("exerciseName", ""),
             "targetSets": len(sets_arr) or 3,
             "targetReps": first.get("reps") or 10,
             "notes": "",
-        })
+        }
+        if ex.get("exerciseId"):
+            entry["exerciseId"] = ex["exerciseId"]
+        exercises.append(entry)
     return {
         "title": custom.get("title") or "Workout",
         "type": custom.get("type", "strength"),
@@ -149,6 +156,19 @@ def _resolve_workout_content(workout: Dict[str, Any], template_map: Dict[str, An
         "exercises": exercises,
         "template_id": None,
     }
+
+
+def _included_weeks(plan: Dict[str, Any], weeks_cap: Optional[int]) -> List[Dict[str, Any]]:
+    """Weeks that actually get scheduled: within the cap, and resolved.
+
+    Rolling-materialization plans: only resolved weeks have real workouts;
+    intent-only stubs are scheduled later, week by week, via resolve_week.
+    Missing `resolved` = resolved (legacy plans).
+    """
+    weeks = sorted(plan.get("weeks", []) or [], key=lambda w: w.get("weekNumber", 0))
+    if weeks_cap:
+        weeks = [w for w in weeks if w.get("weekNumber", 0) <= weeks_cap]
+    return [w for w in weeks if w.get("resolved") is not False]
 
 
 def _build_events(
@@ -165,15 +185,15 @@ def _build_events(
     Emits workout events (type 'deload' for deload weeks, else 'workout') plus a
     'rest' event for each restDays entry. Each event carries planId/planWeek/
     planDay for back-linking and idempotency.
+
+    Workout/deload events without a library template but WITH exercises (custom
+    plan workouts) carry a transient `_pendingTemplate` marker: the handler
+    creates + links a PredefinedWorkout on the confirmed write path (never on
+    dry-run) and strips the marker before insert. Workouts whose referenced
+    template was deleted are dropped entirely rather than inserted as orphans.
     """
     events: List[Dict[str, Any]] = []
-    weeks = sorted(plan.get("weeks", []) or [], key=lambda w: w.get("weekNumber", 0))
-    if weeks_cap:
-        weeks = [w for w in weeks if w.get("weekNumber", 0) <= weeks_cap]
-    # Rolling-materialization plans: only resolved weeks have real workouts;
-    # intent-only stubs are scheduled later, week by week, via resolve_week.
-    # Missing `resolved` = resolved (legacy plans).
-    weeks = [w for w in weeks if w.get("resolved") is not False]
+    weeks = _included_weeks(plan, weeks_cap)
     included_week_numbers = {w.get("weekNumber", 0) for w in weeks}
 
     for week in weeks:
@@ -184,6 +204,10 @@ def _build_events(
             day = workout.get("dayOfWeek", 1)
             date = _compute_event_date(start_date, week_number, day)
             content = _resolve_workout_content(workout, template_map)
+            if content.get("missing_template"):
+                logger.warning("plan workout references missing template — skipped",
+                               plan_id=str(plan_oid), week=week_number, day=day)
+                continue
             event = {
                 "userId": user_oid,
                 "planId": plan_oid,
@@ -204,6 +228,10 @@ def _build_events(
             }
             if content.get("template_id"):
                 event["workoutTemplateId"] = content["template_id"]
+            elif content["exercises"]:
+                # Custom plan workout — needs a library template created and
+                # linked on the write path (see _ensure_templates).
+                event["_pendingTemplate"] = content
             events.append(event)
 
         for rest_day in week.get("restDays", []) or []:
@@ -257,6 +285,124 @@ def _slot_key(event: Dict[str, Any]) -> tuple:
     # deload share it (a re-planned deload week moves the session, no duplicate).
     type_class = "workout" if etype in ("workout", "deload", None) else etype
     return (event.get("planWeek"), event.get("planDay"), type_class)
+
+
+def _template_content_key(name: str, exercises: List[Dict[str, Any]]) -> tuple:
+    """Identity of a workout's content: title + ordered exercise prescription.
+    Used to dedupe template creation (same custom workout repeated across
+    weeks → one library entry) and to match plan-tagged templates on re-runs."""
+    return (
+        name,
+        tuple(
+            (ex.get("exerciseName", ""), ex.get("targetSets", 3), ex.get("targetReps", 10))
+            for ex in exercises
+        ),
+    )
+
+
+def _template_doc_key(doc: Dict[str, Any]) -> tuple:
+    """The same content key, recomputed from a PredefinedWorkout document."""
+    exercises = []
+    for block in doc.get("blocks", []) or []:
+        for ex in block.get("exercises", []) or []:
+            sets, reps = _parse_volume(ex.get("volume"))
+            exercises.append({"exerciseName": ex.get("exercise_name", ""),
+                              "targetSets": sets, "targetReps": reps})
+    return _template_content_key(doc.get("name", ""), exercises)
+
+
+def _template_doc_exercise_ids(doc: Dict[str, Any]) -> List[Any]:
+    return [
+        ex.get("exercise_id")
+        for block in doc.get("blocks", []) or []
+        for ex in block.get("exercises", []) or []
+    ]
+
+
+async def _ensure_templates(
+    ctx: SkillContext, user_id: str, plan: Dict[str, Any], events: List[Dict[str, Any]]
+) -> int:
+    """Create (or reuse) a PredefinedWorkout for every event carrying a
+    `_pendingTemplate` marker, link it via workoutTemplateId, and backfill
+    resolved exerciseIds into the event's embedded workoutDetails.
+
+    Dedupe is by content key, both within the run (a workout repeated across
+    weeks shares ONE library entry) and across re-runs (overwrite deletes the
+    plan's events but not its templates — plan-tagged templates with matching
+    content are reused, so re-scheduling never duplicates the library). Keying
+    by content rather than name also keeps two same-titled workouts with
+    different prescriptions (e.g. easy-week vs hard-week "Intervals") apart.
+
+    Only called on the confirmed write path — dry-run previews write nothing.
+    Returns the number of templates created.
+    """
+    pending = [e for e in events if e.get("_pendingTemplate")]
+    if not pending:
+        return 0
+
+    user_oid = ObjectId(user_id)
+    plan_tag = f"plan-{plan['_id']}"
+    # key -> (template_id, ordered exercise ids)
+    known: Dict[tuple, tuple] = {}
+    async for doc in ctx.db.predefinedworkouts.find({"createdBy": user_oid, "tags": plan_tag}):
+        known[_template_doc_key(doc)] = (doc["_id"], _template_doc_exercise_ids(doc))
+
+    created = 0
+    resolver = ExerciseResolver(ctx.db)
+    now = datetime.utcnow()
+    for event in pending:
+        content = event.pop("_pendingTemplate")
+        key = _template_content_key(content["title"], content["exercises"])
+        if key not in known:
+            blocks = [{
+                "name": "Main Workout",
+                "exercises": [
+                    {
+                        "exercise_name": ex.get("exerciseName", ""),
+                        "exercise_id": ex.get("exerciseId"),
+                        "volume": f"{ex.get('targetSets', 3)}x{ex.get('targetReps', 10)}",
+                        "rest": "60s",
+                        "notes": ex.get("notes", ""),
+                    }
+                    for ex in content["exercises"]
+                ],
+            }]
+            # best_effort: the write is already user-confirmed — take the best
+            # match (or create) rather than stalling, same as schedule_to_calendar.
+            blocks, _report = await resolver.resolve_blocks(
+                user_id, blocks, on_ambiguous="best_effort"
+            )
+            template_doc = {
+                "name": content["title"],
+                "goal": f"Part of plan: {plan.get('name', 'training plan')}",
+                "primary_disciplines": [content.get("type", "strength")],
+                "estimated_duration": content.get("duration", 45),
+                "difficulty_level": "intermediate",
+                "blocks": blocks,
+                "tags": ["ai-generated", "plan", plan_tag],
+                "isCommon": False,
+                "createdBy": user_oid,
+                "popularity": 0,
+                "ratings": {"average": 0, "count": 0},
+                "createdAt": now,
+                "updatedAt": now,
+            }
+            result = await ctx.db.predefinedworkouts.insert_one(template_doc)
+            known[key] = (result.inserted_id, _template_doc_exercise_ids(template_doc))
+            created += 1
+
+        template_id, exercise_ids = known[key]
+        event["workoutTemplateId"] = template_id
+        embedded = event.get("workoutDetails", {}).get("exercises", [])
+        if len(embedded) == len(exercise_ids):
+            for entry, ex_id in zip(embedded, exercise_ids):
+                if ex_id and not entry.get("exerciseId"):
+                    entry["exerciseId"] = ex_id
+
+    if created:
+        logger.info("created plan workout templates",
+                    plan_id=str(plan["_id"]), created=created, linked=len(pending))
+    return created
 
 
 def _serialize_event(event: Dict[str, Any]) -> Dict[str, Any]:
@@ -385,7 +531,26 @@ async def schedule_plan_to_calendar(ctx: SkillContext, user_id: str, args: Dict[
 
     now = datetime.utcnow()
     proposed = _build_events(plan, start_date, weeks_cap, template_map, user_oid, plan_oid, now)
+
+    # Predefined workouts whose template was deleted are dropped by
+    # _build_events (no orphan events) — surface that instead of hiding it.
+    skipped_missing = sum(
+        1
+        for w in _included_weeks(plan, weeks_cap)
+        for wk in (w.get("workouts") or [])
+        if wk.get("workoutType") == "predefined"
+        and str(wk.get("predefinedWorkoutId")) not in template_map
+    )
+
     if not proposed:
+        if skipped_missing:
+            return {
+                "success": False,
+                "message": (
+                    f"All {skipped_missing} workout(s) in range reference deleted workout "
+                    "templates, so there's nothing to schedule. Want me to rebuild them?"
+                ),
+            }
         return {"success": False, "message": "This plan has no workouts to schedule yet."}
 
     unresolved_count = sum(
@@ -433,6 +598,11 @@ async def schedule_plan_to_calendar(ctx: SkillContext, user_id: str, args: Dict[
     ]
 
     preview_msg = _format_preview(plan, proposed, already_scheduled, moved, conflicts, start_date)
+    if skipped_missing:
+        preview_msg += (
+            f"\n\nNote: {skipped_missing} workout(s) reference a deleted workout template "
+            "and were skipped — want me to rebuild them?"
+        )
     if unresolved_count:
         preview_msg += (
             f"\n\nNote: {unresolved_count} later week(s) aren't finalized yet — they follow the plan's "
@@ -474,6 +644,12 @@ async def schedule_plan_to_calendar(ctx: SkillContext, user_id: str, args: Dict[
     else:
         insert_list = to_insert
 
+    # Custom plan workouts get a library template created + linked now (write
+    # path only — dry-run previews never reach here).
+    await _ensure_templates(ctx, user_id, plan, insert_list)
+    for e in proposed:
+        e.pop("_pendingTemplate", None)
+
     inserted_count = 0
     if insert_list:
         result = await ctx.db.calendarevents.insert_many(insert_list)
@@ -494,13 +670,19 @@ async def schedule_plan_to_calendar(ctx: SkillContext, user_id: str, args: Dict[
     )
 
     skipped_msg = f" ({len(already_scheduled)} already scheduled, skipped)" if already_scheduled and not overwrite else ""
+    message = (
+        f"Scheduled **{inserted_count}** session(s) for **{plan.get('name', 'your plan')}** "
+        f"starting {start_date.strftime('%A, %B %d')}{skipped_msg}. Your plan is now active!"
+    )
+    if skipped_missing:
+        message += (
+            f"\n\nNote: {skipped_missing} workout(s) reference a deleted workout template "
+            "and were skipped — want me to rebuild them?"
+        )
     return {
         "success": True,
         "dry_run": False,
         "written": True,
         "events_created": inserted_count,
-        "message": (
-            f"Scheduled **{inserted_count}** session(s) for **{plan.get('name', 'your plan')}** "
-            f"starting {start_date.strftime('%A, %B %d')}{skipped_msg}. Your plan is now active!"
-        ),
+        "message": message,
     }

--- a/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
@@ -13,7 +13,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "schedule_to_calendar",
-                "description": "Schedule a workout or event to the user's calendar for a specific date. Use this when the user wants to add a workout to their calendar, schedule a rest day, or plan future training.",
+                "description": "Schedule a workout or event to the user's calendar for a specific date. Use this when the user wants to add a workout to their calendar, schedule a rest day, or plan future training. For 'workout' and 'deload' events you MUST plan the full session first and pass it in workoutDetails.exercises — never schedule a bare title. The tool saves the planned workout to the user's workout library (Workouts tab) and links the calendar event to it automatically.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -32,7 +32,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                         },
                         "workoutDetails": {
                             "type": "object",
-                            "description": "Details for workout events",
+                            "description": "Details for workout events. REQUIRED (with a non-empty exercises list) for type 'workout' and 'deload'.",
                             "properties": {
                                 "workoutType": {
                                     "type": "string",
@@ -46,6 +46,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                                 "exercises": {
                                     "type": "array",
                                     "description": "Exercises for this workout",
+                                    "minItems": 1,
                                     "items": {
                                         "type": "object",
                                         "properties": {
@@ -67,7 +68,8 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                                         "required": ["exerciseName"]
                                     }
                                 }
-                            }
+                            },
+                            "required": ["exercises"]
                         },
                         "notes": {
                             "type": "string",

--- a/ai-coach-service/tests/test_calendar_service.py
+++ b/ai-coach-service/tests/test_calendar_service.py
@@ -181,3 +181,103 @@ class TestScheduleToCalendar:
         assert result["is_today"] is True
         assert result["relativeDay"] == "today"
         assert result["dateISO"] == "2026-07-13"
+
+
+# ------------------- schedule_to_calendar: template linking -------------------
+
+def _anchor(monkeypatch):
+    monkeypatch.setattr(
+        calendar_service_module, "get_user_today",
+        AsyncMock(return_value=(TODAY, "Asia/Jerusalem")),
+    )
+
+
+def _fake_resolver(monkeypatch):
+    """ExerciseResolver stub that assigns an ObjectId to every exercise."""
+    async def resolve_blocks(user_id, blocks, on_ambiguous="ask"):
+        for block in blocks:
+            for ex in block.get("exercises", []):
+                ex["exercise_id"] = ex.get("exercise_id") or ObjectId()
+        return blocks, {"resolved": [], "created": [], "ambiguous": [], "pending_create": []}
+
+    resolver = MagicMock()
+    resolver.resolve_blocks = AsyncMock(side_effect=resolve_blocks)
+    monkeypatch.setattr(calendar_service_module, "ExerciseResolver", MagicMock(return_value=resolver))
+    return resolver
+
+
+def _insert_db():
+    db = MagicMock()
+    db.calendarevents.insert_one = AsyncMock(return_value=MagicMock(inserted_id=ObjectId()))
+    db.predefinedworkouts.insert_one = AsyncMock(return_value=MagicMock(inserted_id=ObjectId()))
+    return db
+
+
+class TestScheduleToCalendarTemplateLink:
+    @pytest.mark.parametrize("event_type", ["workout", "deload"])
+    async def test_workout_without_exercises_rejected(self, monkeypatch, event_type):
+        _anchor(monkeypatch)
+        db = _insert_db()
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID, {"date": "today", "title": "Leg Day", "type": event_type}
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "missing_workout_details"
+        assert "workoutDetails.exercises" in result["message"]
+        db.calendarevents.insert_one.assert_not_called()
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+    async def test_workout_with_empty_exercises_rejected(self, monkeypatch):
+        _anchor(monkeypatch)
+        db = _insert_db()
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID,
+            {"date": "today", "title": "Leg Day", "type": "workout",
+             "workoutDetails": {"exercises": []}},
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "missing_workout_details"
+        db.calendarevents.insert_one.assert_not_called()
+
+    @pytest.mark.parametrize("event_type", ["workout", "deload"])
+    async def test_workout_with_exercises_creates_and_links_template(self, monkeypatch, event_type):
+        _anchor(monkeypatch)
+        _fake_resolver(monkeypatch)
+        db = _insert_db()
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID,
+            {"date": "today", "title": "Leg Day", "type": event_type,
+             "workoutDetails": {"exercises": [
+                 {"exerciseName": "Squat", "targetSets": 5, "targetReps": 5},
+             ]}},
+        )
+
+        assert result["success"] is True
+        db.predefinedworkouts.insert_one.assert_awaited_once()
+        template = db.predefinedworkouts.insert_one.call_args[0][0]
+        assert template["isCommon"] is False
+        assert template["createdBy"] == ObjectId(USER_ID)
+
+        event = db.calendarevents.insert_one.call_args[0][0]
+        assert event["workoutTemplateId"] is not None
+        assert event["workoutDetails"]["exercises"][0]["exerciseId"] is not None
+
+    async def test_rest_event_needs_no_exercises(self, monkeypatch):
+        _anchor(monkeypatch)
+        db = _insert_db()
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID, {"date": "today", "title": "Rest Day", "type": "rest"}
+        )
+
+        assert result["success"] is True
+        db.predefinedworkouts.insert_one.assert_not_called()

--- a/ai-coach-service/tests/test_schedule_plan_skill.py
+++ b/ai-coach-service/tests/test_schedule_plan_skill.py
@@ -111,11 +111,28 @@ class TestResolveWorkoutContent:
         assert c["exercises"][0]["targetSets"] == 4
         assert c["exercises"][0]["targetReps"] == 8
 
-    def test_missing_template_degrades(self):
+    def test_missing_template_flagged(self):
         workout = {"workoutType": "predefined", "predefinedWorkoutId": ObjectId()}
         c = _resolve_workout_content(workout, {})
         assert c["title"] == "Workout"
         assert c["exercises"] == []
+        assert c["missing_template"] is True
+
+    def test_custom_workout_keeps_exercise_id(self):
+        ex_id = ObjectId()
+        workout = {
+            "workoutType": "custom",
+            "customWorkout": {
+                "title": "Hills",
+                "exercises": [
+                    {"exerciseId": ex_id, "exerciseName": "Hill Sprint", "sets": [{"reps": 8}]},
+                    {"exerciseName": "Jog", "sets": []},
+                ],
+            },
+        }
+        c = _resolve_workout_content(workout, {})
+        assert c["exercises"][0]["exerciseId"] == ex_id
+        assert "exerciseId" not in c["exercises"][1]
 
 
 def _sample_plan():
@@ -174,22 +191,58 @@ class TestBuildEvents:
         events = _build_events(plan, SUNDAY, 1, {}, plan["userId"], plan["_id"], NOW)
         assert all(e["planWeek"] == 1 for e in events)
 
+    def test_custom_with_exercises_marked_for_template(self):
+        plan = _sample_plan()
+        plan["weeks"][0]["workouts"][0]["customWorkout"]["exercises"] = [
+            {"exerciseName": "Squat", "sets": [{"reps": 5}] * 3},
+        ]
+        events = _build_events(plan, SUNDAY, None, {}, plan["userId"], plan["_id"], NOW)
+        marked = [e for e in events if e.get("_pendingTemplate")]
+        assert len(marked) == 1
+        assert marked[0]["title"].startswith("S&C")
+        # exercise-less customs keep current behavior: scheduled, no marker
+        assert all("_pendingTemplate" not in e for e in events if e is not marked[0])
+
+    def test_missing_template_workout_dropped(self):
+        plan = _sample_plan()
+        plan["weeks"][0]["workouts"][0] = {
+            "dayOfWeek": 0, "workoutType": "predefined", "predefinedWorkoutId": ObjectId(),
+        }
+        events = _build_events(plan, SUNDAY, None, {}, plan["userId"], plan["_id"], NOW)
+        # The dangling reference is dropped: 2 remaining workouts + 1 rest = 3
+        assert len(events) == 3
+        assert all(not e["title"].startswith("Workout (") for e in events)
+
 
 # --------------------------- handler ---------------------------
 
-def _make_ctx(plan, existing_events=None, templates=None):
-    """Build a SkillContext-like mock with an async Mongo db."""
+def _make_ctx(plan, existing_events=None, templates=None, plan_tagged_templates=None):
+    """Build a SkillContext-like mock with an async Mongo db.
+
+    predefinedworkouts.find serves two queries: the template_map batch fetch
+    (by _id) and _ensure_templates' plan-tagged reuse lookup (by tags) — each
+    call gets a fresh iterator over the matching fixture list.
+    """
     existing_events = existing_events or []
     templates = templates or []
+    plan_tagged_templates = plan_tagged_templates or []
 
-    async def _template_iter():
-        for t in templates:
-            yield t
+    def _template_find(query, *a, **k):
+        docs = plan_tagged_templates if "tags" in query else templates
+
+        async def _iter():
+            for t in docs:
+                yield t
+
+        return _iter()
 
     db = MagicMock()
     db.plans.find_one = AsyncMock(return_value=plan)
     db.plans.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
-    db.predefinedworkouts.find = MagicMock(return_value=_template_iter())
+    db.predefinedworkouts.find = MagicMock(side_effect=_template_find)
+    db.predefinedworkouts.insert_one = AsyncMock(
+        side_effect=lambda doc, *a, **k: MagicMock(inserted_id=ObjectId())
+    )
 
     find_result = MagicMock()
     find_result.to_list = AsyncMock(return_value=existing_events)
@@ -323,6 +376,149 @@ class TestHandler:
         )
         assert result.get("needs_input") == "start_date"
         ctx.db.calendarevents.insert_many.assert_not_called()
+
+
+# ------------------- custom-workout template creation -------------------
+
+import app.core.agents.skills.schedule_plan_skill as schedule_plan_module  # noqa: E402
+
+
+@pytest.fixture
+def fake_resolver(monkeypatch):
+    """ExerciseResolver stub that assigns an ObjectId to every exercise."""
+    async def resolve_blocks(user_id, blocks, on_ambiguous="ask"):
+        for block in blocks:
+            for ex in block.get("exercises", []):
+                ex["exercise_id"] = ex.get("exercise_id") or ObjectId()
+        return blocks, {"resolved": [], "created": [], "ambiguous": [], "pending_create": []}
+
+    resolver = MagicMock()
+    resolver.resolve_blocks = AsyncMock(side_effect=resolve_blocks)
+    monkeypatch.setattr(schedule_plan_module, "ExerciseResolver", MagicMock(return_value=resolver))
+    return resolver
+
+
+def _custom_plan_with_exercises():
+    """A 3-week plan repeating the SAME custom workout each week."""
+    workout = {
+        "dayOfWeek": 0, "workoutType": "custom",
+        "customWorkout": {
+            "title": "Hill Repeats", "type": "cardio", "durationMinutes": 40,
+            "exercises": [{"exerciseName": "Hill Sprint", "sets": [{"reps": 8}] * 4}],
+        },
+    }
+    return {
+        "_id": ObjectId(),
+        "userId": ObjectId(),
+        "name": "Run Plan",
+        "schedule": {"weeksTotal": 3},
+        "weeks": [
+            {"weekNumber": n, "deloadWeek": False, "restDays": [], "workouts": [dict(workout)]}
+            for n in (1, 2, 3)
+        ],
+    }
+
+
+class TestEnsureTemplates:
+    @pytest.mark.asyncio
+    async def test_repeated_custom_workout_creates_one_shared_template(self, fake_resolver):
+        plan = _custom_plan_with_exercises()
+        ctx = _make_ctx(plan)
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False},
+        )
+        assert result["events_created"] == 3
+        # one template for the workout repeated across 3 weeks
+        ctx.db.predefinedworkouts.insert_one.assert_awaited_once()
+        template = ctx.db.predefinedworkouts.insert_one.call_args.args[0]
+        assert template["name"] == "Hill Repeats"
+        assert template["isCommon"] is False
+        assert template["createdBy"] == plan["userId"]
+        assert f"plan-{plan['_id']}" in template["tags"]
+        assert template["blocks"][0]["exercises"][0]["exercise_id"] is not None
+
+        inserted = ctx.db.calendarevents.insert_many.call_args.args[0]
+        template_ids = {e.get("workoutTemplateId") for e in inserted}
+        assert len(template_ids) == 1 and None not in template_ids
+        # internal marker never persisted; resolved ids backfilled into events
+        assert all("_pendingTemplate" not in e for e in inserted)
+        assert all(
+            e["workoutDetails"]["exercises"][0].get("exerciseId") is not None
+            for e in inserted
+        )
+
+    @pytest.mark.asyncio
+    async def test_dry_run_creates_no_templates(self, fake_resolver):
+        plan = _custom_plan_with_exercises()
+        ctx = _make_ctx(plan)
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]), {"plan_id": str(plan["_id"]), "start_date": "2026-07-12"},
+        )
+        assert result["dry_run"] is True
+        ctx.db.predefinedworkouts.insert_one.assert_not_called()
+        ctx.db.calendarevents.insert_many.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rerun_reuses_plan_tagged_template(self, fake_resolver):
+        plan = _custom_plan_with_exercises()
+        existing_id = ObjectId()
+        existing_ex_id = ObjectId()
+        tagged = [{
+            "_id": existing_id,
+            "name": "Hill Repeats",
+            "tags": ["ai-generated", "plan", f"plan-{plan['_id']}"],
+            "blocks": [{"name": "Main Workout", "exercises": [
+                {"exercise_id": existing_ex_id, "exercise_name": "Hill Sprint", "volume": "4x8"},
+            ]}],
+        }]
+        ctx = _make_ctx(plan, plan_tagged_templates=tagged)
+        await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False},
+        )
+        ctx.db.predefinedworkouts.insert_one.assert_not_called()
+        inserted = ctx.db.calendarevents.insert_many.call_args.args[0]
+        assert all(e["workoutTemplateId"] == existing_id for e in inserted)
+        assert all(
+            e["workoutDetails"]["exercises"][0]["exerciseId"] == existing_ex_id
+            for e in inserted
+        )
+
+    @pytest.mark.asyncio
+    async def test_same_name_different_content_gets_own_template(self, fake_resolver):
+        plan = _custom_plan_with_exercises()
+        # Same title, different prescription (hard week) — must NOT reuse.
+        plan["weeks"][2]["workouts"][0]["customWorkout"] = {
+            "title": "Hill Repeats", "type": "cardio", "durationMinutes": 40,
+            "exercises": [{"exerciseName": "Hill Sprint", "sets": [{"reps": 12}] * 6}],
+        }
+        ctx = _make_ctx(plan)
+        await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False},
+        )
+        assert ctx.db.predefinedworkouts.insert_one.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_missing_template_workouts_skipped_with_note(self, fake_resolver):
+        plan = _custom_plan_with_exercises()
+        plan["weeks"][0]["workouts"][0] = {
+            "dayOfWeek": 0, "workoutType": "predefined", "predefinedWorkoutId": ObjectId(),
+        }
+        ctx = _make_ctx(plan)
+        preview = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]), {"plan_id": str(plan["_id"]), "start_date": "2026-07-12"},
+        )
+        assert preview["proposed_count"] == 2
+        assert "deleted workout template" in preview["message"]
+
+        result = await schedule_plan_to_calendar(
+            ctx, str(plan["userId"]),
+            {"plan_id": str(plan["_id"]), "start_date": "2026-07-12", "dry_run": False},
+        )
+        assert result["events_created"] == 2
+        assert "deleted workout template" in result["message"]
 
 
 # ------------------- skeleton plans (rolling materialization) -------------------

--- a/backend/src/jobs/calendarConsistencyJob.js
+++ b/backend/src/jobs/calendarConsistencyJob.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 const CalendarEvent = require('../models/CalendarEvent');
 const WorkoutLog = require('../models/WorkoutLog');
 const ExternalActivity = require('../models/ExternalActivity');
+const Exercise = require('../models/Exercise');
+const PredefinedWorkout = require('../models/PredefinedWorkout');
 const StravaIntegrationService = require('../services/StravaIntegrationService');
 
 /**
@@ -10,11 +12,13 @@ const StravaIntegrationService = require('../services/StravaIntegrationService')
  * Ensures data consistency between CalendarEvent and its linked collections:
  * - WorkoutLog (from TrainNow)
  * - ExternalActivity (from Strava)
+ * - PredefinedWorkout (workout library / Workouts tab)
  *
  * Tasks:
  * 1. Find WorkoutLogs without CalendarEvent and create them
  * 2. Find ExternalActivities without CalendarEvent and create them
  * 3. Find CalendarEvents with broken links (workoutLogId or externalActivityId pointing to non-existent docs) and delete them
+ * 4. Find upcoming AI-scheduled workout events with no workoutTemplateId and back-link them to a (deduped) library template
  */
 
 class CalendarConsistencyJob {
@@ -26,6 +30,9 @@ class CalendarConsistencyJob {
       externalActivitiesProcessed: 0,
       externalActivitiesFixed: 0,
       orphanedCalendarEventsDeleted: 0,
+      orphanWorkoutEventsLinked: 0,
+      orphanTemplatesCreated: 0,
+      orphanWorkoutEventsSkipped: 0,
       errors: []
     };
   }
@@ -45,6 +52,9 @@ class CalendarConsistencyJob {
         externalActivitiesProcessed: 0,
         externalActivitiesFixed: 0,
         orphanedCalendarEventsDeleted: 0,
+        orphanWorkoutEventsLinked: 0,
+        orphanTemplatesCreated: 0,
+        orphanWorkoutEventsSkipped: 0,
         errors: []
       };
 
@@ -52,6 +62,7 @@ class CalendarConsistencyJob {
       await this.syncWorkoutLogs();
       await this.syncExternalActivities();
       await this.cleanupOrphanedCalendarEvents();
+      await this.linkOrphanWorkoutEvents();
 
       const duration = Date.now() - startTime;
       this.logger.info('[CalendarConsistencyJob] Consistency check completed', {
@@ -249,6 +260,115 @@ class CalendarConsistencyJob {
   }
 
   /**
+   * Find upcoming workout/deload CalendarEvents that have embedded exercises
+   * but no workoutTemplateId (historically created by the AI coach), create a
+   * backing PredefinedWorkout, and link them.
+   *
+   * Deduped: orphans are grouped by (user, title-minus-date-suffix, exercise
+   * prescription) and each group shares ONE template — a plan's repeated
+   * weekly session gets a single library entry, not one per event. Idempotent
+   * by construction: linked events no longer match the query. Past/completed
+   * orphans are left alone (they render from embedded details and add no
+   * Workouts-tab value).
+   */
+  async linkOrphanWorkoutEvents(userId = null) {
+    this.logger.info('[CalendarConsistencyJob] Linking orphan workout events...');
+
+    try {
+      const query = {
+        type: { $in: ['workout', 'deload'] },
+        $or: [{ workoutTemplateId: { $exists: false } }, { workoutTemplateId: null }],
+        status: 'scheduled',
+        date: { $gte: new Date() },
+        'workoutDetails.exercises.0': { $exists: true }
+      };
+      if (userId) query.userId = userId;
+
+      const orphans = await CalendarEvent.find(query).lean();
+
+      const groups = new Map();
+      for (const event of orphans) {
+        const title = (event.title || 'Workout')
+          .replace(/\s*\([A-Z][a-z]{2} \d{1,2}\)\s*$/, '')
+          .trim() || 'Workout';
+        const signature = (event.workoutDetails.exercises || [])
+          .map((ex) => `${ex.exerciseName}|${ex.targetSets || ''}|${ex.targetReps || ''}`)
+          .join(';');
+        const key = `${event.userId}::${title}::${signature}`;
+        if (!groups.has(key)) groups.set(key, { title, events: [] });
+        groups.get(key).events.push(event);
+      }
+
+      for (const { title, events } of groups.values()) {
+        try {
+          const sample = events[0];
+          const blockExercises = [];
+          for (const ex of sample.workoutDetails.exercises || []) {
+            let exerciseId = ex.exerciseId;
+            if (!exerciseId && ex.exerciseName) {
+              // blockExerciseSchema requires exercise_id — recover it by name.
+              const escaped = ex.exerciseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const match = await Exercise.findOne({ name: new RegExp(`^${escaped}$`, 'i') })
+                .select('_id')
+                .lean();
+              exerciseId = match?._id;
+            }
+            if (!exerciseId) continue;
+            blockExercises.push({
+              exercise_id: exerciseId,
+              exercise_name: ex.exerciseName,
+              volume: `${ex.targetSets || 3}x${ex.targetReps || 10}`,
+              rest: '60s',
+              notes: ex.notes || ''
+            });
+          }
+
+          if (blockExercises.length === 0) {
+            this.stats.orphanWorkoutEventsSkipped += events.length;
+            continue;
+          }
+
+          const template = await PredefinedWorkout.create({
+            name: title,
+            goal: '',
+            primary_disciplines: [sample.workoutDetails.type || 'strength'],
+            estimated_duration: sample.workoutDetails.estimatedDuration || 45,
+            difficulty_level: 'intermediate',
+            blocks: [{ name: 'Main Workout', exercises: blockExercises }],
+            tags: ['ai-generated', 'backfill'],
+            isCommon: false,
+            createdBy: sample.userId
+          });
+
+          await CalendarEvent.updateMany(
+            { _id: { $in: events.map((e) => e._id) } },
+            { $set: { workoutTemplateId: template._id } }
+          );
+
+          this.stats.orphanTemplatesCreated++;
+          this.stats.orphanWorkoutEventsLinked += events.length;
+          this.logger.info(
+            `[CalendarConsistencyJob] Linked ${events.length} orphan event(s) to new template "${title}" (${template._id})`
+          );
+        } catch (error) {
+          this.stats.errors.push({
+            phase: 'orphanWorkoutEvents',
+            title,
+            error: error.message
+          });
+        }
+      }
+
+      this.logger.info(
+        `[CalendarConsistencyJob] Orphan link complete: ${this.stats.orphanWorkoutEventsLinked} linked via ${this.stats.orphanTemplatesCreated} template(s), ${this.stats.orphanWorkoutEventsSkipped} skipped`
+      );
+    } catch (error) {
+      this.logger.error('[CalendarConsistencyJob] Orphan workout link failed', { error: error.message });
+      this.stats.errors.push({ phase: 'orphanWorkoutEvents', error: error.message });
+    }
+  }
+
+  /**
    * Run for a specific user only
    */
   async runForUser(userId) {
@@ -262,12 +382,16 @@ class CalendarConsistencyJob {
         externalActivitiesProcessed: 0,
         externalActivitiesFixed: 0,
         orphanedCalendarEventsDeleted: 0,
+        orphanWorkoutEventsLinked: 0,
+        orphanTemplatesCreated: 0,
+        orphanWorkoutEventsSkipped: 0,
         errors: []
       };
 
       await this.syncWorkoutLogsForUser(userId);
       await this.syncExternalActivitiesForUser(userId);
       await this.cleanupOrphanedCalendarEventsForUser(userId);
+      await this.linkOrphanWorkoutEvents(userId);
 
       const duration = Date.now() - startTime;
       this.logger.info(`[CalendarConsistencyJob] User ${userId} consistency check completed`, {

--- a/backend/src/jobs/calendarConsistencyJob.js
+++ b/backend/src/jobs/calendarConsistencyJob.js
@@ -275,11 +275,16 @@ class CalendarConsistencyJob {
     this.logger.info('[CalendarConsistencyJob] Linking orphan workout events...');
 
     try {
+      // Start-of-day UTC: event dates are stored as midnight UTC, so plain
+      // new Date() would exclude today's orphans.
+      const startOfTodayUtc = new Date();
+      startOfTodayUtc.setUTCHours(0, 0, 0, 0);
+
       const query = {
         type: { $in: ['workout', 'deload'] },
         $or: [{ workoutTemplateId: { $exists: false } }, { workoutTemplateId: null }],
         status: 'scheduled',
-        date: { $gte: new Date() },
+        date: { $gte: startOfTodayUtc },
         'workoutDetails.exercises.0': { $exists: true }
       };
       if (userId) query.userId = userId;
@@ -302,13 +307,18 @@ class CalendarConsistencyJob {
       for (const { title, events } of groups.values()) {
         try {
           const sample = events[0];
+          const sourceExercises = sample.workoutDetails.exercises || [];
           const blockExercises = [];
-          for (const ex of sample.workoutDetails.exercises || []) {
+          for (const ex of sourceExercises) {
             let exerciseId = ex.exerciseId;
             if (!exerciseId && ex.exerciseName) {
-              // blockExerciseSchema requires exercise_id — recover it by name.
+              // blockExerciseSchema requires exercise_id — recover it by name,
+              // scoped to exercises this user can see (commons + their own).
               const escaped = ex.exerciseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-              const match = await Exercise.findOne({ name: new RegExp(`^${escaped}$`, 'i') })
+              const match = await Exercise.findOne({
+                name: new RegExp(`^${escaped}$`, 'i'),
+                $or: [{ isCommon: true }, { createdBy: sample.userId }]
+              })
                 .select('_id')
                 .lean();
               exerciseId = match?._id;
@@ -323,8 +333,15 @@ class CalendarConsistencyJob {
             });
           }
 
-          if (blockExercises.length === 0) {
+          // All-or-nothing: a partially resolved template would show a
+          // mangled version of the session in the Workouts tab — worse than
+          // leaving the event unlinked.
+          if (blockExercises.length !== sourceExercises.length) {
             this.stats.orphanWorkoutEventsSkipped += events.length;
+            this.logger.info(
+              `[CalendarConsistencyJob] Skipped ${events.length} orphan event(s) for "${title}": ` +
+              `${sourceExercises.length - blockExercises.length}/${sourceExercises.length} exercises unresolved`
+            );
             continue;
           }
 

--- a/frontend/src/components/dashboard/TodayView.jsx
+++ b/frontend/src/components/dashboard/TodayView.jsx
@@ -149,11 +149,10 @@ export default function TodayView() {
   }, []);
 
   const startSession = () => {
-    if (session?.eventId) {
-      navigate(createPageUrl(`Calendar`));
-    } else {
-      navigate(createPageUrl("TrainNow"));
-    }
+    // TrainNow shows calendar-scheduled sessions as the "Scheduled Today" card
+    // (same pickTodaySession selection) and owns the LiveWorkout launch flow,
+    // including the active-session conflict guard.
+    navigate(createPageUrl("TrainNow"));
   };
 
   // Tap an answer chip → short inline coach reply (no navigation)

--- a/frontend/src/pages/TrainNow.jsx
+++ b/frontend/src/pages/TrainNow.jsx
@@ -392,12 +392,13 @@ export default function TrainNow() {
           const { scheduledEvent, completedToday: doneToday } = pickTodaySession(events);
           setCompletedToday(doneToday);
 
-          if (calendarData.success && scheduledEvent?.type === 'workout') {
+          if (calendarData.success && ['workout', 'deload'].includes(scheduledEvent?.type)) {
             console.log('[TrainNow] Using calendar workout -', scheduledEvent.title);
 
             // Convert calendar exercise format to the format expected by parseWorkoutToSessionData
             const calendarExercises = scheduledEvent.workoutDetails?.exercises || [];
             const convertedExercises = calendarExercises.map(ex => ({
+              exercise_id: ex.exerciseId || ex.exercise_id,
               exercise_name: ex.exerciseName || ex.exercise_name,
               volume: ex.targetSets && ex.targetReps ? `${ex.targetSets}x${ex.targetReps}` : null,
               sets: ex.targetSets || 3,
@@ -410,8 +411,11 @@ export default function TrainNow() {
               name: scheduledEvent.title,
               estimated_duration: scheduledEvent.workoutDetails?.estimatedDuration || 45,
               primary_disciplines: [scheduledEvent.workoutDetails?.type || 'strength'],
-              blocks: scheduledEvent.workoutTemplateId?.blocks || [],
-              exercises: convertedExercises, // Include exercises from calendar event
+              // Embedded event exercises are the source of truth; template blocks
+              // only as fallback — parseWorkoutToSessionData concatenates both,
+              // so including both duplicates every exercise.
+              blocks: convertedExercises.length > 0 ? [] : (scheduledEvent.workoutTemplateId?.blocks || []),
+              exercises: convertedExercises,
               calendarEventId: scheduledEvent._id
             });
             setIsFromCalendar(true);

--- a/frontend/src/utils/todaySession.js
+++ b/frontend/src/utils/todaySession.js
@@ -22,10 +22,13 @@ export function pickTodaySession(events) {
   );
 
   const scheduledEvent =
-    pending.find((e) => e.type === "workout") || pending[0] || null;
+    pending.find((e) => e.type === "workout" || e.type === "deload") ||
+    pending[0] ||
+    null;
 
   const completedToday = list.some(
-    (e) => e.type === "workout" && e.status === "completed"
+    (e) =>
+      (e.type === "workout" || e.type === "deload") && e.status === "completed"
   );
 
   return { scheduledEvent, completedToday };


### PR DESCRIPTION
## Problem

1. **Sensei added workouts to the calendar without linking them to a workout id.** Calendar entries rendered fine (from embedded `workoutDetails`) but had no backing `predefinedworkouts` doc and no `workoutTemplateId`, so they never appeared in the Workouts tab.
2. **Dashboard "Start session" navigated to the Calendar page**, which has no auto-open logic — the user landed on a bare grid instead of the workout.

## Root causes

- `schedule_to_calendar` only required `date/title/type`, so the LLM could schedule a bare workout title: no template created, no link (`calendar_service.py`).
- `schedule_plan_to_calendar` never created templates for custom plan workouts (`template_id` always `None`) and silently inserted empty orphan events for deleted template references (`schedule_plan_skill.py`).
- `TodayView.startSession` explicitly routed calendar-backed sessions to `/Calendar`.
- Latent: TrainNow merged populated template `blocks` **and** embedded event exercises, duplicating every exercise in the live session for linked events.

## Changes

**ai-coach-service**
- `schedule_to_calendar`: `workoutDetails.exercises` is now required for `workout`/`deload` events — enforced in the tool JSON schema and by a server-side gate that returns a self-correcting error so the agent plans the session and retries. Deload events also get a template + link. Prompt updated (plan first, tool saves to library + links automatically).
- `schedule_plan_to_calendar`: on the confirmed write path (never on dry-run), custom plan workouts get a `predefinedworkouts` template created and linked. Deduped by content key (title + exercise prescription) within the run — a 12-week plan repeating one custom workout gets ONE library entry — and across re-runs via plan-tagged templates, so overwrite/reschedule never duplicates the library. Same-titled workouts with different prescriptions get separate templates. Resolved `exerciseId`s are backfilled into the events' embedded exercises. Workouts referencing deleted templates are dropped with a user-facing note instead of inserted as orphans.

**backend**
- `calendarConsistencyJob`: new `linkOrphanWorkoutEvents` task back-links existing upcoming scheduled orphan events. Grouped by (user, title-minus-date, exercise signature) so each group shares one template; missing exercise ids are recovered by exact case-insensitive name match against the exercise catalog (block schema requires `exercise_id`); unmatchable events are skipped and counted. Idempotent — linked events no longer match the query. (Prod currently has exactly 1 such orphan, on the pm-test account.)

**frontend**
- `TodayView`: "Start session" always routes to TrainNow, whose shared `pickTodaySession` shows the same event as a "Scheduled Today" card and owns the LiveWorkout launch (incl. active-session conflict guard).
- `TrainNow`: embedded event exercises are the source of truth (template blocks only as fallback) — fixes exercise duplication; `exerciseId` now carried into the live session; deload events are treated as startable scheduled sessions (`todaySession.js` picker too).

## Testing

- `ai-coach-service`: 360 tests pass (`pytest`), including new coverage: gate rejects exercise-less workout/deload events with no inserts; workout+deload create & link templates; plan write path creates ONE shared template for a repeated custom workout; dry-run creates zero templates; re-run reuses the plan-tagged template; same-name/different-content gets its own template; deleted-template workouts skipped with note; `_pendingTemplate` marker never persisted.
- Frontend production build passes; backend job passes `node --check`.
- Not exercised end-to-end in a running stack; suggested manual check: ask Sensei to schedule a workout for today → it appears in the Workouts tab; Dashboard "Start session" → TrainNow scheduled card → LiveWorkout shows each exercise once.

## Notes / follow-ups

- `schedule_to_calendar` has no way to link an *existing* template — "schedule my Push Day for Friday" clones it into the library (date-suffixed). A `workoutTemplateId` arg is the natural follow-up.
- `update_calendar_workout_skill` edits an event's embedded details without touching the linked template — template and event can diverge after edits (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)