### PR TITLE
Calendar events reference workouts instead of embedding exercises

### DIFF
--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -178,10 +178,11 @@ EXERCISE HOW-TO — CHOOSE VIDEO vs TEXT BY CONTEXT (don't default to one):
   - User says a video is GOOD / perfect / "save this": call `save_exercise_video` with just the `exercise_name` (and `which="alternative"` only if they picked the second option). Confirm briefly ("Saved 👍").
 
 CALENDAR WORKFLOW:
+A calendar event only combines a workout with a date — it never carries its own exercise list.
 When user asks to add/schedule a workout for a specific date:
-1. Design the workout and get user approval
-2. Call `schedule_to_calendar` with the workout details (title, date, workoutDetails with exercises) — the first call returns a PREVIEW and writes nothing
-3. `workoutDetails` with the FULL exercise list is REQUIRED for workout/deload events — never schedule a bare title. The tool creates the calendar event directly (it does NOT need a template first): it saves the planned workout to the user's workout library and links the event to it automatically
+1. FIRST check whether the workout already exists in the library (`list_workout_templates` / `grep_workouts`). If it does, call `schedule_to_calendar` with its id as `workout_template_id` — do NOT resend its exercises; the event links to the existing workout and nothing is duplicated
+2. Only when the session is genuinely new: design it, get user approval, and pass the FULL exercise list in `workoutDetails` — this creates ONE new library workout and links the event to it. Never schedule a bare title
+3. The first `schedule_to_calendar` call returns a PREVIEW and writes nothing
 4. Show the user the preview — ESPECIALLY any exercise-name substitutions (e.g. their "Easy Run" matched to catalog "Treadmill Run") — and ask them to confirm. Only after they confirm, call `schedule_to_calendar` again with the same arguments plus `dry_run=false`. If they decline, do NOT write — adjust or drop the action
 5. If for today, ask if they want to start training now
 

--- a/ai-coach-service/app/core/agents/services/calendar_service.py
+++ b/ai-coach-service/app/core/agents/services/calendar_service.py
@@ -11,6 +11,7 @@ import structlog
 
 from app.core.agents.date_utils import get_user_today, relative_day_label
 from app.core.agents.services.exercise_resolver import ExerciseResolver
+from app.core.agents.volume_utils import flatten_template_exercises
 
 logger = structlog.get_logger()
 
@@ -46,19 +47,55 @@ class CalendarService:
             workout_details = args.get("workoutDetails", {})
             notes = args.get("notes", "")
 
+            # Linking an existing library workout: verify it exists and is
+            # visible to this user BEFORE any preview/write, so a bad id is a
+            # structured error the agent can recover from by re-listing.
+            existing_template = None
+            template_id_arg = args.get("workout_template_id")
+            if template_id_arg:
+                try:
+                    template_oid = ObjectId(template_id_arg)
+                except Exception:
+                    template_oid = None
+                if template_oid is not None:
+                    existing_template = await self.db.predefinedworkouts.find_one({
+                        "_id": template_oid,
+                        "$or": [{"isCommon": True}, {"createdBy": ObjectId(user_id)}],
+                    })
+                if existing_template is None:
+                    return {
+                        "success": False,
+                        "error": "template_not_found",
+                        "message": (
+                            f"No workout template with id '{template_id_arg}' is available to this user. "
+                            "Call list_workout_templates to find the correct id, or pass "
+                            "workoutDetails.exercises to schedule a new custom session."
+                        ),
+                    }
+
             # Hard gate: a workout on the calendar must be a planned session
             # backed by a library template — never a bare title. Returning a
             # tool error here makes the agent plan the exercises and retry.
-            if event_type in ("workout", "deload") and not workout_details.get("exercises"):
+            if (
+                event_type in ("workout", "deload")
+                and existing_template is None
+                and not workout_details.get("exercises")
+            ):
                 return {
                     "success": False,
                     "error": "missing_workout_details",
                     "message": (
-                        "A workout calendar event must include workoutDetails.exercises. "
-                        "Plan the session first (exercise names, targetSets, targetReps, muscles), "
-                        "then call schedule_to_calendar again with the full workoutDetails."
+                        "A workout calendar event must reference a workout. Either pass "
+                        "workout_template_id for an existing library workout (find it with "
+                        "list_workout_templates), or plan the session first and pass the full "
+                        "workoutDetails.exercises to create a new one."
                     ),
                 }
+
+            # When linking a library workout, the template name is the natural
+            # default title (the caller may still override it).
+            if existing_template is not None and not args.get("title"):
+                title = existing_template.get("name", title)
 
             # Add date to title to make it unique and identifiable
             date_suffix = event_date.strftime("%b %d")
@@ -70,14 +107,16 @@ class CalendarService:
             # catalog — silent substitutions must be visible BEFORE any write.
             if args.get("dry_run", True):
                 return await self._preview_schedule(
-                    user_id, event_date, title_with_date, event_type, workout_details, today
+                    user_id, event_date, title_with_date, event_type, workout_details, today,
+                    existing_template=existing_template,
                 )
 
             workout_template_id = None
-            exercises = []
 
-            # If this is a workout event with details, first save it to user's workout library
-            if event_type in ("workout", "deload") and workout_details:
+            if existing_template is not None:
+                # Link the existing library workout — never duplicate it.
+                workout_template_id = existing_template["_id"]
+            elif event_type in ("workout", "deload") and workout_details:
                 # Build the blocks structure; the shared resolver fills in real
                 # exercise ids (exact → fuzzy → vector → create) so neither the
                 # PredefinedWorkout nor the CalendarEvent can carry a null id.
@@ -104,15 +143,6 @@ class CalendarService:
                 blocks, _report = await ExerciseResolver(self.db).resolve_blocks(
                     user_id, blocks, on_ambiguous="best_effort"
                 )
-
-                for ex, resolved in zip(workout_exercises, blocks[0]["exercises"]):
-                    exercises.append({
-                        "exerciseId": resolved["exercise_id"],
-                        "exerciseName": resolved["exercise_name"],
-                        "targetSets": ex.get("targetSets", 3),
-                        "targetReps": ex.get("targetReps", 10),
-                        "notes": ex.get("notes", "")
-                    })
 
                 # Save workout to user's library (PredefinedWorkout collection)
                 workout_template = {
@@ -146,17 +176,24 @@ class CalendarService:
                 "updatedAt": datetime.utcnow()
             }
 
-            # Link to workout template if created
+            # Link to workout template (existing library workout or just created)
             if workout_template_id:
                 event_data["workoutTemplateId"] = workout_template_id
 
-            # Add workout details to calendar event
-            if event_type in ("workout", "deload") and workout_details:
-                event_data["workoutDetails"] = {
-                    "type": workout_details.get("workoutType", "strength"),
-                    "estimatedDuration": workout_details.get("estimatedDuration", 45),
-                    "exercises": exercises
-                }
+            # The event only carries display scalars — exercises live on the
+            # linked template, never embedded in the calendar event.
+            if event_type in ("workout", "deload"):
+                if existing_template is not None:
+                    disciplines = existing_template.get("primary_disciplines") or []
+                    event_data["workoutDetails"] = {
+                        "type": (disciplines[0].lower() if disciplines else "strength"),
+                        "estimatedDuration": existing_template.get("estimated_duration", 45),
+                    }
+                elif workout_details:
+                    event_data["workoutDetails"] = {
+                        "type": workout_details.get("workoutType", "strength"),
+                        "estimatedDuration": workout_details.get("estimatedDuration", 45),
+                    }
 
             # Insert into calendarevents collection (Mongoose uses lowercase, no underscore)
             result = await self.db.calendarevents.insert_one(event_data)
@@ -164,13 +201,19 @@ class CalendarService:
             if result.inserted_id:
                 # Format the date nicely for the response
                 formatted_date = event_date.strftime("%A, %B %d, %Y")
-                exercise_count = len(workout_details.get("exercises", [])) if workout_details else 0
+                if existing_template is not None:
+                    exercise_count = len(flatten_template_exercises(existing_template))
+                    duration = existing_template.get("estimated_duration", 45)
+                else:
+                    exercise_count = len(workout_details.get("exercises", [])) if workout_details else 0
+                    duration = workout_details.get("estimatedDuration", 45) if workout_details else 45
 
                 response_msg = f"Scheduled **{title_with_date}** for **{formatted_date}**!"
-                if workout_template_id:
+                if existing_template is not None:
+                    response_msg += f"\n\nLinked to **{existing_template.get('name')}** from your workout library."
+                elif workout_template_id:
                     response_msg += "\n\n**Saved to your workout library** - you can reuse this workout anytime!"
                 if event_type in ("workout", "deload") and exercise_count > 0:
-                    duration = workout_details.get("estimatedDuration", 45)
                     response_msg += f"\n\n**{exercise_count} exercises** | **~{duration} min**"
 
                 # Check if it's today (user-local)
@@ -182,6 +225,7 @@ class CalendarService:
                     "success": True,
                     "message": response_msg,
                     "event_id": str(result.inserted_id),
+                    "workout_template_id": str(workout_template_id) if workout_template_id else None,
                     "date": formatted_date,
                     "dateISO": event_date.strftime("%Y-%m-%d"),
                     "relativeDay": relative_day_label(event_date.date(), today.date()),
@@ -202,6 +246,7 @@ class CalendarService:
         event_type: str,
         workout_details: Dict[str, Any],
         today: datetime,
+        existing_template: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
         """Dry-run preview for schedule_to_calendar: resolve exercise names
         without creating anything, and return what a confirmed call would write."""
@@ -209,7 +254,20 @@ class CalendarService:
         preview_msg = f"**Preview — nothing scheduled yet**\n\n**{title_with_date}** on **{formatted_date}** ({event_type})"
 
         resolved_exercises = []
-        if event_type in ("workout", "deload") and workout_details:
+        if existing_template is not None:
+            # Linking a library workout: nothing to resolve — the template's
+            # exercises are already canonical. Just show what gets linked.
+            flat = flatten_template_exercises(existing_template)
+            lines = [
+                f"- **{ex['exerciseName']}** — {ex['targetSets']}x{ex['targetReps']}"
+                for ex in flat
+            ]
+            duration = existing_template.get("estimated_duration", 45)
+            preview_msg += (
+                f"\n\nLinks existing library workout **{existing_template.get('name')}** "
+                f"(no new workout is created), ~{duration} min:\n" + "\n".join(lines)
+            )
+        elif event_type in ("workout", "deload") and workout_details:
             workout_exercises = workout_details.get("exercises", [])
             items = [
                 {
@@ -340,11 +398,31 @@ class CalendarService:
                     "events": []
                 }
 
+            # Events reference their workout — batch-fetch the linked templates
+            # so the coach still sees the exercise-by-exercise list.
+            template_ids = {
+                event["workoutTemplateId"]
+                for event in events
+                if event.get("workoutTemplateId")
+            }
+            templates_by_id = {}
+            if template_ids:
+                async for tmpl in self.db.predefinedworkouts.find(
+                    {"_id": {"$in": list(template_ids)}}
+                ):
+                    templates_by_id[tmpl["_id"]] = tmpl
+
             # Format events for response
             formatted_events = []
             for event in events:
                 workout_details = event.get("workoutDetails") or {}
-                raw_exercises = workout_details.get("exercises") or []
+                template = templates_by_id.get(event.get("workoutTemplateId"))
+                if template is not None:
+                    raw_exercises = flatten_template_exercises(template)
+                else:
+                    # Legacy fallback: unmigrated/completed events still embed
+                    # their exercises (completed = actual performed sets).
+                    raw_exercises = workout_details.get("exercises") or []
                 # Include the actual exercise-by-exercise list (not just a count) so
                 # the coach can reason about, and swap, specific exercises. Keep it
                 # compact to control tokens.
@@ -357,6 +435,9 @@ class CalendarService:
                     }
                     for ex in raw_exercises
                 ]
+                duration = workout_details.get("estimatedDuration")
+                if duration is None and template is not None:
+                    duration = template.get("estimated_duration")
                 formatted_events.append({
                     "id": str(event["_id"]),
                     "date": event["date"].strftime("%Y-%m-%d"),
@@ -366,7 +447,9 @@ class CalendarService:
                     "title": event.get("title", "Untitled"),
                     "type": event.get("type", "workout"),
                     "status": event.get("status", "scheduled"),
-                    "duration": workout_details.get("estimatedDuration"),
+                    "duration": duration,
+                    "workoutTemplateId": str(event["workoutTemplateId"]) if event.get("workoutTemplateId") else None,
+                    "templateName": template.get("name") if template is not None else None,
                     "exerciseCount": len(raw_exercises),
                     "exercises": exercises,
                     "notes": event.get("notes", "")

--- a/ai-coach-service/app/core/agents/services/workout_service.py
+++ b/ai-coach-service/app/core/agents/services/workout_service.py
@@ -235,23 +235,52 @@ class WorkoutService:
                 return {"success": True, "deleted": 0,
                         "message": "No matching templates of yours found (common/public templates can't be deleted)."}
 
-            preview = [{"id": str(t["_id"]), "name": t.get("name", "")} for t in targets]
+            # Calendar events reference these templates instead of embedding
+            # exercises — a template with upcoming scheduled events can't be
+            # deleted or those sessions would go empty.
+            referenced: List[Dict[str, Any]] = []
+            deletable: List[Dict[str, Any]] = []
+            for t in targets:
+                refs = await self.db.calendarevents.count_documents({
+                    "workoutTemplateId": t["_id"],
+                    "status": {"$in": ["scheduled", "in_progress"]},
+                })
+                if refs > 0:
+                    referenced.append({"id": str(t["_id"]), "name": t.get("name", ""), "upcoming_events": refs})
+                else:
+                    deletable.append(t)
+
+            preview = [{"id": str(t["_id"]), "name": t.get("name", "")} for t in deletable]
+
+            if not deletable:
+                names = ", ".join(f"{r['name']} ({r['upcoming_events']} upcoming)" for r in referenced)
+                return {"success": False, "skipped_referenced": referenced,
+                        "message": (f"Can't delete — still scheduled on the calendar: {names}. "
+                                    "Delete or reschedule those events first.")}
 
             if not args.get("confirm", False):
-                msg = f"This would delete {len(targets)} template(s): " + ", ".join(t["name"] for t in preview) + "."
+                msg = f"This would delete {len(deletable)} template(s): " + ", ".join(t["name"] for t in preview) + "."
+                if referenced:
+                    names = ", ".join(f"{r['name']} ({r['upcoming_events']} upcoming)" for r in referenced)
+                    msg += f" Skipping (scheduled on the calendar): {names}."
                 if unmatched_keeps:
                     msg += (f" ⚠️ Note: keep name(s) {unmatched_keeps} matched nothing in your library — "
                             "double-check them before confirming.")
                 msg += " Confirm to delete."
                 return {"success": True, "needs_confirmation": True, "would_delete": preview,
+                        "skipped_referenced": referenced,
                         "unmatched_keep_names": unmatched_keeps, "message": msg}
 
             result = await self.db.predefinedworkouts.delete_many(
-                {**own_filter, "_id": {"$in": [t["_id"] for t in targets]}}
+                {**own_filter, "_id": {"$in": [t["_id"] for t in deletable]}}
             )
             logger.info(f"Deleted {result.deleted_count} workout template(s) for user {user_id}")
+            msg = f"Deleted {result.deleted_count} template(s): " + ", ".join(t["name"] for t in preview) + "."
+            if referenced:
+                names = ", ".join(f"{r['name']} ({r['upcoming_events']} upcoming)" for r in referenced)
+                msg += f" Skipped (scheduled on the calendar): {names}."
             return {"success": True, "deleted": result.deleted_count,
-                    "message": f"Deleted {result.deleted_count} template(s): " + ", ".join(t["name"] for t in preview) + "."}
+                    "skipped_referenced": referenced, "message": msg}
 
         except Exception as e:
             logger.error(f"Error deleting workout template: {e}")

--- a/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
@@ -218,11 +218,14 @@ def _build_events(
                 "type": "deload" if is_deload else "workout",
                 "status": "scheduled",
                 "notes": workout.get("notes") or "",
+                # Events only carry display scalars — the exercises live on
+                # the linked template. _exerciseCount is transient (popped
+                # before insert) so previews can still show counts.
                 "workoutDetails": {
                     "type": content["type"],
                     "estimatedDuration": content["duration"],
-                    "exercises": content["exercises"],
                 },
+                "_exerciseCount": len(content["exercises"]),
                 "createdAt": now,
                 "updatedAt": now,
             }
@@ -323,8 +326,8 @@ async def _ensure_templates(
     ctx: SkillContext, user_id: str, plan: Dict[str, Any], events: List[Dict[str, Any]]
 ) -> int:
     """Create (or reuse) a PredefinedWorkout for every event carrying a
-    `_pendingTemplate` marker, link it via workoutTemplateId, and backfill
-    resolved exerciseIds into the event's embedded workoutDetails.
+    `_pendingTemplate` marker and link it via workoutTemplateId (events don't
+    embed exercises — the template is the only copy).
 
     Dedupe is by content key, both within the run (a workout repeated across
     weeks shares ONE library entry) and across re-runs (overwrite deletes the
@@ -391,13 +394,8 @@ async def _ensure_templates(
             known[key] = (result.inserted_id, _template_doc_exercise_ids(template_doc))
             created += 1
 
-        template_id, exercise_ids = known[key]
+        template_id, _exercise_ids = known[key]
         event["workoutTemplateId"] = template_id
-        embedded = event.get("workoutDetails", {}).get("exercises", [])
-        if len(embedded) == len(exercise_ids):
-            for entry, ex_id in zip(embedded, exercise_ids):
-                if ex_id and not entry.get("exerciseId"):
-                    entry["exerciseId"] = ex_id
 
     if created:
         logger.info("created plan workout templates",
@@ -414,7 +412,7 @@ def _serialize_event(event: Dict[str, Any]) -> Dict[str, Any]:
         "week": event["planWeek"],
         "title": event["title"],
         "type": event["type"],
-        "exerciseCount": len(event.get("workoutDetails", {}).get("exercises", [])),
+        "exerciseCount": event.get("_exerciseCount", 0),
     }
 
 
@@ -649,6 +647,7 @@ async def schedule_plan_to_calendar(ctx: SkillContext, user_id: str, args: Dict[
     await _ensure_templates(ctx, user_id, plan, insert_list)
     for e in proposed:
         e.pop("_pendingTemplate", None)
+        e.pop("_exerciseCount", None)
 
     inserted_count = 0
     if insert_list:

--- a/ai-coach-service/app/core/agents/skills/update_calendar_workout_skill.py
+++ b/ai-coach-service/app/core/agents/skills/update_calendar_workout_skill.py
@@ -1,11 +1,14 @@
 """
 Skill: update_calendar_workout
 
-Swap, add, or remove ONE exercise inside a scheduled calendar workout's
-embedded exercise list (workoutDetails.exercises). Dry-run by default with a
-conversational confirm, matching reschedule_session. Optionally applies the
-same change to all FUTURE events with the same title (e.g. "dragon flag on
-every Strength and Conditioning day").
+Swap, add, or remove ONE exercise inside a scheduled calendar workout.
+Calendar events don't embed exercises — they reference a PredefinedWorkout —
+so the edit lands on the linked template with copy-on-write semantics:
+a shared template (common library / referenced elsewhere) is cloned into a
+user-owned copy and the event relinked; an exclusively-owned template is
+edited in place. Legacy events that still embed exercises keep the old
+in-place behavior. Dry-run by default with a conversational confirm.
+Optionally applies the same change to all FUTURE events with the same title.
 """
 
 from datetime import datetime
@@ -13,6 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from bson import ObjectId
 
+from app.core.agents.services.exercise_resolver import ExerciseResolver
 from app.core.agents.skills.registry import SkillContext, skill
 
 
@@ -22,7 +26,7 @@ def resolve_exercise_change(
     target_exercise: Optional[str],
     new_exercise: Optional[Dict[str, Any]],
 ) -> Tuple[Optional[List[Dict[str, Any]]], str]:
-    """Pure: apply the operation to a copy of the exercise list.
+    """Pure: apply the operation to a copy of a legacy embedded exercise list.
 
     Returns (new_list, summary) — new_list is None on failure and summary
     holds the error message.
@@ -83,12 +87,108 @@ def resolve_exercise_change(
     return None, f"Unknown operation '{operation}' (use swap, add, or remove)."
 
 
+def resolve_block_change(
+    blocks: List[Dict[str, Any]],
+    operation: str,
+    target_exercise: Optional[str],
+    new_exercise: Optional[Dict[str, Any]],
+) -> Tuple[Optional[List[Dict[str, Any]]], str]:
+    """Pure: apply the operation to a deep copy of template blocks.
+
+    Returns (new_blocks, summary) — new_blocks is None on failure and summary
+    holds the error message. New entries carry no exercise_id yet; the caller
+    resolves ids before persisting (blockExerciseSchema requires them).
+    """
+    operation = (operation or "").lower()
+    copied = [
+        {**b, "exercises": [dict(ex) for ex in (b.get("exercises") or [])]}
+        for b in (blocks or [])
+    ]
+
+    def find_target() -> Tuple[int, int]:
+        needle = (target_exercise or "").strip().lower()
+        for bi, block in enumerate(copied):
+            for ei, ex in enumerate(block["exercises"]):
+                if needle and needle in (ex.get("exercise_name") or "").lower():
+                    return bi, ei
+        return -1, -1
+
+    def listed_names() -> str:
+        names = [ex.get("exercise_name") or "?" for b in copied for ex in b["exercises"]]
+        return ", ".join(names[:30])
+
+    def build_entry() -> Dict[str, Any]:
+        return {
+            "exercise_name": new_exercise.get("name"),
+            "volume": f"{new_exercise.get('sets', 3)}x{new_exercise.get('reps', 8)}",
+            "rest": "60s",
+            "notes": new_exercise.get("notes") or "",
+        }
+
+    if operation == "swap":
+        if not target_exercise or not new_exercise:
+            return None, "swap needs both target_exercise and new_exercise."
+        bi, ei = find_target()
+        if bi < 0:
+            return None, f"'{target_exercise}' is not in this workout. It has: {listed_names()}"
+        old_name = copied[bi]["exercises"][ei].get("exercise_name")
+        copied[bi]["exercises"][ei] = build_entry()
+        return copied, f"Swap **{old_name}** → **{new_exercise.get('name')}**"
+
+    if operation == "add":
+        if not new_exercise:
+            return None, "add needs new_exercise."
+        if not copied:
+            copied = [{"name": "Main Workout", "exercises": []}]
+        copied[-1]["exercises"].append(build_entry())
+        return copied, f"Add **{new_exercise.get('name')}**"
+
+    if operation == "remove":
+        if not target_exercise:
+            return None, "remove needs target_exercise."
+        bi, ei = find_target()
+        if bi < 0:
+            return None, f"'{target_exercise}' is not in this workout. It has: {listed_names()}"
+        removed = copied[bi]["exercises"].pop(ei)
+        return copied, f"Remove **{removed.get('exercise_name')}**"
+
+    return None, f"Unknown operation '{operation}' (use swap, add, or remove)."
+
+
+async def _is_template_shared(
+    ctx: SkillContext,
+    user_oid: ObjectId,
+    template: Dict[str, Any],
+    exclude_event_ids: List[ObjectId],
+) -> bool:
+    """A template is shared when editing it in place would change something the
+    user didn't ask to change: the common library, another user's workout,
+    other calendar events, or a training plan that references it."""
+    if template.get("isCommon"):
+        return True
+    if template.get("createdBy") and template["createdBy"] != user_oid:
+        return True
+    other_refs = await ctx.db.calendarevents.count_documents({
+        "workoutTemplateId": template["_id"],
+        "_id": {"$nin": exclude_event_ids},
+        "status": {"$nin": ["cancelled"]},
+    })
+    if other_refs > 0:
+        return True
+    plan_refs = await ctx.db.plans.count_documents({
+        "weeks.workouts.predefinedWorkoutId": template["_id"],
+    })
+    return plan_refs > 0
+
+
 @skill(
     name="update_calendar_workout",
     description=(
         "Swap, add, or remove ONE exercise inside a scheduled calendar workout. Use this to "
         "actually apply a change like 'replace Russian Twists with Dragon Flag in Sunday's "
-        "Strength workout'. Previews the change first; only writes after the user confirms "
+        "Strength workout'. The change lands on the workout the event links to: if that workout "
+        "is shared (common library or used by other sessions), a personalized copy is created "
+        "for this event. Previews the change first; only writes after the user confirms "
         "(dry_run=false). Can apply the same change to all future events with the same title."
     ),
     parameters={
@@ -144,15 +244,28 @@ async def update_calendar_workout(ctx: SkillContext, user_id: str, args: Dict[st
     if not event:
         return {"success": False, "message": "I couldn't find that workout on your calendar."}
 
-    exercises = (event.get("workoutDetails") or {}).get("exercises") or []
-    updated, summary = resolve_exercise_change(
-        exercises,
-        args.get("operation"),
-        args.get("target_exercise"),
-        args.get("new_exercise"),
-    )
-    if updated is None:
-        return {"success": False, "message": summary}
+    template = None
+    if event.get("workoutTemplateId"):
+        template = await ctx.db.predefinedworkouts.find_one({"_id": event["workoutTemplateId"]})
+
+    operation = args.get("operation")
+    target_exercise = args.get("target_exercise")
+    new_exercise = args.get("new_exercise")
+
+    if template is not None:
+        updated_blocks, summary = resolve_block_change(
+            template.get("blocks") or [], operation, target_exercise, new_exercise
+        )
+        if updated_blocks is None:
+            return {"success": False, "message": summary}
+    else:
+        # Legacy event without a template link: edit the embedded list in place.
+        exercises = (event.get("workoutDetails") or {}).get("exercises") or []
+        updated_exercises, summary = resolve_exercise_change(
+            exercises, operation, target_exercise, new_exercise
+        )
+        if updated_exercises is None:
+            return {"success": False, "message": summary}
 
     title = event.get("title", "workout")
     date_str = event["date"].strftime("%A, %B %d") if event.get("date") else "?"
@@ -175,44 +288,112 @@ async def update_calendar_workout(ctx: SkillContext, user_id: str, args: Dict[st
     if apply_recurring and sibling_ids:
         scope += f" and **{len(sibling_ids)} more upcoming** '{title.split('(')[0].strip()}' sessions"
 
+    shared = False
+    if template is not None:
+        shared = await _is_template_shared(ctx, user_oid, template, [event_oid, *sibling_ids])
+
     dry_run = args.get("dry_run", True)
     if dry_run:
+        if template is not None:
+            effect = (
+                f"\n\nThis creates a personalized copy of **{template.get('name')}** for "
+                "these session(s) — the original workout stays unchanged."
+                if shared
+                else f"\n\nThis edits your workout **{template.get('name')}** directly."
+            )
+        else:
+            effect = ""
         return {
             "success": True,
             "dry_run": True,
-            "message": f"{summary} in {scope}.\n\nConfirm?",
+            "message": f"{summary} in {scope}.{effect}\n\nConfirm?",
         }
 
     now = datetime.utcnow()
-    await ctx.db.calendarevents.update_one(
-        {"_id": event_oid, "userId": user_oid},
-        {"$set": {"workoutDetails.exercises": updated, "updatedAt": now}},
-    )
-    changed = 1
 
-    # Apply the same operation to each sibling independently (their exercise
-    # lists may differ slightly).
-    for sid in sibling_ids:
-        sib = await ctx.db.calendarevents.find_one({"_id": sid, "userId": user_oid})
-        if not sib:
-            continue
-        sib_exercises = (sib.get("workoutDetails") or {}).get("exercises") or []
-        sib_updated, _ = resolve_exercise_change(
-            sib_exercises,
-            args.get("operation"),
-            args.get("target_exercise"),
-            args.get("new_exercise"),
+    if template is None:
+        # Legacy path: embedded lists edited per event.
+        await ctx.db.calendarevents.update_one(
+            {"_id": event_oid, "userId": user_oid},
+            {"$set": {"workoutDetails.exercises": updated_exercises, "updatedAt": now}},
         )
-        if sib_updated is not None:
-            await ctx.db.calendarevents.update_one(
-                {"_id": sid, "userId": user_oid},
-                {"$set": {"workoutDetails.exercises": sib_updated, "updatedAt": now}},
+        changed = 1
+        for sid in sibling_ids:
+            sib = await ctx.db.calendarevents.find_one({"_id": sid, "userId": user_oid})
+            if not sib:
+                continue
+            sib_exercises = (sib.get("workoutDetails") or {}).get("exercises") or []
+            sib_updated, _ = resolve_exercise_change(
+                sib_exercises, operation, target_exercise, new_exercise
             )
-            changed += 1
+            if sib_updated is not None:
+                await ctx.db.calendarevents.update_one(
+                    {"_id": sid, "userId": user_oid},
+                    {"$set": {"workoutDetails.exercises": sib_updated, "updatedAt": now}},
+                )
+                changed += 1
+        return {
+            "success": True,
+            "dry_run": False,
+            "events_changed": changed,
+            "message": f"Done — {summary.lower()} in {changed} session(s).",
+        }
+
+    # blockExerciseSchema requires exercise_id on every entry — resolve the
+    # edited blocks (entries that already have an id pass straight through).
+    resolved_blocks, _report = await ExerciseResolver(ctx.db).resolve_blocks(
+        user_id, updated_blocks, on_ambiguous="best_effort"
+    )
+
+    if shared:
+        # Copy-on-write: clone into a user-owned workout and relink the
+        # event(s); the shared original stays untouched.
+        clone = {
+            "name": template.get("name"),
+            "goal": template.get("goal", ""),
+            "primary_disciplines": template.get("primary_disciplines") or ["General Fitness"],
+            "estimated_duration": template.get("estimated_duration", 45),
+            "difficulty_level": template.get("difficulty_level", "intermediate"),
+            "blocks": resolved_blocks,
+            "tags": sorted(set((template.get("tags") or []) + ["ai-generated", "customized"])),
+            "isCommon": False,
+            "createdBy": user_oid,
+            "createdAt": now,
+            "updatedAt": now,
+        }
+        insert_result = await ctx.db.predefinedworkouts.insert_one(clone)
+        new_template_id = insert_result.inserted_id
+        relink_ids = [event_oid]
+        # Only siblings that share THIS template follow the relink — a sibling
+        # linked to a different workout shouldn't silently change workouts.
+        for sid in sibling_ids:
+            sib = await ctx.db.calendarevents.find_one({"_id": sid, "userId": user_oid})
+            if sib and sib.get("workoutTemplateId") == template["_id"]:
+                relink_ids.append(sid)
+        await ctx.db.calendarevents.update_many(
+            {"_id": {"$in": relink_ids}, "userId": user_oid},
+            {"$set": {"workoutTemplateId": new_template_id, "updatedAt": now}},
+        )
+        changed = len(relink_ids)
+        note = " (personalized copy created — the shared workout is unchanged)"
+    else:
+        # Exclusively ours: edit the template in place. Every event linked to
+        # it — including same-template siblings — sees the change automatically.
+        await ctx.db.predefinedworkouts.update_one(
+            {"_id": template["_id"]},
+            {"$set": {"blocks": resolved_blocks, "updatedAt": now}},
+        )
+        changed = 1
+        if sibling_ids:
+            changed += await ctx.db.calendarevents.count_documents({
+                "_id": {"$in": sibling_ids},
+                "workoutTemplateId": template["_id"],
+            })
+        note = ""
 
     return {
         "success": True,
         "dry_run": False,
         "events_changed": changed,
-        "message": f"Done — {summary.lower()} in {changed} session(s).",
+        "message": f"Done — {summary.lower()} in {changed} session(s){note}.",
     }

--- a/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
@@ -13,7 +13,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "schedule_to_calendar",
-                "description": "Schedule a workout or event to the user's calendar for a specific date. Use this when the user wants to add a workout to their calendar, schedule a rest day, or plan future training. For 'workout' and 'deload' events you MUST plan the full session first and pass it in workoutDetails.exercises — never schedule a bare title. The tool saves the planned workout to the user's workout library (Workouts tab) and links the calendar event to it automatically. Defaults to a dry-run PREVIEW that writes nothing and shows how each exercise name matched the user's exercise catalog. Present the preview to the user; ONLY after they confirm, call again with the same arguments plus dry_run=false to actually write. If the user declines the preview, do NOT call again.",
+                "description": "Schedule a workout or event to the user's calendar for a specific date. A calendar event only combines a workout with a date — it never carries its own exercise list. For 'workout' and 'deload' events, EITHER pass workout_template_id for an existing library workout (find it with list_workout_templates / grep_workouts — ALWAYS prefer this; it links the event without creating anything new), OR plan a brand-new session and pass workoutDetails.exercises (this creates a new library workout and links it). Never schedule a bare title. Defaults to a dry-run PREVIEW that writes nothing. Present the preview to the user; ONLY after they confirm, call again with the same arguments plus dry_run=false to actually write. If the user declines the preview, do NOT call again.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -23,16 +23,20 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                         },
                         "title": {
                             "type": "string",
-                            "description": "Title for the calendar event (e.g., 'Upper Body Strength', 'Active Recovery', 'Rest Day')"
+                            "description": "Title for the calendar event (e.g., 'Upper Body Strength', 'Active Recovery', 'Rest Day'). When linking a library workout via workout_template_id, omit to default to the workout's name."
                         },
                         "type": {
                             "type": "string",
                             "enum": ["workout", "rest", "deload", "event"],
                             "description": "Type of calendar event"
                         },
+                        "workout_template_id": {
+                            "type": "string",
+                            "description": "ID of an existing library workout to schedule (from list_workout_templates or grep_workouts). ALWAYS pass this instead of workoutDetails when the workout already exists — do NOT resend its exercises."
+                        },
                         "workoutDetails": {
                             "type": "object",
-                            "description": "Details for workout events. REQUIRED (with a non-empty exercises list) for type 'workout' and 'deload'.",
+                            "description": "Details for a NEWLY designed workout session — creates a new library workout. For 'workout'/'deload' events, required only when workout_template_id is not given.",
                             "properties": {
                                 "workoutType": {
                                     "type": "string",
@@ -68,8 +72,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                                         "required": ["exerciseName"]
                                     }
                                 }
-                            },
-                            "required": ["exercises"]
+                            }
                         },
                         "notes": {
                             "type": "string",

--- a/ai-coach-service/app/core/agents/volume_utils.py
+++ b/ai-coach-service/app/core/agents/volume_utils.py
@@ -1,0 +1,35 @@
+"""Volume-string parsing and template flattening shared by calendar flows.
+
+Calendar events reference a PredefinedWorkout instead of embedding exercises,
+so every consumer derives sets/reps from the template's blocks via these
+helpers. Mirrors backend/src/utils/volume.js.
+"""
+
+import re
+from typing import Any, Dict, List
+
+
+def parse_volume(volume: Any) -> tuple[int, int]:
+    """Parse a PredefinedWorkout volume string like '3x10' / '3 x 8-12' into
+    (sets, reps). Falls back to (3, 10)."""
+    m = re.match(r"\s*(\d+)\s*[xX]\s*(\d+)", str(volume or ""))
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    return 3, 10
+
+
+def flatten_template_exercises(template: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Flatten template blocks[].exercises[] into the per-exercise shape the
+    coach surfaces (name/targetSets/targetReps/notes + exerciseId)."""
+    flattened = []
+    for block in (template or {}).get("blocks", []) or []:
+        for ex in block.get("exercises", []) or []:
+            sets, reps = parse_volume(ex.get("volume"))
+            flattened.append({
+                "exerciseId": ex.get("exercise_id"),
+                "exerciseName": ex.get("exercise_name", ""),
+                "targetSets": sets,
+                "targetReps": reps,
+                "notes": ex.get("notes", ""),
+            })
+    return flattened

--- a/ai-coach-service/app/services/daily_pick_service.py
+++ b/ai-coach-service/app/services/daily_pick_service.py
@@ -144,8 +144,11 @@ async def load_calendar_context(db, user_id: str, timezone: str = 'UTC') -> Dict
         }).to_list(20)
 
         # Get recent completed workouts (last 14 days) — completed calendar
-        # events carry workoutDetails.exercises, the only live source of what
-        # the user actually did (the workouts collection is unused).
+        # events carry workoutDetails.exercises (ACTUAL performed sets), the
+        # only live source of what the user actually did (the workouts
+        # collection is unused). Scheduled events no longer embed exercises —
+        # they reference a template — but completed history is exempt.
+        # TODO: long-term, read this from workoutlogs via workoutLogId.
         two_weeks_ago = start_of_today - timedelta(days=14)
         recent_workouts = await db.calendarevents.find({
             "userId": user_oid,

--- a/ai-coach-service/tests/test_calendar_service.py
+++ b/ai-coach-service/tests/test_calendar_service.py
@@ -265,10 +265,12 @@ class TestScheduleToCalendarTemplateLink:
         template = db.predefinedworkouts.insert_one.call_args[0][0]
         assert template["isCommon"] is False
         assert template["createdBy"] == ObjectId(USER_ID)
+        assert template["blocks"][0]["exercises"][0]["exercise_id"] is not None
 
+        # The event only references the template — exercises are never embedded.
         event = db.calendarevents.insert_one.call_args[0][0]
         assert event["workoutTemplateId"] is not None
-        assert event["workoutDetails"]["exercises"][0]["exerciseId"] is not None
+        assert "exercises" not in event["workoutDetails"]
 
     async def test_rest_event_needs_no_exercises(self, monkeypatch):
         _anchor(monkeypatch)
@@ -280,6 +282,113 @@ class TestScheduleToCalendarTemplateLink:
         )
 
         assert result["success"] is True
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+
+# ------------------- schedule_to_calendar: linking an existing template -------------------
+
+LIBRARY_TEMPLATE_ID = ObjectId()
+
+
+def _library_template(is_common=True, created_by=None):
+    return {
+        "_id": LIBRARY_TEMPLATE_ID,
+        "name": "Endurance 1",
+        "primary_disciplines": ["Calisthenics"],
+        "estimated_duration": 75,
+        "isCommon": is_common,
+        **({"createdBy": created_by} if created_by else {}),
+        "blocks": [{
+            "name": "Main Workout",
+            "exercises": [
+                {"exercise_id": ObjectId(), "exercise_name": "Pull-Ups", "volume": "4x8", "rest": "60s", "notes": ""},
+                {"exercise_id": ObjectId(), "exercise_name": "Dips", "volume": "3x12", "rest": "60s", "notes": ""},
+            ],
+        }],
+    }
+
+
+class TestScheduleToCalendarExistingTemplate:
+    async def test_template_id_links_without_creating_template(self, monkeypatch):
+        _anchor(monkeypatch)
+        db = _insert_db()
+        db.predefinedworkouts.find_one = AsyncMock(return_value=_library_template())
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID,
+            {"date": "today", "type": "workout", "dry_run": False,
+             "workout_template_id": str(LIBRARY_TEMPLATE_ID)},
+        )
+
+        assert result["success"] is True
+        # No duplicate template is ever created for a library workout.
+        db.predefinedworkouts.insert_one.assert_not_called()
+        event = db.calendarevents.insert_one.call_args[0][0]
+        assert event["workoutTemplateId"] == LIBRARY_TEMPLATE_ID
+        assert "exercises" not in event["workoutDetails"]
+        assert event["workoutDetails"]["estimatedDuration"] == 75
+        # Title defaults to the template name (plus the date suffix).
+        assert event["title"].startswith("Endurance 1")
+        assert result["workout_template_id"] == str(LIBRARY_TEMPLATE_ID)
+
+    async def test_template_id_not_found_errors(self, monkeypatch):
+        _anchor(monkeypatch)
+        db = _insert_db()
+        # Covers both a bogus id and another user's private template — the
+        # access-scoped find_one returns nothing either way.
+        db.predefinedworkouts.find_one = AsyncMock(return_value=None)
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID,
+            {"date": "today", "type": "workout", "dry_run": False,
+             "workout_template_id": str(ObjectId())},
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "template_not_found"
+        db.calendarevents.insert_one.assert_not_called()
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+    async def test_template_lookup_scoped_to_user_visible(self, monkeypatch):
+        _anchor(monkeypatch)
+        db = _insert_db()
+        db.predefinedworkouts.find_one = AsyncMock(return_value=_library_template())
+        service = CalendarService(db)
+
+        await service.schedule_to_calendar(
+            USER_ID,
+            {"date": "today", "type": "workout", "dry_run": False,
+             "workout_template_id": str(LIBRARY_TEMPLATE_ID)},
+        )
+
+        query = db.predefinedworkouts.find_one.call_args[0][0]
+        assert query["_id"] == LIBRARY_TEMPLATE_ID
+        assert {"isCommon": True} in query["$or"]
+        assert {"createdBy": ObjectId(USER_ID)} in query["$or"]
+
+    async def test_template_id_dry_run_previews_without_resolver(self, monkeypatch):
+        _anchor(monkeypatch)
+        resolver_cls = MagicMock()
+        monkeypatch.setattr(calendar_service_module, "ExerciseResolver", resolver_cls)
+        db = _insert_db()
+        db.predefinedworkouts.find_one = AsyncMock(return_value=_library_template())
+        service = CalendarService(db)
+
+        result = await service.schedule_to_calendar(
+            USER_ID,
+            {"date": "today", "type": "workout",
+             "workout_template_id": str(LIBRARY_TEMPLATE_ID)},
+        )
+
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        # Template exercises are canonical — the resolver must not run.
+        resolver_cls.assert_not_called()
+        assert "Endurance 1" in result["message"]
+        assert "Pull-Ups" in result["message"]
+        db.calendarevents.insert_one.assert_not_called()
         db.predefinedworkouts.insert_one.assert_not_called()
 
 

--- a/ai-coach-service/tests/test_schedule_plan_skill.py
+++ b/ai-coach-service/tests/test_schedule_plan_skill.py
@@ -441,12 +441,11 @@ class TestEnsureTemplates:
         inserted = ctx.db.calendarevents.insert_many.call_args.args[0]
         template_ids = {e.get("workoutTemplateId") for e in inserted}
         assert len(template_ids) == 1 and None not in template_ids
-        # internal marker never persisted; resolved ids backfilled into events
+        # internal markers never persisted; events reference the template
+        # instead of embedding exercises
         assert all("_pendingTemplate" not in e for e in inserted)
-        assert all(
-            e["workoutDetails"]["exercises"][0].get("exerciseId") is not None
-            for e in inserted
-        )
+        assert all("_exerciseCount" not in e for e in inserted)
+        assert all("exercises" not in e["workoutDetails"] for e in inserted)
 
     @pytest.mark.asyncio
     async def test_dry_run_creates_no_templates(self, fake_resolver):
@@ -480,10 +479,7 @@ class TestEnsureTemplates:
         ctx.db.predefinedworkouts.insert_one.assert_not_called()
         inserted = ctx.db.calendarevents.insert_many.call_args.args[0]
         assert all(e["workoutTemplateId"] == existing_id for e in inserted)
-        assert all(
-            e["workoutDetails"]["exercises"][0]["exerciseId"] == existing_ex_id
-            for e in inserted
-        )
+        assert all("exercises" not in e["workoutDetails"] for e in inserted)
 
     @pytest.mark.asyncio
     async def test_same_name_different_content_gets_own_template(self, fake_resolver):

--- a/ai-coach-service/tests/test_update_calendar_workout_skill.py
+++ b/ai-coach-service/tests/test_update_calendar_workout_skill.py
@@ -1,0 +1,243 @@
+"""update_calendar_workout copy-on-write behavior.
+
+Calendar events reference a PredefinedWorkout instead of embedding exercises,
+so per-day edits land on the linked template: a shared template (common /
+referenced by other events or plans) is cloned into a user-owned copy and the
+event relinked; an exclusively-owned template is edited in place; legacy
+events without a template keep the old embedded-list edit.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bson import ObjectId
+
+import app.core.agents.skills.update_calendar_workout_skill as skill_module
+from app.core.agents.skills.update_calendar_workout_skill import (
+    resolve_block_change,
+    update_calendar_workout,
+)
+
+USER_ID = str(ObjectId())
+EVENT_ID = ObjectId()
+TEMPLATE_ID = ObjectId()
+
+
+def _template(is_common=False, created_by=None):
+    return {
+        "_id": TEMPLATE_ID,
+        "name": "Strength A",
+        "primary_disciplines": ["Strength"],
+        "estimated_duration": 60,
+        "difficulty_level": "intermediate",
+        "isCommon": is_common,
+        "createdBy": created_by,
+        "tags": ["ai-generated"],
+        "blocks": [{
+            "name": "Main Workout",
+            "exercises": [
+                {"exercise_id": ObjectId(), "exercise_name": "Russian Twists", "volume": "3x20", "rest": "60s", "notes": ""},
+                {"exercise_id": ObjectId(), "exercise_name": "Pull-Ups", "volume": "4x8", "rest": "60s", "notes": ""},
+            ],
+        }],
+    }
+
+
+def _event(template_id=TEMPLATE_ID, embedded=None):
+    event = {
+        "_id": EVENT_ID,
+        "userId": ObjectId(USER_ID),
+        "title": "Strength A (Jul 20)",
+        "date": datetime(2026, 7, 20),
+        "type": "workout",
+        "status": "scheduled",
+        "workoutDetails": {"type": "strength", "estimatedDuration": 60},
+    }
+    if template_id:
+        event["workoutTemplateId"] = template_id
+    if embedded is not None:
+        event["workoutDetails"]["exercises"] = embedded
+    return event
+
+
+def _make_ctx(event, template=None, other_event_refs=0, plan_refs=0):
+    db = MagicMock()
+    db.calendarevents.find_one = AsyncMock(return_value=event)
+    db.calendarevents.count_documents = AsyncMock(return_value=other_event_refs)
+    db.calendarevents.update_one = AsyncMock()
+    db.calendarevents.update_many = AsyncMock()
+    db.predefinedworkouts.find_one = AsyncMock(return_value=template)
+    db.predefinedworkouts.insert_one = AsyncMock(return_value=MagicMock(inserted_id=ObjectId()))
+    db.predefinedworkouts.update_one = AsyncMock()
+    db.plans.count_documents = AsyncMock(return_value=plan_refs)
+
+    find_result = MagicMock()
+
+    async def _iter():
+        return
+        yield
+
+    db.calendarevents.find = MagicMock(return_value=_iter())
+
+    ctx = MagicMock()
+    ctx.db = db
+    return ctx
+
+
+def _fake_resolver(monkeypatch):
+    async def resolve_blocks(user_id, blocks, on_ambiguous="ask"):
+        for block in blocks:
+            for ex in block.get("exercises", []):
+                ex["exercise_id"] = ex.get("exercise_id") or ObjectId()
+        return blocks, {"resolved": [], "created": [], "ambiguous": [], "pending_create": []}
+
+    resolver = MagicMock()
+    resolver.resolve_blocks = AsyncMock(side_effect=resolve_blocks)
+    monkeypatch.setattr(skill_module, "ExerciseResolver", MagicMock(return_value=resolver))
+    return resolver
+
+
+SWAP_ARGS = {
+    "event_id": str(EVENT_ID),
+    "operation": "swap",
+    "target_exercise": "Russian Twists",
+    "new_exercise": {"name": "Dragon Flag", "sets": 3, "reps": 8},
+    "dry_run": False,
+}
+
+
+class TestResolveBlockChange:
+    def test_swap_replaces_in_place(self):
+        blocks = _template()["blocks"]
+        updated, summary = resolve_block_change(blocks, "swap", "russian", {"name": "Dragon Flag"})
+        assert updated is not None
+        names = [ex["exercise_name"] for ex in updated[0]["exercises"]]
+        assert names == ["Dragon Flag", "Pull-Ups"]
+        assert "Dragon Flag" in summary
+        # original untouched
+        assert blocks[0]["exercises"][0]["exercise_name"] == "Russian Twists"
+
+    def test_add_appends_to_last_block(self):
+        updated, _ = resolve_block_change(_template()["blocks"], "add", None, {"name": "Plank", "sets": 3, "reps": 30})
+        assert updated[-1]["exercises"][-1]["exercise_name"] == "Plank"
+        assert updated[-1]["exercises"][-1]["volume"] == "3x30"
+
+    def test_remove_missing_target_lists_names(self):
+        updated, summary = resolve_block_change(_template()["blocks"], "remove", "Deadlift", None)
+        assert updated is None
+        assert "Pull-Ups" in summary
+
+
+@pytest.mark.asyncio
+class TestCopyOnWrite:
+    async def test_shared_common_template_cloned_and_relinked(self, monkeypatch):
+        _fake_resolver(monkeypatch)
+        ctx = _make_ctx(_event(), template=_template(is_common=True))
+
+        result = await update_calendar_workout(ctx, USER_ID, dict(SWAP_ARGS))
+
+        assert result["success"] is True
+        ctx.db.predefinedworkouts.insert_one.assert_awaited_once()
+        clone = ctx.db.predefinedworkouts.insert_one.call_args[0][0]
+        assert clone["isCommon"] is False
+        assert clone["createdBy"] == ObjectId(USER_ID)
+        assert "customized" in clone["tags"]
+        names = [ex["exercise_name"] for ex in clone["blocks"][0]["exercises"]]
+        assert names == ["Dragon Flag", "Pull-Ups"]
+        # the shared original is never edited
+        ctx.db.predefinedworkouts.update_one.assert_not_called()
+        # event relinked to the clone
+        relink = ctx.db.calendarevents.update_many.call_args[0]
+        assert relink[0]["_id"]["$in"] == [EVENT_ID]
+        assert relink[1]["$set"]["workoutTemplateId"] == ctx.db.predefinedworkouts.insert_one.return_value.inserted_id
+
+    async def test_template_referenced_by_other_events_cloned(self, monkeypatch):
+        _fake_resolver(monkeypatch)
+        ctx = _make_ctx(
+            _event(),
+            template=_template(is_common=False, created_by=ObjectId(USER_ID)),
+            other_event_refs=2,
+        )
+
+        result = await update_calendar_workout(ctx, USER_ID, dict(SWAP_ARGS))
+
+        assert result["success"] is True
+        ctx.db.predefinedworkouts.insert_one.assert_awaited_once()
+        ctx.db.predefinedworkouts.update_one.assert_not_called()
+
+    async def test_exclusive_template_edited_in_place(self, monkeypatch):
+        _fake_resolver(monkeypatch)
+        ctx = _make_ctx(
+            _event(),
+            template=_template(is_common=False, created_by=ObjectId(USER_ID)),
+        )
+
+        result = await update_calendar_workout(ctx, USER_ID, dict(SWAP_ARGS))
+
+        assert result["success"] is True
+        ctx.db.predefinedworkouts.insert_one.assert_not_called()
+        ctx.db.predefinedworkouts.update_one.assert_awaited_once()
+        update = ctx.db.predefinedworkouts.update_one.call_args[0]
+        assert update[0] == {"_id": TEMPLATE_ID}
+        names = [ex["exercise_name"] for ex in update[1]["$set"]["blocks"][0]["exercises"]]
+        assert names == ["Dragon Flag", "Pull-Ups"]
+        # the event keeps its link — nothing relinked
+        ctx.db.calendarevents.update_many.assert_not_called()
+
+    async def test_plan_referenced_template_cloned(self, monkeypatch):
+        _fake_resolver(monkeypatch)
+        ctx = _make_ctx(
+            _event(),
+            template=_template(is_common=False, created_by=ObjectId(USER_ID)),
+            plan_refs=1,
+        )
+
+        await update_calendar_workout(ctx, USER_ID, dict(SWAP_ARGS))
+
+        ctx.db.predefinedworkouts.insert_one.assert_awaited_once()
+        ctx.db.predefinedworkouts.update_one.assert_not_called()
+
+    async def test_dry_run_previews_effect_and_writes_nothing(self, monkeypatch):
+        _fake_resolver(monkeypatch)
+        ctx = _make_ctx(_event(), template=_template(is_common=True))
+
+        result = await update_calendar_workout(
+            ctx, USER_ID, {**SWAP_ARGS, "dry_run": True}
+        )
+
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        assert "personalized copy" in result["message"]
+        ctx.db.predefinedworkouts.insert_one.assert_not_called()
+        ctx.db.predefinedworkouts.update_one.assert_not_called()
+        ctx.db.calendarevents.update_one.assert_not_called()
+        ctx.db.calendarevents.update_many.assert_not_called()
+
+    async def test_legacy_event_without_template_edits_embedded_list(self, monkeypatch):
+        _fake_resolver(monkeypatch)
+        embedded = [
+            {"exerciseName": "Russian Twists", "targetSets": 3, "targetReps": 20},
+            {"exerciseName": "Pull-Ups", "targetSets": 4, "targetReps": 8},
+        ]
+        ctx = _make_ctx(_event(template_id=None, embedded=embedded), template=None)
+
+        result = await update_calendar_workout(ctx, USER_ID, dict(SWAP_ARGS))
+
+        assert result["success"] is True
+        ctx.db.predefinedworkouts.insert_one.assert_not_called()
+        update = ctx.db.calendarevents.update_one.call_args[0]
+        new_names = [ex["exerciseName"] for ex in update[1]["$set"]["workoutDetails.exercises"]]
+        assert new_names == ["Dragon Flag", "Pull-Ups"]
+
+    async def test_missing_target_errors_without_writes(self, monkeypatch):
+        _fake_resolver(monkeypatch)
+        ctx = _make_ctx(_event(), template=_template(is_common=True))
+
+        result = await update_calendar_workout(
+            ctx, USER_ID, {**SWAP_ARGS, "target_exercise": "Deadlift"}
+        )
+
+        assert result["success"] is False
+        ctx.db.predefinedworkouts.insert_one.assert_not_called()
+        ctx.db.calendarevents.update_one.assert_not_called()

--- a/ai-coach-service/tests/test_workout_template_tools.py
+++ b/ai-coach-service/tests/test_workout_template_tools.py
@@ -28,6 +28,8 @@ def _service(own_templates=None, total_matching=None, deleted=0):
         return_value=total_matching if total_matching is not None else len(own_templates))
     db.predefinedworkouts.delete_many = AsyncMock(
         return_value=MagicMock(deleted_count=deleted))
+    # Deletion guard: no calendar events reference these templates by default.
+    db.calendarevents.count_documents = AsyncMock(return_value=0)
     svc = WorkoutService(db)
     return svc, db
 
@@ -107,3 +109,29 @@ class TestDeleteTemplate:
         res = await svc.delete_workout_template(str(USER), {"name": "Does Not Exist"})
         assert res["success"] is True and res["deleted"] == 0
         db.predefinedworkouts.delete_many.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_template_with_upcoming_events_is_refused(self):
+        # Calendar events reference templates — deleting one that upcoming
+        # events link to would empty those sessions.
+        own = [_tmpl("Scheduled One")]
+        svc, db = _service(own)
+        db.calendarevents.count_documents = AsyncMock(return_value=2)
+        res = await svc.delete_workout_template(str(USER), {
+            "template_id": str(own[0]["_id"]), "confirm": True,
+        })
+        assert res["success"] is False
+        assert res["skipped_referenced"][0]["upcoming_events"] == 2
+        db.predefinedworkouts.delete_many.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_referenced_templates_skipped_others_deleted(self):
+        own = [_tmpl("Scheduled One"), _tmpl("Unused One")]
+        svc, db = _service(own, deleted=1)
+        db.calendarevents.count_documents = AsyncMock(
+            side_effect=lambda q: 3 if q["workoutTemplateId"] == own[0]["_id"] else 0)
+        res = await svc.delete_workout_template(str(USER), {"keep_only": ["nothing kept"], "confirm": True})
+        assert res["success"] is True and res["deleted"] == 1
+        assert res["skipped_referenced"][0]["name"] == "Scheduled One"
+        deleted_ids = db.predefinedworkouts.delete_many.call_args.args[0]["_id"]["$in"]
+        assert deleted_ids == [own[1]["_id"]]

--- a/backend/scripts/migrate-calendar-embedded-exercises.js
+++ b/backend/scripts/migrate-calendar-embedded-exercises.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * One-off migration: calendar events only combine a workout with a date —
+ * they must not embed an exercise list. For every SCHEDULED/IN_PROGRESS
+ * workout/deload event that carries both a workoutTemplateId and an embedded
+ * workoutDetails.exercises copy, verify the linked template still holds the
+ * exercises and $unset the embedded copy.
+ *
+ * Explicitly NOT touched:
+ *  - completed/skipped events — their workoutDetails.exercises are ACTUAL
+ *    performed sets (workout-log flow), a historical record;
+ *  - events without a workoutTemplateId — run the calendar consistency job
+ *    (linkOrphanWorkoutEvents) first so orphans get templates, then re-run;
+ *  - events whose template is missing or empty — the embedded copy stays as
+ *    the only backstop (reported in the summary);
+ *  - events whose embedded count differs from the template (pre-fix
+ *    update_calendar_workout edits drifted them) — kept unless --force.
+ *
+ * Usage:
+ *   node scripts/migrate-calendar-embedded-exercises.js             # dry run (default)
+ *   node scripts/migrate-calendar-embedded-exercises.js --apply     # write
+ *   node scripts/migrate-calendar-embedded-exercises.js --apply --force   # also strip count-mismatched events
+ *   node scripts/migrate-calendar-embedded-exercises.js --user <id> # limit to one user
+ */
+
+const mongoose = require('mongoose');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../.env') });
+
+const CalendarEvent = require('../src/models/CalendarEvent');
+const PredefinedWorkout = require('../src/models/PredefinedWorkout');
+const { flattenTemplateExercises } = require('../src/utils/volume');
+
+const APPLY = process.argv.includes('--apply');
+const FORCE = process.argv.includes('--force');
+const userFlagIdx = process.argv.indexOf('--user');
+const USER_ID = userFlagIdx > -1 ? process.argv[userFlagIdx + 1] : null;
+
+async function main() {
+  await mongoose.connect(process.env.MONGODB_URI);
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY RUN'}${FORCE ? ' +force' : ''}${USER_ID ? ` user=${USER_ID}` : ''}`);
+
+  const query = {
+    type: { $in: ['workout', 'deload'] },
+    workoutTemplateId: { $exists: true, $ne: null },
+    status: { $in: ['scheduled', 'in_progress'] },
+    'workoutDetails.exercises.0': { $exists: true }
+  };
+  if (USER_ID) query.userId = new mongoose.Types.ObjectId(USER_ID);
+
+  const events = await CalendarEvent.find(query).lean();
+  console.log(`Examined: ${events.length} event(s) with a template AND an embedded exercise list`);
+
+  const stats = { unset: 0, missingTemplate: 0, emptyTemplate: 0, countMismatch: 0 };
+
+  for (const event of events) {
+    const template = await PredefinedWorkout.findById(event.workoutTemplateId).lean();
+    const label = `${event._id} "${event.title}" (${new Date(event.date).toISOString().slice(0, 10)})`;
+
+    if (!template) {
+      stats.missingTemplate++;
+      console.log(`  SKIP missing template: ${label}`);
+      continue;
+    }
+
+    const flattened = flattenTemplateExercises(template);
+    if (!flattened.length) {
+      stats.emptyTemplate++;
+      console.log(`  SKIP template has no exercises: ${label}`);
+      continue;
+    }
+
+    const embeddedCount = event.workoutDetails.exercises.length;
+    if (flattened.length !== embeddedCount && !FORCE) {
+      stats.countMismatch++;
+      console.log(`  SKIP count mismatch (template ${flattened.length} vs embedded ${embeddedCount}, use --force): ${label}`);
+      continue;
+    }
+
+    if (APPLY) {
+      await CalendarEvent.updateOne(
+        { _id: event._id },
+        { $unset: { 'workoutDetails.exercises': 1 } }
+      );
+    }
+    stats.unset++;
+  }
+
+  console.log('\nSummary:');
+  console.log(`  ${APPLY ? 'Unset' : 'Would unset'}: ${stats.unset}`);
+  console.log(`  Skipped — missing template: ${stats.missingTemplate}`);
+  console.log(`  Skipped — template empty: ${stats.emptyTemplate}`);
+  console.log(`  Skipped — count mismatch: ${stats.countMismatch}`);
+  if (stats.missingTemplate + stats.emptyTemplate > 0) {
+    console.log('  → run the calendar consistency job (linkOrphanWorkoutEvents) and re-check the skipped events.');
+  }
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/controllers/calendarController.js
+++ b/backend/src/controllers/calendarController.js
@@ -2,6 +2,11 @@ const CalendarEvent = require('../models/CalendarEvent');
 const WorkoutLog = require('../models/WorkoutLog');
 const PredefinedWorkout = require('../models/PredefinedWorkout');
 const { validationResult } = require('express-validator');
+const { flattenTemplateExercises } = require('../utils/volume');
+const {
+  ensureTemplateForCustomEvent,
+  applyExercisesCopyOnWrite
+} = require('../services/templateMaterializer');
 
 // Get calendar events for a date range
 const getEvents = async (req, res) => {
@@ -96,27 +101,29 @@ const createEvent = async (req, res) => {
       userId: req.user._id
     };
 
-    // If a workout template is provided, populate workout details
+    // Events only reference workouts — exercises live on the template.
     if (req.body.workoutTemplateId) {
       const template = await PredefinedWorkout.findById(req.body.workoutTemplateId);
       if (template) {
         eventData.title = eventData.title || template.name;
         eventData.workoutDetails = {
+          ...(eventData.workoutDetails || {}),
           type: template.primary_disciplines?.[0]?.toLowerCase() || 'strength',
-          estimatedDuration: template.estimated_duration,
-          exercises: template.blocks?.flatMap(block =>
-            block.exercises?.map(ex => ({
-              // Omit rather than propagate a null id from a legacy template —
-              // workoutDetails.exerciseId is optional.
-              ...(ex.exercise_id ? { exerciseId: ex.exercise_id } : {}),
-              exerciseName: ex.exercise_name,
-              targetSets: parseInt(ex.volume?.split('x')[0]) || 3,
-              targetReps: parseInt(ex.volume?.split('x')[1]) || 8,
-              notes: ex.notes
-            }))
-          ) || []
+          estimatedDuration: template.estimated_duration
         };
       }
+    } else if (['workout', 'deload'].includes(eventData.type) && eventData.status !== 'completed') {
+      // Bare-exercises payload (chat flow, custom builds, legacy clients):
+      // materialize a library template so the event can link it. Completed
+      // events are historical records of performed sets and keep theirs.
+      const templateId = await ensureTemplateForCustomEvent(req.user._id, eventData);
+      if (templateId) eventData.workoutTemplateId = templateId;
+    }
+
+    // Scheduled events never persist an embedded exercise list, whatever the
+    // client sent. Completed events keep actual performed sets (workout-log flow).
+    if (eventData.status !== 'completed' && eventData.workoutDetails?.exercises) {
+      delete eventData.workoutDetails.exercises;
     }
 
     const event = new CalendarEvent(eventData);
@@ -151,10 +158,27 @@ const updateEvent = async (req, res) => {
       });
     }
 
+    const updateData = { ...req.body };
+
+    // Exercises never land on the event. If a client edits a workout's
+    // exercise list, the edit goes to the linked template — copy-on-write
+    // when the template is shared (common / other events reference it).
+    const incomingExercises = updateData.workoutDetails?.exercises;
+    if (incomingExercises) {
+      updateData.workoutDetails = { ...updateData.workoutDetails };
+      delete updateData.workoutDetails.exercises;
+
+      const existing = await CalendarEvent.findOne({ _id: req.params.id, userId: req.user._id });
+      if (existing && ['workout', 'deload'].includes(existing.type) && existing.status !== 'completed') {
+        const templateId = await applyExercisesCopyOnWrite(req.user._id, existing, incomingExercises);
+        if (templateId) updateData.workoutTemplateId = templateId;
+      }
+    }
+
     // Single query with ownership check
     const updatedEvent = await CalendarEvent.findOneAndUpdate(
       { _id: req.params.id, userId: req.user._id },
-      req.body,
+      updateData,
       { new: true, runValidators: true }
     ).populate('workoutTemplateId', 'name goal primary_disciplines estimated_duration');
 
@@ -265,6 +289,13 @@ const startWorkout = async (req, res) => {
     // Update event status (will save after linking workoutLogId to avoid double save)
     event.status = 'in_progress';
 
+    // The linked template is the source of truth for exercises; the embedded
+    // list is a legacy fallback for unmigrated/orphan events.
+    const templateExercises = flattenTemplateExercises(event.workoutTemplateId);
+    const plannedExercises = templateExercises.length
+      ? templateExercises
+      : event.workoutDetails?.exercises || [];
+
     // Create a workout log entry
     const workoutLog = new WorkoutLog({
       userId: req.user._id,
@@ -272,7 +303,7 @@ const startWorkout = async (req, res) => {
       title: event.title,
       type: event.workoutDetails?.type || 'strength',
       startedAt: new Date(),
-      exercises: event.workoutDetails?.exercises?.map((ex, i) => ({
+      exercises: plannedExercises.map((ex, i) => ({
         exerciseId: ex.exerciseId,
         exerciseName: ex.exerciseName,
         order: i,
@@ -283,7 +314,7 @@ const startWorkout = async (req, res) => {
           isCompleted: false
         })),
         notes: ex.notes
-      })) || []
+      }))
     });
 
     await workoutLog.save();

--- a/backend/src/jobs/calendarConsistencyJob.js
+++ b/backend/src/jobs/calendarConsistencyJob.js
@@ -357,9 +357,14 @@ class CalendarConsistencyJob {
             createdBy: sample.userId
           });
 
+          // Link the template and drop the embedded copy in one pass — the
+          // template is now the only source of the planned exercises.
           await CalendarEvent.updateMany(
             { _id: { $in: events.map((e) => e._id) } },
-            { $set: { workoutTemplateId: template._id } }
+            {
+              $set: { workoutTemplateId: template._id },
+              $unset: { 'workoutDetails.exercises': 1 }
+            }
           );
 
           this.stats.orphanTemplatesCreated++;

--- a/backend/src/models/CalendarEvent.js
+++ b/backend/src/models/CalendarEvent.js
@@ -33,7 +33,14 @@ const calendarEventSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: 'PredefinedWorkout'
   },
-  // Workout details (can be from template or custom)
+  // Display metadata for the event. Scheduled events must NOT embed
+  // exercises — the linked workoutTemplateId is the source of truth
+  // (see templateMaterializer / migrate-calendar-embedded-exercises).
+  // The exercises path stays in the schema for two reasons: completed
+  // events store ACTUAL performed sets here (workout-log flow), and
+  // legacy unmigrated events still hydrate their embedded copy.
+  // NOTE: ai-coach-service (Python) writes this collection too — keep
+  // its event shape (calendar_service.py, schedule_plan_skill.py) in sync.
   workoutDetails: {
     type: {
       type: String
@@ -114,7 +121,9 @@ calendarEventSchema.statics.getByDateRange = function(userId, startDate, endDate
     status: { $ne: 'cancelled' }
   })
   .sort({ date: 1 })
-  .populate('workoutTemplateId', 'name goal primary_disciplines estimated_duration');
+  // blocks included: events don't embed exercises, so range consumers
+  // (calendar page, detail modal, MCP list) read them off the template.
+  .populate('workoutTemplateId', 'name goal primary_disciplines estimated_duration blocks');
 };
 
 // Static method to get today's events

--- a/backend/src/routes/predefinedWorkouts.js
+++ b/backend/src/routes/predefinedWorkouts.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const PredefinedWorkout = require('../models/PredefinedWorkout');
+const CalendarEvent = require('../models/CalendarEvent');
 const WorkoutService = require('../services/WorkoutService');
 const { auth, optionalAuth } = require('../middleware/auth');
 const router = express.Router();
@@ -223,8 +224,29 @@ router.delete('/:id', auth, async (req, res) => {
       return res.status(404).json({ error: 'Predefined workout not found' });
     }
 
+    // Calendar events reference workouts instead of embedding exercises, so
+    // deleting a workout that upcoming events link to would empty those
+    // sessions. Completed/skipped history may dangle (readers null-guard).
+    const upcomingRefs = await CalendarEvent.countDocuments({
+      workoutTemplateId: workout._id,
+      status: { $in: ['scheduled', 'in_progress'] }
+    });
+    const forceDelete = req.user.role === 'superAdmin' && req.query.force === 'true';
+    if (upcomingRefs > 0 && !forceDelete) {
+      return res.status(409).json({
+        error: `This workout is scheduled on the calendar (${upcomingRefs} upcoming event(s)). ` +
+          'Delete or reschedule those events first.'
+      });
+    }
+
     // SuperAdmin can delete any workout, including common ones
     if (req.user.role === 'superAdmin') {
+      if (upcomingRefs > 0) {
+        await CalendarEvent.updateMany(
+          { workoutTemplateId: workout._id, status: { $in: ['scheduled', 'in_progress'] } },
+          { $unset: { workoutTemplateId: 1 } }
+        );
+      }
       await workout.deleteOne();
       return res.json({ message: 'Predefined workout deleted successfully' });
     }

--- a/backend/src/services/templateMaterializer.js
+++ b/backend/src/services/templateMaterializer.js
@@ -1,0 +1,130 @@
+const CalendarEvent = require('../models/CalendarEvent');
+const PredefinedWorkout = require('../models/PredefinedWorkout');
+const Exercise = require('../models/Exercise');
+
+// Calendar events only reference workouts — they never carry their own
+// exercise list. Clients that still send bare exercises (chat ActionButtons,
+// custom WorkoutModal builds, legacy API callers) get a real library template
+// materialized here so the event can link it.
+
+const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Resolve an exercise name to an id the user can see (commons + their own);
+// create a minimal user-owned exercise when nothing matches. Unlike the
+// nightly consistency job we cannot skip unresolved names — the embedded
+// copy on the event is gone, so the template is the only record.
+const resolveOrCreateExercise = async (userId, exerciseName) => {
+  const match = await Exercise.findOne({
+    name: new RegExp(`^${escapeRegex(exerciseName)}$`, 'i'),
+    $or: [{ isCommon: true }, { createdBy: userId }]
+  })
+    .select('_id')
+    .lean();
+  if (match) return match._id;
+
+  const created = await Exercise.create({
+    name: exerciseName,
+    muscles: ['full body'],
+    discipline: ['strength'],
+    isCommon: false,
+    createdBy: userId
+  });
+  return created._id;
+};
+
+const buildBlocks = async (userId, exercises) => {
+  const blockExercises = [];
+  for (const ex of exercises) {
+    if (!ex.exerciseName) continue;
+    const exerciseId = ex.exerciseId || (await resolveOrCreateExercise(userId, ex.exerciseName));
+    blockExercises.push({
+      exercise_id: exerciseId,
+      exercise_name: ex.exerciseName,
+      volume: `${ex.targetSets || 3}x${ex.targetReps || 10}`,
+      rest: '60s',
+      notes: ex.notes || ''
+    });
+  }
+  return [{ name: 'Main Workout', exercises: blockExercises }];
+};
+
+// Create a user-owned template from a bare-exercises event payload and
+// return its id, or null when there is nothing to materialize.
+const ensureTemplateForCustomEvent = async (userId, eventData) => {
+  const exercises = eventData.workoutDetails?.exercises;
+  if (!exercises?.length) return null;
+
+  const name = (eventData.title || 'Workout')
+    .replace(/\s*\([A-Z][a-z]{2} \d{1,2}\)\s*$/, '')
+    .trim() || 'Workout';
+
+  const blocks = await buildBlocks(userId, exercises);
+  if (!blocks[0].exercises.length) return null;
+
+  const template = await PredefinedWorkout.create({
+    name,
+    goal: '',
+    primary_disciplines: [eventData.workoutDetails?.type || 'strength'],
+    estimated_duration: eventData.workoutDetails?.estimatedDuration || 45,
+    difficulty_level: 'intermediate',
+    blocks,
+    tags: ['user-created'],
+    isCommon: false,
+    createdBy: userId
+  });
+  return template._id;
+};
+
+// A template is shared when editing it in place would change something the
+// user didn't ask to change: the common library, another user's workout, or
+// other calendar events still pointing at it.
+const isTemplateShared = async (userId, template, excludeEventId) => {
+  if (template.isCommon) return true;
+  if (template.createdBy && String(template.createdBy) !== String(userId)) return true;
+  const otherRefs = await CalendarEvent.countDocuments({
+    workoutTemplateId: template._id,
+    _id: { $ne: excludeEventId },
+    status: { $nin: ['cancelled'] }
+  });
+  return otherRefs > 0;
+};
+
+// Copy-on-write for per-event exercise edits: shared template → clone with
+// the new exercises and relink the event; exclusively-owned template → edit
+// its blocks in place. Returns the template id the event should reference.
+const applyExercisesCopyOnWrite = async (userId, event, exercises) => {
+  const blocks = await buildBlocks(userId, exercises);
+  if (!blocks[0].exercises.length) return event.workoutTemplateId || null;
+
+  const template = event.workoutTemplateId
+    ? await PredefinedWorkout.findById(event.workoutTemplateId)
+    : null;
+
+  if (!template) {
+    return ensureTemplateForCustomEvent(userId, {
+      title: event.title,
+      workoutDetails: { ...(event.workoutDetails || {}), exercises }
+    });
+  }
+
+  if (await isTemplateShared(userId, template, event._id)) {
+    const clone = await PredefinedWorkout.create({
+      name: template.name,
+      goal: template.goal || '',
+      primary_disciplines: template.primary_disciplines,
+      estimated_duration: template.estimated_duration,
+      difficulty_level: template.difficulty_level,
+      blocks,
+      tags: [...new Set([...(template.tags || []), 'ai-generated', 'customized'])],
+      isCommon: false,
+      createdBy: userId
+    });
+    return clone._id;
+  }
+
+  template.blocks = blocks;
+  await template.save();
+  return template._id;
+};
+
+module.exports = { ensureTemplateForCustomEvent, applyExercisesCopyOnWrite };

--- a/backend/src/utils/volume.js
+++ b/backend/src/utils/volume.js
@@ -1,0 +1,32 @@
+// Volume strings ("3x10", "4 x 8-12") are the template-side rep scheme.
+// Calendar events no longer embed exercises, so every consumer that needs
+// sets/reps derives them from the linked PredefinedWorkout via these helpers.
+
+const VOLUME_RE = /^\s*(\d+)\s*[xX]\s*(\d+)/;
+
+const parseVolume = (volume) => {
+  const match = typeof volume === 'string' ? volume.match(VOLUME_RE) : null;
+  if (!match) return { sets: 3, reps: 10 };
+  return { sets: parseInt(match[1], 10), reps: parseInt(match[2], 10) };
+};
+
+// Flatten template.blocks[].exercises[] into the shape calendar consumers
+// (WorkoutLog creation, API responses) expect. Entries without an
+// exercise_id keep their name — the id is optional downstream.
+const flattenTemplateExercises = (template) => {
+  if (!template?.blocks?.length) return [];
+  return template.blocks.flatMap((block) =>
+    (block.exercises || []).map((ex) => {
+      const { sets, reps } = parseVolume(ex.volume);
+      return {
+        ...(ex.exercise_id ? { exerciseId: ex.exercise_id } : {}),
+        exerciseName: ex.exercise_name,
+        targetSets: sets,
+        targetReps: reps,
+        notes: ex.notes || ''
+      };
+    })
+  );
+};
+
+module.exports = { parseVolume, flattenTemplateExercises };

--- a/frontend/src/components/calendar/CalendarEventDetailModal.jsx
+++ b/frontend/src/components/calendar/CalendarEventDetailModal.jsx
@@ -40,6 +40,24 @@ const WORKOUT_TYPE_COLORS = {
   hybrid: { bg: "bg-teal-50", text: "text-teal-700", badge: "bg-teal-500" }
 };
 
+// Scheduled events reference their workout — flatten the populated template
+// blocks into the display shape (volume "3x10" → targetSets/targetReps).
+const flattenTemplateBlocks = (blocks) => {
+  if (!Array.isArray(blocks)) return [];
+  return blocks.flatMap(block =>
+    (block.exercises || []).map(ex => {
+      const m = /^\s*(\d+)\s*[xX]\s*(\d+)/.exec(ex.volume || '');
+      return {
+        exerciseId: ex.exercise_id,
+        exerciseName: ex.exercise_name,
+        targetSets: m ? parseInt(m[1], 10) : 3,
+        targetReps: m ? parseInt(m[2], 10) : 10,
+        notes: ex.notes
+      };
+    })
+  );
+};
+
 export default function CalendarEventDetailModal({ event, onClose, onStartWorkout, onDelete }) {
   if (!event) return null;
 
@@ -50,8 +68,15 @@ export default function CalendarEventDetailModal({ event, onClose, onStartWorkou
   const workoutType = event.workoutDetails?.type || event.eventType || "strength";
   const typeColors = WORKOUT_TYPE_COLORS[workoutType] || WORKOUT_TYPE_COLORS.strength;
 
-  const exercises = event.workoutDetails?.exercises || [];
-  const duration = event.workoutDetails?.estimatedDuration || event.workoutDetails?.durationMinutes || 60;
+  // Completed events embed the ACTUAL performed sets; scheduled events read
+  // the plan from the linked workout template (embedded list is a legacy
+  // fallback for unmigrated events).
+  const embeddedExercises = event.workoutDetails?.exercises || [];
+  const templateExercises = flattenTemplateBlocks(event.workoutTemplateId?.blocks);
+  const exercises = status === 'completed'
+    ? (embeddedExercises.length ? embeddedExercises : templateExercises)
+    : (templateExercises.length ? templateExercises : embeddedExercises);
+  const duration = event.workoutDetails?.estimatedDuration || event.workoutDetails?.durationMinutes || event.workoutTemplateId?.estimated_duration || 60;
   const notes = event.workoutDetails?.notes || event.notes || "";
 
   const eventDate = typeof event.date === 'string' ? new Date(event.date) : event.date;
@@ -154,7 +179,9 @@ export default function CalendarEventDetailModal({ event, onClose, onStartWorkou
                           </span>
                         </div>
                         <span className="text-xs text-gray-500">
-                          {setsCompleted}/{totalSets} sets
+                          {totalSets > 0
+                            ? `${setsCompleted}/${totalSets} sets`
+                            : `${exercise.targetSets || 3} × ${exercise.targetReps || '-'}`}
                         </span>
                       </div>
 

--- a/frontend/src/components/calendar/WorkoutSelectionModal.jsx
+++ b/frontend/src/components/calendar/WorkoutSelectionModal.jsx
@@ -149,6 +149,9 @@ I want to add a workout to my calendar for ${dateStr}. Please help me decide wha
       title: selectedWorkout.name || "Unnamed Workout",
       type: workoutType,
       durationMinutes: selectedWorkout.estimated_duration || selectedWorkout.duration_minutes || 60,
+      // The library workout's id: the calendar event links to it instead of
+      // carrying its own exercise copy (exercises stay for local preview).
+      workoutTemplateId: selectedWorkout._id || selectedWorkout.id,
       exercises: workoutExercises,
       notes: `Applied from: ${selectedWorkout.name}\n\nGoal: ${selectedWorkout.goal || "No goal specified"}`,
       totalStrain: 0,

--- a/frontend/src/components/dashboard/TodayView.jsx
+++ b/frontend/src/components/dashboard/TodayView.jsx
@@ -83,8 +83,17 @@ export default function TodayView() {
             duration:
               scheduledEvent.workoutDetails?.durationMinutes ||
               scheduledEvent.workoutDetails?.estimatedDuration ||
+              scheduledEvent.workoutTemplateId?.estimated_duration ||
               null,
-            exercises: scheduledEvent.workoutDetails?.exercises?.length || null,
+            // Exercise count comes from the linked template; embedded list
+            // is a legacy fallback for unmigrated events.
+            exercises:
+              scheduledEvent.workoutTemplateId?.blocks?.reduce(
+                (n, b) => n + (b.exercises?.length || 0),
+                0
+              ) ||
+              scheduledEvent.workoutDetails?.exercises?.length ||
+              null,
             eventId: scheduledEvent.id,
           });
           setSessionLoading(false);

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -570,7 +570,10 @@ export default function CalendarPage() {
 
   const handleAddEvent = async (workoutData) => {
     try {
-      // Convert workout data to calendar event format
+      // Convert workout data to calendar event format. Events only combine a
+      // workout with a date: when a library workout is picked we send its id
+      // and no exercises; for a custom build we send the exercises and the
+      // backend materializes a library workout to link.
       const eventData = {
         date: workoutData.date,
         title: workoutData.title,
@@ -578,15 +581,15 @@ export default function CalendarPage() {
         status: 'scheduled',
         workoutDetails: {
           type: workoutData.type || 'strength',
-          estimatedDuration: workoutData.durationMinutes || 60,
-          exercises: workoutData.exercises || []
+          estimatedDuration: workoutData.durationMinutes || 60
         },
         notes: workoutData.notes
       };
 
-      // If workoutTemplateId is provided, add it
       if (workoutData.workoutTemplateId) {
         eventData.workoutTemplateId = workoutData.workoutTemplateId;
+      } else {
+        eventData.workoutDetails.exercises = workoutData.exercises || [];
       }
 
       await CalendarEvent.create(eventData);

--- a/frontend/src/pages/TrainNow.jsx
+++ b/frontend/src/pages/TrainNow.jsx
@@ -395,7 +395,11 @@ export default function TrainNow() {
           if (calendarData.success && ['workout', 'deload'].includes(scheduledEvent?.type)) {
             console.log('[TrainNow] Using calendar workout -', scheduledEvent.title);
 
-            // Convert calendar exercise format to the format expected by parseWorkoutToSessionData
+            // The linked template's blocks are the source of truth; embedded
+            // event exercises only remain on legacy unmigrated events.
+            const templateBlocks = scheduledEvent.workoutTemplateId?.blocks || [];
+
+            // Convert legacy embedded format for parseWorkoutToSessionData
             const calendarExercises = scheduledEvent.workoutDetails?.exercises || [];
             const convertedExercises = calendarExercises.map(ex => ({
               exercise_id: ex.exerciseId || ex.exercise_id,
@@ -411,11 +415,11 @@ export default function TrainNow() {
               name: scheduledEvent.title,
               estimated_duration: scheduledEvent.workoutDetails?.estimatedDuration || 45,
               primary_disciplines: [scheduledEvent.workoutDetails?.type || 'strength'],
-              // Embedded event exercises are the source of truth; template blocks
-              // only as fallback — parseWorkoutToSessionData concatenates both,
-              // so including both duplicates every exercise.
-              blocks: convertedExercises.length > 0 ? [] : (scheduledEvent.workoutTemplateId?.blocks || []),
-              exercises: convertedExercises,
+              // parseWorkoutToSessionData concatenates blocks and exercises,
+              // so exactly one of the two may be non-empty or every exercise
+              // duplicates.
+              blocks: templateBlocks,
+              exercises: templateBlocks.length > 0 ? [] : convertedExercises,
               calendarEventId: scheduledEvent._id
             });
             setIsFromCalendar(true);


### PR DESCRIPTION
## Problem

Prod evidence: calendar event `6a564d8cf259cd645fdd2ae9` carried a `workoutTemplateId` **and** a full embedded copy of 24 exercises under `workoutDetails.exercises`, and its linked template `6a564d8cf259cd645fdd2ae8` ("Endurance 1 (Jul 14)") was a duplicate of the common library workout "Endurance 1" created 100ms earlier by the same `schedule_to_calendar` call.

Two defects, both descended from PR #113:
1. Calendar events embedded exercise lists — an event should only combine a workout with a date.
2. Sensei duplicated an existing library workout into a new per-user template on every confirmed schedule (the known PR #113 follow-up: no link-existing-template argument).

## Fix

**Invariant:** a scheduled calendar event = workout reference (`workoutTemplateId`) + date + status/title + display scalars. Exercises live only on the `predefinedworkouts` template. **Exception (by design):** completed events keep embedded `workoutDetails.exercises` — those are *actual performed sets* written by the workout-log flow, a historical record.

- **Backend**: `createEvent` no longer copies template exercises into events; bare-exercise payloads (chat ActionButtons, custom builds) get a template materialized server-side (`templateMaterializer.js`); `updateEvent` applies exercise edits copy-on-write to the template; `startWorkout` builds the WorkoutLog from template blocks; `getByDateRange` populates blocks; the consistency job `$unset`s embedded copies as it back-links orphans; deleting a workout referenced by upcoming events returns 409.
- **Sensei**: `schedule_to_calendar` gains `workout_template_id` — existing library workouts are linked, never duplicated (prompt + tool schema updated to prefer it); `update_calendar_workout` edits the linked template copy-on-write (shared → personalized clone + relink, exclusive → in place); plan scheduling and `get_calendar_events` follow the same model.
- **Frontend**: TrainNow, TodayView, and the event detail modal read exercises from the populated template blocks (embedded list kept as legacy fallback); library picks send `workoutTemplateId`.
- **Migration**: `backend/scripts/migrate-calendar-embedded-exercises.js` (dry-run default) strips embedded exercises from scheduled events with a verified template. Run the consistency job first; completed/skipped events are never touched.

## Verification

A/B on a scratch DB (throwaway user, dropped after) — scheduling library "Endurance 1" on 2 days:

| | old (main) | new |
|---|---|---|
| duplicate templates created | 2 | **0** |
| embedded exercises per event | 3 | **0** |
| approx event size | ~900B | ~485B |

- `pytest` ai-coach-service: **381 passed** (new suites for template linking + copy-on-write + deletion guard)
- backend `npm test` green, frontend `vite build` green

## Rollout

1. Deploy (backward compatible — legacy events keep working via read fallbacks)
2. Run the calendar consistency job, then the migration script (`--apply` after dry-run review)
3. Later cleanup PR: remove read fallbacks once prod is migrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)