### PR TITLE
TOR-88: Sensei executes calendar action after the user declines its confirmation question

### DIFF
--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -417,7 +417,11 @@ USER DATA:
             "update_goal": "Updating your fitness goal",
             "list_goals": "Fetching your fitness goals",
             # Calendar tools
-            "schedule_to_calendar": f"Scheduling {function_args.get('title', 'event')} for {function_args.get('date', 'your calendar')}",
+            "schedule_to_calendar": (
+                f"Scheduling {function_args.get('title', 'event')} for {function_args.get('date', 'your calendar')}"
+                if function_args.get("dry_run") is False
+                else f"Previewing {function_args.get('title', 'event')} for {function_args.get('date', 'your calendar')}"
+            ),
             "get_calendar_events": "Checking your calendar",
             # Daily suggestion
             "get_daily_recommendation": "Checking your Today's Pick",

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -75,7 +75,7 @@ WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I 
 - `list_goals`: View user's goals.
 
 **Calendar** (Scheduling workouts):
-- `schedule_to_calendar`: Schedule a SINGLE workout or event to a specific date. Use this for one-off scheduling. Supports 'today', 'tomorrow', or ISO dates.
+- `schedule_to_calendar`: Schedule a SINGLE workout or event to a specific date. Use this for one-off scheduling. Supports 'today', 'tomorrow', or ISO dates. It defaults to a dry-run PREVIEW that writes nothing and shows how each exercise name matched the user's catalog; show the user the preview (including any name substitutions), and only after they confirm, call it again with `dry_run=false` to actually write.
 - `schedule_plan_to_calendar`: Schedule an ENTIRE multi-week plan (or several weeks of it) in ONE call. Whenever the user wants a whole plan put on the calendar, use this — never place plan workouts day-by-day with repeated `schedule_to_calendar` calls. It defaults to a dry-run PREVIEW that writes nothing; show the user the preview, and only after they confirm, call it again with `dry_run=false` to actually write the events.
 - `get_calendar_events`: Check what's already scheduled on the user's calendar.
 - `reschedule_session`: Move or skip ONE session the user missed or wants to change. Previews first, writes on confirm.
@@ -180,9 +180,10 @@ EXERCISE HOW-TO — CHOOSE VIDEO vs TEXT BY CONTEXT (don't default to one):
 CALENDAR WORKFLOW:
 When user asks to add/schedule a workout for a specific date:
 1. Design the workout and get user approval
-2. Call `schedule_to_calendar` with the workout details (title, date, workoutDetails with exercises)
+2. Call `schedule_to_calendar` with the workout details (title, date, workoutDetails with exercises) — the first call returns a PREVIEW and writes nothing
 3. `workoutDetails` with the FULL exercise list is REQUIRED for workout/deload events — never schedule a bare title. The tool creates the calendar event directly (it does NOT need a template first): it saves the planned workout to the user's workout library and links the event to it automatically
-4. If for today, ask if they want to start training now
+4. Show the user the preview — ESPECIALLY any exercise-name substitutions (e.g. their "Easy Run" matched to catalog "Treadmill Run") — and ask them to confirm. Only after they confirm, call `schedule_to_calendar` again with the same arguments plus `dry_run=false`. If they decline, do NOT write — adjust or drop the action
+5. If for today, ask if they want to start training now
 
 DATE DISCIPLINE (CRITICAL):
 `get_calendar_events` results include `today` (the user's local date) and a `relativeDay` label on every event ("today", "tomorrow", "yesterday", "in N days", "N days ago"). ALWAYS use these labels when telling the user what is scheduled today/tomorrow/yesterday — NEVER recompute relative days from raw YYYY-MM-DD dates yourself. If no event has `relativeDay: "today"`, then nothing is SCHEDULED today — but before telling the user they have no workout, check the TODAY'S PICK context block or call `get_daily_recommendation`: answer "nothing on your calendar, but your Today's Pick is <name>" and offer to walk through or start it.
@@ -223,6 +224,8 @@ IMPORTANT PRINCIPLES:
    - Before calling `research`: ALWAYS ask at least 1 question first (unless user already gave very specific details)
    - Before calling `web_search`: Ask if they want videos, articles, or general info
    - Before creating workouts: Ask about focus, time, energy level
+
+   **HONOR THE ANSWER (CRITICAL):** When YOU ask a confirmation or either/or question, your next action MUST follow the user's answer. If they decline or pick a different option, do NOT execute the declined action or use the declined value in any tool call — a "no" to a preview means you never call the tool with `dry_run=false`.
 
    Example - BAD (don't do this):
    User: "I have shoulder pain"

--- a/ai-coach-service/app/core/agents/services/calendar_service.py
+++ b/ai-coach-service/app/core/agents/services/calendar_service.py
@@ -64,6 +64,15 @@ class CalendarService:
             date_suffix = event_date.strftime("%b %d")
             title_with_date = f"{title} ({date_suffix})"
 
+            # Default is a dry-run PREVIEW that writes nothing (TOR-88: an
+            # event was written against the user's explicit decline). The
+            # preview surfaces how each exercise name resolved against the
+            # catalog — silent substitutions must be visible BEFORE any write.
+            if args.get("dry_run", True):
+                return await self._preview_schedule(
+                    user_id, event_date, title_with_date, event_type, workout_details, today
+                )
+
             workout_template_id = None
             exercises = []
 
@@ -184,6 +193,81 @@ class CalendarService:
         except Exception as e:
             logger.error(f"Error scheduling to calendar: {e}")
             return {"success": False, "message": f"Error scheduling event: {str(e)}"}
+
+    async def _preview_schedule(
+        self,
+        user_id: str,
+        event_date: datetime,
+        title_with_date: str,
+        event_type: str,
+        workout_details: Dict[str, Any],
+        today: datetime,
+    ) -> Dict[str, Any]:
+        """Dry-run preview for schedule_to_calendar: resolve exercise names
+        without creating anything, and return what a confirmed call would write."""
+        formatted_date = event_date.strftime("%A, %B %d, %Y")
+        preview_msg = f"**Preview — nothing scheduled yet**\n\n**{title_with_date}** on **{formatted_date}** ({event_type})"
+
+        resolved_exercises = []
+        if event_type in ("workout", "deload") and workout_details:
+            workout_exercises = workout_details.get("exercises", [])
+            items = [
+                {
+                    "exercise_name": ex.get("exerciseName", ""),
+                    "muscles": ex.get("muscles"),
+                    "discipline": workout_details.get("disciplines"),
+                    "equipment": ex.get("equipment"),
+                    "difficulty": workout_details.get("difficulty"),
+                }
+                for ex in workout_exercises
+            ]
+            # create=False: a preview must not leave phantom catalog entries
+            # behind if the user declines.
+            resolutions = await ExerciseResolver(self.db).resolve(
+                user_id, items, on_ambiguous="best_effort", create=False
+            )
+
+            lines = []
+            for ex, res in zip(workout_exercises, resolutions):
+                given = ex.get("exerciseName", "")
+                is_new = res["status"] == "create_pending"
+                matched = res.get("matched_name")
+                resolved_exercises.append({
+                    "given": given,
+                    "resolved": given if is_new else matched,
+                    "is_new": is_new,
+                    "method": res.get("method"),
+                })
+                volume = f"{ex.get('targetSets', 3)}x{ex.get('targetReps', 10)}"
+                if is_new:
+                    lines.append(f"- **{given}** — {volume} (new — will be added to your exercise catalog)")
+                elif matched and matched.lower() != given.lower():
+                    lines.append(f"- \"{given}\" → matched to existing **{matched}** — {volume}")
+                else:
+                    lines.append(f"- **{matched or given}** — {volume}")
+            duration = workout_details.get("estimatedDuration", 45)
+            preview_msg += f", ~{duration} min:\n" + "\n".join(lines)
+
+        preview_msg += (
+            "\n\nShow this preview to the user and ask them to confirm. "
+            "If they confirm, call `schedule_to_calendar` again with the SAME arguments plus `dry_run=false`. "
+            "If they want a matched exercise kept under its ORIGINAL name instead, call `add_exercise` "
+            "with that exact name first, then retry with `dry_run=false`. "
+            "If the user declines, do NOT call this tool again."
+        )
+
+        return {
+            "success": True,
+            "dry_run": True,
+            "message": preview_msg,
+            "proposed_event": {
+                "title": title_with_date,
+                "date": event_date.strftime("%Y-%m-%d"),
+                "type": event_type,
+                "relativeDay": relative_day_label(event_date.date(), today.date()),
+            },
+            "resolved_exercises": resolved_exercises,
+        }
 
     async def get_calendar_events(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Get user's calendar events for a date range"""

--- a/ai-coach-service/app/core/agents/services/exercise_resolver.py
+++ b/ai-coach-service/app/core/agents/services/exercise_resolver.py
@@ -123,9 +123,13 @@ class ExerciseResolver:
         items: List[Dict[str, Any]],
         *,
         on_ambiguous: str = "ask",
+        create: bool = True,
     ) -> List[Dict[str, Any]]:
         """Resolve each {exercise_name, exercise_id?, muscles?, discipline?, ...}
-        to {status, exercise_id, matched_name, method, score, candidates}."""
+        to {status, exercise_id, matched_name, method, score, candidates}.
+
+        create=False is a preview probe: genuinely-new names stay
+        "create_pending" and nothing is written to the catalog."""
         user_oid = ObjectId(user_id)
         visibility = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
 
@@ -161,7 +165,7 @@ class ExerciseResolver:
         # entries for a workout that never persists would leave phantom
         # exercises behind.
         has_ambiguous = any(r["status"] == "ambiguous" for r in results)
-        if pending and not (on_ambiguous == "ask" and has_ambiguous):
+        if pending and create and not (on_ambiguous == "ask" and has_ambiguous):
             for idx in pending:
                 name = (items[idx].get("exercise_name") or "").strip()
                 cached = by_lower_name.get(name.lower())

--- a/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
@@ -13,7 +13,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "schedule_to_calendar",
-                "description": "Schedule a workout or event to the user's calendar for a specific date. Use this when the user wants to add a workout to their calendar, schedule a rest day, or plan future training. For 'workout' and 'deload' events you MUST plan the full session first and pass it in workoutDetails.exercises — never schedule a bare title. The tool saves the planned workout to the user's workout library (Workouts tab) and links the calendar event to it automatically.",
+                "description": "Schedule a workout or event to the user's calendar for a specific date. Use this when the user wants to add a workout to their calendar, schedule a rest day, or plan future training. For 'workout' and 'deload' events you MUST plan the full session first and pass it in workoutDetails.exercises — never schedule a bare title. The tool saves the planned workout to the user's workout library (Workouts tab) and links the calendar event to it automatically. Defaults to a dry-run PREVIEW that writes nothing and shows how each exercise name matched the user's exercise catalog. Present the preview to the user; ONLY after they confirm, call again with the same arguments plus dry_run=false to actually write. If the user declines the preview, do NOT call again.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -74,6 +74,10 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                         "notes": {
                             "type": "string",
                             "description": "Additional notes for the calendar event"
+                        },
+                        "dry_run": {
+                            "type": "boolean",
+                            "description": "Preview only, no writes. Default true. Set false ONLY after the user has confirmed the preview."
                         }
                     },
                     "required": ["date", "title", "type"]

--- a/ai-coach-service/tests/test_calendar_service.py
+++ b/ai-coach-service/tests/test_calendar_service.py
@@ -172,7 +172,7 @@ class TestScheduleToCalendar:
         service = CalendarService(db)
 
         result = await service.schedule_to_calendar(
-            USER_ID, {"date": "today", "title": "Recovery Walk", "type": "event"}
+            USER_ID, {"date": "today", "title": "Recovery Walk", "type": "event", "dry_run": False}
         )
 
         assert result["success"] is True
@@ -254,7 +254,7 @@ class TestScheduleToCalendarTemplateLink:
 
         result = await service.schedule_to_calendar(
             USER_ID,
-            {"date": "today", "title": "Leg Day", "type": event_type,
+            {"date": "today", "title": "Leg Day", "type": event_type, "dry_run": False,
              "workoutDetails": {"exercises": [
                  {"exerciseName": "Squat", "targetSets": 5, "targetReps": 5},
              ]}},
@@ -276,8 +276,94 @@ class TestScheduleToCalendarTemplateLink:
         service = CalendarService(db)
 
         result = await service.schedule_to_calendar(
-            USER_ID, {"date": "today", "title": "Rest Day", "type": "rest"}
+            USER_ID, {"date": "today", "title": "Rest Day", "type": "rest", "dry_run": False}
         )
 
         assert result["success"] is True
         db.predefinedworkouts.insert_one.assert_not_called()
+
+
+# ------------------- schedule_to_calendar: dry-run preview (TOR-88) -------------------
+#
+# The incident: the agent scheduled "Easy Run" and silently resolved the
+# exercise to catalog "Treadmill Run"; the user's later "no" changed nothing.
+# schedule_to_calendar now defaults to a preview that writes nothing and
+# surfaces resolution, so a decline means dry_run=false is simply never sent.
+
+def _preview_resolver(monkeypatch, resolutions):
+    """ExerciseResolver stub whose resolve() returns the given resolutions."""
+    resolver = MagicMock()
+    resolver.resolve = AsyncMock(return_value=resolutions)
+    monkeypatch.setattr(calendar_service_module, "ExerciseResolver", MagicMock(return_value=resolver))
+    return resolver
+
+
+def _resolved(given, matched, method="fuzzy"):
+    return {"status": "resolved", "exercise_id": ObjectId(), "exercise_name": given,
+            "matched_name": matched, "method": method, "score": 0.9, "candidates": []}
+
+
+def _create_pending(given):
+    return {"status": "create_pending", "exercise_id": None, "exercise_name": given,
+            "matched_name": None, "method": "create_pending", "score": None, "candidates": []}
+
+
+EASY_RUN_ARGS = {
+    "date": "today", "title": "Easy Run", "type": "workout",
+    "workoutDetails": {"estimatedDuration": 20, "exercises": [
+        {"exerciseName": "Easy Run", "targetSets": 1, "targetReps": 1},
+    ]},
+}
+
+
+class TestScheduleToCalendarDryRun:
+    async def test_default_dry_run_writes_nothing(self, monkeypatch):
+        # TOR-88 regression: a call without dry_run=false must never write,
+        # so a declined confirmation can no longer produce a calendar event.
+        _anchor(monkeypatch)
+        resolver = _preview_resolver(monkeypatch, [_resolved("Easy Run", "Treadmill Run")])
+        db = _insert_db()
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(USER_ID, dict(EASY_RUN_ARGS))
+
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        db.calendarevents.insert_one.assert_not_called()
+        db.predefinedworkouts.insert_one.assert_not_called()
+        # The probe must not create catalog exercises for a declined workout.
+        assert resolver.resolve.call_args.kwargs["create"] is False
+
+    async def test_preview_surfaces_resolved_name(self, monkeypatch):
+        _anchor(monkeypatch)
+        _preview_resolver(monkeypatch, [_resolved("Easy Run", "Treadmill Run")])
+        service = CalendarService(_insert_db())
+
+        result = await service.schedule_to_calendar(USER_ID, dict(EASY_RUN_ARGS))
+
+        assert "Treadmill Run" in result["message"]
+        assert result["resolved_exercises"] == [
+            {"given": "Easy Run", "resolved": "Treadmill Run", "is_new": False, "method": "fuzzy"},
+        ]
+
+    async def test_preview_marks_new_exercises(self, monkeypatch):
+        _anchor(monkeypatch)
+        _preview_resolver(monkeypatch, [_create_pending("Easy Run")])
+        service = CalendarService(_insert_db())
+
+        result = await service.schedule_to_calendar(USER_ID, dict(EASY_RUN_ARGS))
+
+        assert result["resolved_exercises"][0]["is_new"] is True
+        assert "new" in result["message"]
+
+    async def test_preview_rest_event_writes_nothing(self, monkeypatch):
+        _anchor(monkeypatch)
+        db = _insert_db()
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID, {"date": "today", "title": "Rest Day", "type": "rest"}
+        )
+
+        assert result["dry_run"] is True
+        db.calendarevents.insert_one.assert_not_called()

--- a/ai-coach-service/tests/test_exercise_resolver.py
+++ b/ai-coach-service/tests/test_exercise_resolver.py
@@ -107,6 +107,18 @@ class TestResolutionLadder:
         assert blocks[0]["exercises"][0]["exercise_id"] == PUSH_UP["_id"]
         assert report["resolved"][0]["method"] == "vector"
 
+    async def test_create_false_probe_leaves_pending_and_writes_nothing(self):
+        # Preview probe (TOR-88): dry-run resolution must not leave phantom
+        # catalog exercises behind if the user declines the preview.
+        db = _db(catalog=[PLANK])
+        results = await ExerciseResolver(db).resolve(
+            str(USER), [{"exercise_name": "Zercher Carry"}],
+            on_ambiguous="best_effort", create=False,
+        )
+        assert results[0]["status"] == "create_pending"
+        assert results[0]["exercise_id"] is None
+        db.exercises.insert_one.assert_not_called()
+
     async def test_no_match_creates_private_exercise(self):
         created = ObjectId()
         db = _db(catalog=[PLANK], created_id=created)


### PR DESCRIPTION
## What changed

Fixes [TOR-88](https://linear.app/torii-fitness/issue/TOR-88/sensei-executes-calendar-action-after-the-user-declines-its).

**Root cause:** `schedule_to_calendar` was the only calendar write tool with no preview/confirm gate — every call wrote `calendarevents` + `predefinedworkouts` immediately, and exercise-name resolution was invisible to the user (a requested run was silently resolved to a different catalog exercise at write time, so a later decline of that name couldn't undo the already-written event). There was also no prompt rule binding the agent's own confirmation question to its next tool call.

- `schedule_to_calendar` now **defaults to a dry-run preview** (same protocol as `schedule_plan_to_calendar` / `reschedule_session`): the first call writes nothing and returns a preview that surfaces how each exercise name resolved against the user's catalog. Writing requires an explicit `dry_run=false` after user confirmation — so a decline structurally means nothing is ever written, even if the model misbehaves.
- `ExerciseResolver.resolve(..., create=False)` probe mode: previews never create phantom catalog exercises for workouts that may be declined.
- `SYSTEM_PROMPT`: preview protocol documented in the tool catalog + CALENDAR WORKFLOW, plus a new **HONOR THE ANSWER** rule (a decline of the agent's own confirmation question must never be followed by the declined tool call).
- Orchestrator streams "Previewing …" instead of "Scheduling …" for preview calls.

## Acceptance criteria

- [x] After the user declines a confirmation/naming question, no calendar event is written — the default tool call is a no-write preview; a decline means `dry_run=false` is never sent, and a stray default call writes nothing.
- [x] A regression eval/test covering the decline path exists and passes — no LLM-in-the-loop eval harness exists in this repo, so this is a deterministic service-level pytest at the tool seam: `test_default_dry_run_writes_nothing` (plus preview-content and no-phantom-exercise tests).
- [x] No regression in existing confirm-then-write flows — `schedule_plan_to_calendar` / `reschedule_session` untouched; their test suites pass unchanged.

## Verification

- `ai-coach-service: .venv/bin/pytest` — **365 passed** (full suite; poetry not on PATH, used the project venv).
- Targeted: `pytest tests/test_calendar_service.py tests/test_exercise_resolver.py tests/test_schedule_plan_skill.py` — 79 passed.
- Exercised the real flow: replayed the incident-shaped arguments through the real `CalendarService` (read-only dry-run path) — the default call returned the preview with the name-substitution line and no collection counts changed; an uncatalogued exercise name was flagged "(new — will be added…)" without being created.
- Lint: ruff is configured but not installed in the local venv; all changed files pass `py_compile`; no-new-findings bar left to CI.

## Notes for review

- Behavior change: rest/event scheduling now also takes one confirm round-trip (uniform `dry_run` semantics, same as the plan tool) — intentional.
- Model compliance with the confirm protocol stays probabilistic; the structural default means the failure mode degrades to "asked twice", never "wrote after decline".

🤖 Generated with [Claude Code](https://claude.com/claude-code)