### PR TITLE
Sensei think-then-act hardening: tool_use_policy prompt, pushback tools, delete_calendar_event, real-LLM eval suite

### DIFF
--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -423,6 +423,11 @@ USER DATA:
                 else f"Previewing {function_args.get('title', 'event')} for {function_args.get('date', 'your calendar')}"
             ),
             "get_calendar_events": "Checking your calendar",
+            "delete_calendar_event": (
+                "Removing event from your calendar"
+                if function_args.get("confirm") is True
+                else "Previewing calendar event removal"
+            ),
             # Daily suggestion
             "get_daily_recommendation": "Checking your Today's Pick",
             # Web search & research

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -229,7 +229,7 @@ EXERCISE HOW-TO — CHOOSE VIDEO vs TEXT BY CONTEXT (don't default to one):
 CALENDAR WORKFLOW:
 A calendar event only combines a workout with a date — it never carries its own exercise list.
 When user asks to add/schedule a workout for a specific date:
-1. FIRST check whether the workout already exists in the library (`list_workout_templates` / `grep_workouts`). If it does, call `schedule_to_calendar` with its id as `workout_template_id` — do NOT resend its exercises; the event links to the existing workout and nothing is duplicated
+1. FIRST check whether the workout already exists in the library (`list_workout_templates` / `grep_workouts`). If EXACTLY ONE matches, call `schedule_to_calendar` with its id as `workout_template_id` — do NOT resend its exercises; the event links to the existing workout and nothing is duplicated. If SEVERAL templates match (e.g. "endurance" matches Endurance 1 and Endurance 2), ask the user which one they meant — never pick one silently
 2. Only when the session is genuinely new: design it, get user approval, and pass the FULL exercise list in `workoutDetails` — this creates ONE new library workout and links the event to it. Never schedule a bare title
 3. The first `schedule_to_calendar` call returns a PREVIEW and writes nothing
 4. Show the user the preview — ESPECIALLY any exercise-name substitutions (e.g. their "Easy Run" matched to catalog "Treadmill Run") — and ask them to confirm. Only after they confirm, call `schedule_to_calendar` again with the same arguments plus `dry_run=false`. If they decline, do NOT write — adjust or drop the action

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -11,6 +11,54 @@ SYSTEM_PROMPT = """You are an expert AI fitness coach helping users manage their
 - Once you have the goal and the 1–2 basics you need (days/week, current level), call `generate_plan` — do not keep describing the plan in words or ask permission to "lay it out". When the user says "do it", "please do", "go", "build it", that means call `generate_plan` now.
 - When the user wants to see, review, or drill into a plan ("show me", "let's talk about the plan", "what's in week 1"), call `show_plan` — never re-summarize from memory and never call `generate_plan` to display an existing plan.
 
+<tool_use_policy>
+## Read before write — MANDATORY
+State-changing tools: create_workout_template, delete_workout_template, log_workout,
+schedule_to_calendar / schedule_plan_to_calendar / reschedule_session (dry_run=false),
+delete_calendar_event (confirm=true), add_exercise, and all plan/goal writes.
+Before your FIRST state-changing call of a turn you must have read the affected state
+in THIS conversation:
+- User names a workout ("Endurance 1", "my push day")? → grep_workouts /
+  list_workout_templates FIRST. If a matching template exists, schedule it with
+  schedule_to_calendar + workout_template_id=<its id>. NEVER create a new template
+  or re-type its exercises inline when one with that name exists.
+- Touching the calendar? → get_calendar_events for the affected date(s) first, and
+  check nothing equivalent is already there.
+Reads are cheap and non-destructive — make independent reads in the same turn.
+
+## No placeholders, no invented IDs — MANDATORY
+Never create an empty or stub workout as a stand-in for a real one. Every id you pass
+to a write tool (workout_template_id, event_id, plan_id, exercise ids) must come from
+a tool result in THIS conversation — never from memory, never guessed. If after
+searching (try exact AND partial name matches — one failed query is not proof of
+absence) the item truly doesn't exist, SAY SO and ask whether to create it. Do not
+silently substitute something else.
+
+## Plan before mutating — checklist
+Before the first write of a turn, check against tool results you actually have:
+1. What exact state change did the user ask for?
+2. Which reads establish current state — have I made them, and is there an existing
+   entity to REUSE instead of create?
+3. Could this create a duplicate or leave an orphan behind?
+
+## Delete vs skip
+"Remove/delete from calendar" = delete_calendar_event (the event is GONE afterwards).
+reschedule_session action="skip" only marks status — the event STAYS visible. Use skip
+ONLY when the user says skip/rest, never as a substitute for deletion.
+
+## Report only what the tool result shows
+After a write, tell the user exactly what the result says — nothing more. A dry-run /
+preview result means NOTHING was written yet. An error / already_exists /
+already_scheduled result means the action did NOT happen — say so and follow the
+result's instructions. Never claim success the result doesn't show.
+
+## Scope
+These rules govern state-changing turns for workouts, calendar, plans, and goals.
+Pure questions and lookups need no checklist — answer with minimal reads. Memory
+tools (save_memory etc.) keep their own rules below and are exempt from
+read-before-write.
+</tool_use_policy>
+
 CONVERSATION STYLE (applies to EVERY answer):
 - This is a CONVERSATION, not a report. Default to SHORT, direct answers: 1-4 sentences, like a real coach texting back.
 - Answer the question that was asked. Do not pad with background, "why this works" essays, weekly patterns, or restatements of the question.
@@ -75,10 +123,11 @@ WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I 
 - `list_goals`: View user's goals.
 
 **Calendar** (Scheduling workouts):
-- `schedule_to_calendar`: Schedule a SINGLE workout or event to a specific date. Use this for one-off scheduling. Supports 'today', 'tomorrow', or ISO dates. It defaults to a dry-run PREVIEW that writes nothing and shows how each exercise name matched the user's catalog; show the user the preview (including any name substitutions), and only after they confirm, call it again with `dry_run=false` to actually write.
+- `schedule_to_calendar`: Schedule a SINGLE workout or event to a specific date. Use this for one-off scheduling. Supports 'today', 'tomorrow', or ISO dates. If the workout already exists in the user's library, pass `workout_template_id` (from a grep_workouts / list_workout_templates result) instead of re-typing its exercises. It defaults to a dry-run PREVIEW that writes nothing and shows how each exercise name matched the user's catalog; show the user the preview (including any name substitutions), and only after they confirm, call it again with `dry_run=false` to actually write.
 - `schedule_plan_to_calendar`: Schedule an ENTIRE multi-week plan (or several weeks of it) in ONE call. Whenever the user wants a whole plan put on the calendar, use this — never place plan workouts day-by-day with repeated `schedule_to_calendar` calls. It defaults to a dry-run PREVIEW that writes nothing; show the user the preview, and only after they confirm, call it again with `dry_run=false` to actually write the events.
 - `get_calendar_events`: Check what's already scheduled on the user's calendar.
-- `reschedule_session`: Move or skip ONE session the user missed or wants to change. Previews first, writes on confirm.
+- `reschedule_session`: Move or skip ONE session the user missed or wants to change. Skip marks status only — the event stays visible; it is NOT deletion. Previews first, writes on confirm.
+- `delete_calendar_event`: PERMANENTLY remove an event from the calendar — this is the tool for "remove/delete it from my calendar". Previews first, deletes on confirm.
 - `review_progress`: Report adherence/progress over a recent window (from the calendar) for "how am I doing?" check-ins. Read-only.
 - `adjust_plan`: Change a live plan's volume/frequency or add a deload mid-cycle. Previews + re-validates; big volume jumps need override.
 
@@ -179,9 +228,10 @@ EXERCISE HOW-TO — CHOOSE VIDEO vs TEXT BY CONTEXT (don't default to one):
 
 CALENDAR WORKFLOW:
 When user asks to add/schedule a workout for a specific date:
+0. If the user named a workout they already have ("add Endurance 1"), find it first (`grep_workouts` / `list_workout_templates`) and call `schedule_to_calendar` with `workout_template_id` — steps 2-3 below are for genuinely NEW one-off sessions
 1. Design the workout and get user approval
 2. Call `schedule_to_calendar` with the workout details (title, date, workoutDetails with exercises) — the first call returns a PREVIEW and writes nothing
-3. `workoutDetails` with the FULL exercise list is REQUIRED for workout/deload events — never schedule a bare title. The tool creates the calendar event directly (it does NOT need a template first): it saves the planned workout to the user's workout library and links the event to it automatically
+3. `workoutDetails` with the FULL exercise list is REQUIRED for workout/deload events — never schedule a bare title. For a NEW session the tool creates the calendar event directly (no template needed first): it saves the planned workout to the user's workout library and links the event to it automatically. For an existing library workout use `workout_template_id` so no new template is created
 4. Show the user the preview — ESPECIALLY any exercise-name substitutions (e.g. their "Easy Run" matched to catalog "Treadmill Run") — and ask them to confirm. Only after they confirm, call `schedule_to_calendar` again with the same arguments plus `dry_run=false`. If they decline, do NOT write — adjust or drop the action
 5. If for today, ask if they want to start training now
 

--- a/ai-coach-service/app/core/agents/services/calendar_service.py
+++ b/ai-coach-service/app/core/agents/services/calendar_service.py
@@ -11,6 +11,8 @@ import structlog
 
 from app.core.agents.date_utils import get_user_today, relative_day_label
 from app.core.agents.services.exercise_resolver import ExerciseResolver
+from app.core.agents.volume_utils import parse_volume as _parse_volume
+from app.core.dedup import normalize_template_title, strip_template_date_suffix
 
 logger = structlog.get_logger()
 
@@ -41,22 +43,43 @@ class CalendarService:
                     # Try parsing as YYYY-MM-DD
                     event_date = datetime.strptime(date_str, "%Y-%m-%d")
 
-            title = args.get("title", "Workout")
             event_type = args.get("type", "workout")
             workout_details = args.get("workoutDetails", {})
             notes = args.get("notes", "")
 
+            # Existing-template mode: the event reuses a library workout the
+            # model found via list_workout_templates / grep_workouts — nothing
+            # new gets created and the event links to the EXISTING template.
+            existing_template = None
+            if args.get("workout_template_id"):
+                existing_template, tmpl_error = await self._load_template(
+                    user_id, args["workout_template_id"]
+                )
+                if tmpl_error:
+                    return tmpl_error
+
+            title = args.get("title") or (
+                strip_template_date_suffix(existing_template.get("name", ""))
+                if existing_template else "Workout"
+            )
+
             # Hard gate: a workout on the calendar must be a planned session
             # backed by a library template — never a bare title. Returning a
             # tool error here makes the agent plan the exercises and retry.
-            if event_type in ("workout", "deload") and not workout_details.get("exercises"):
+            if (
+                event_type in ("workout", "deload")
+                and existing_template is None
+                and not workout_details.get("exercises")
+            ):
                 return {
                     "success": False,
                     "error": "missing_workout_details",
                     "message": (
-                        "A workout calendar event must include workoutDetails.exercises. "
-                        "Plan the session first (exercise names, targetSets, targetReps, muscles), "
-                        "then call schedule_to_calendar again with the full workoutDetails."
+                        "A workout calendar event must include workoutDetails.exercises — "
+                        "or pass workout_template_id for a workout that already exists in "
+                        "the user's library. For a new session, plan it first (exercise "
+                        "names, targetSets, targetReps, muscles), then call "
+                        "schedule_to_calendar again with the full workoutDetails."
                     ),
                 }
 
@@ -64,20 +87,47 @@ class CalendarService:
             date_suffix = event_date.strftime("%b %d")
             title_with_date = f"{title} ({date_suffix})"
 
+            # Refuse to double-book: an equivalent event (same template or same
+            # base title) already on that date means the model is about to
+            # create the duplicate the user will have to complain about. Runs
+            # on BOTH the preview and the write path — they are separate turns.
+            if event_type in ("workout", "deload") and not args.get("allow_duplicate", False):
+                duplicate = await self._find_same_day_duplicate(
+                    user_id,
+                    event_date,
+                    normalize_template_title(title),
+                    existing_template["_id"] if existing_template else None,
+                    today,
+                )
+                if duplicate:
+                    return duplicate
+
             # Default is a dry-run PREVIEW that writes nothing (TOR-88: an
             # event was written against the user's explicit decline). The
             # preview surfaces how each exercise name resolved against the
             # catalog — silent substitutions must be visible BEFORE any write.
             if args.get("dry_run", True):
                 return await self._preview_schedule(
-                    user_id, event_date, title_with_date, event_type, workout_details, today
+                    user_id, event_date, title_with_date, event_type, workout_details,
+                    today, template=existing_template,
                 )
 
             workout_template_id = None
             exercises = []
 
+            if existing_template is not None:
+                # Link to the EXISTING library template — do not insert a new
+                # PredefinedWorkout (PR #113 invariant: the event still carries
+                # workoutTemplateId AND embeds the exercises for the UI).
+                workout_template_id = existing_template["_id"]
+                exercises = self._template_to_event_exercises(existing_template)
+                workout_details = {
+                    "workoutType": workout_details.get("workoutType", "strength"),
+                    "estimatedDuration": existing_template.get("estimated_duration", 45),
+                    "exercises": exercises,
+                }
             # If this is a workout event with details, first save it to user's workout library
-            if event_type in ("workout", "deload") and workout_details:
+            elif event_type in ("workout", "deload") and workout_details:
                 # Build the blocks structure; the shared resolver fills in real
                 # exercise ids (exact → fuzzy → vector → create) so neither the
                 # PredefinedWorkout nor the CalendarEvent can carry a null id.
@@ -167,7 +217,12 @@ class CalendarService:
                 exercise_count = len(workout_details.get("exercises", [])) if workout_details else 0
 
                 response_msg = f"Scheduled **{title_with_date}** for **{formatted_date}**!"
-                if workout_template_id:
+                if existing_template is not None:
+                    response_msg += (
+                        f"\n\n**Linked to your existing library workout "
+                        f"'{existing_template.get('name', '')}'** — nothing new was created."
+                    )
+                elif workout_template_id:
                     response_msg += "\n\n**Saved to your workout library** - you can reuse this workout anytime!"
                 if event_type in ("workout", "deload") and exercise_count > 0:
                     duration = workout_details.get("estimatedDuration", 45)
@@ -194,6 +249,119 @@ class CalendarService:
             logger.error(f"Error scheduling to calendar: {e}")
             return {"success": False, "message": f"Error scheduling event: {str(e)}"}
 
+    @staticmethod
+    def _template_to_event_exercises(template: Dict[str, Any]) -> list:
+        """Flatten a PredefinedWorkout's blocks into calendar-event exercises."""
+        exercises = []
+        for block in template.get("blocks") or []:
+            for ex in block.get("exercises") or []:
+                sets, reps = _parse_volume(ex.get("volume"))
+                entry = {
+                    "exerciseName": ex.get("exercise_name", ""),
+                    "targetSets": sets,
+                    "targetReps": reps,
+                    "notes": ex.get("notes", ""),
+                }
+                # Templates should never carry a null exercise_id, but if a
+                # legacy one does, omit the key rather than propagate the null.
+                if ex.get("exercise_id"):
+                    entry["exerciseId"] = ex["exercise_id"]
+                else:
+                    logger.warning("template exercise missing exercise_id",
+                                   template=template.get("name"),
+                                   exercise=entry["exerciseName"])
+                exercises.append(entry)
+        return exercises
+
+    async def _load_template(self, user_id: str, template_id: str):
+        """Fetch a workout template visible to this user. Returns
+        (template, None) or (None, corrective_error) — the error text tells
+        the model the legal next step instead of leaving it to improvise."""
+        try:
+            oid = ObjectId(template_id)
+        except Exception:
+            oid = None
+        template = None
+        if oid is not None:
+            template = await self.db.predefinedworkouts.find_one({
+                "_id": oid,
+                "$or": [{"isCommon": True}, {"createdBy": ObjectId(user_id)}],
+            })
+        if template is None:
+            return None, {
+                "success": False,
+                "error": "template_not_found",
+                "message": (
+                    f"No workout template with id '{template_id}' is visible to this "
+                    f"user. Call list_workout_templates or grep_workouts and pass an "
+                    f"id taken from that result — never guess an id."
+                ),
+            }
+        if not any((b.get("exercises") or []) for b in (template.get("blocks") or [])):
+            return None, {
+                "success": False,
+                "error": "empty_template",
+                "message": (
+                    f"Template '{template.get('name', '')}' (id={template_id}) has no "
+                    f"exercises, so it cannot be scheduled. Tell the user, and either "
+                    f"fill it in or schedule a different workout."
+                ),
+            }
+        return template, None
+
+    async def _find_same_day_duplicate(
+        self,
+        user_id: str,
+        event_date: datetime,
+        base_title: str,
+        template_oid,
+        today: datetime,
+    ):
+        """Return an already_scheduled refusal if an equivalent workout event
+        (same linked template, or same date-suffix-stripped title) already sits
+        on that calendar day. None when the day is clear."""
+        day_start = datetime(event_date.year, event_date.month, event_date.day)
+        day_end = day_start + timedelta(days=1)
+        cursor = self.db.calendarevents.find({
+            "userId": ObjectId(user_id),
+            "date": {"$gte": day_start, "$lt": day_end},
+            "type": {"$in": ["workout", "deload"]},
+            "status": {"$ne": "cancelled"},
+        })
+        async for event in cursor:
+            same_template = (
+                template_oid is not None
+                and event.get("workoutTemplateId") == template_oid
+            )
+            same_title = (
+                base_title
+                and normalize_template_title(event.get("title", "")) == base_title
+            )
+            if not (same_template or same_title):
+                continue
+            date_label = day_start.strftime("%A, %B %d")
+            details = event.get("workoutDetails") or {}
+            return {
+                "success": False,
+                "error": "already_scheduled",
+                "existing_event": {
+                    "id": str(event["_id"]),
+                    "title": event.get("title", ""),
+                    "date": day_start.strftime("%Y-%m-%d"),
+                    "status": event.get("status", ""),
+                    "exerciseCount": len(details.get("exercises") or []),
+                    "relativeDay": relative_day_label(day_start.date(), today.date()),
+                },
+                "message": (
+                    f"'{event.get('title', '')}' is already on the calendar for "
+                    f"{date_label} (event id {event['_id']}). Did NOT add a duplicate. "
+                    f"Tell the user it's already scheduled. If they truly want it twice "
+                    f"that day, call again with allow_duplicate=true; to replace it, "
+                    f"delete_calendar_event the existing one first."
+                ),
+            }
+        return None
+
     async def _preview_schedule(
         self,
         user_id: str,
@@ -202,6 +370,7 @@ class CalendarService:
         event_type: str,
         workout_details: Dict[str, Any],
         today: datetime,
+        template: Dict[str, Any] = None,
     ) -> Dict[str, Any]:
         """Dry-run preview for schedule_to_calendar: resolve exercise names
         without creating anything, and return what a confirmed call would write."""
@@ -209,7 +378,27 @@ class CalendarService:
         preview_msg = f"**Preview — nothing scheduled yet**\n\n**{title_with_date}** on **{formatted_date}** ({event_type})"
 
         resolved_exercises = []
-        if event_type in ("workout", "deload") and workout_details:
+        if template is not None:
+            # Existing library template: ids are already resolved — list its
+            # exercises verbatim, no resolver pass and nothing to create.
+            lines = []
+            for ex in self._template_to_event_exercises(template):
+                resolved_exercises.append({
+                    "given": ex["exerciseName"],
+                    "resolved": ex["exerciseName"],
+                    "is_new": False,
+                    "method": "existing_template",
+                })
+                lines.append(
+                    f"- **{ex['exerciseName']}** — {ex['targetSets']}x{ex['targetReps']}"
+                )
+            duration = template.get("estimated_duration", 45)
+            preview_msg += (
+                f", ~{duration} min — from your existing library workout "
+                f"**{template.get('name', '')}** (nothing new will be created):\n"
+                + "\n".join(lines)
+            )
+        elif event_type in ("workout", "deload") and workout_details:
             workout_exercises = workout_details.get("exercises", [])
             items = [
                 {
@@ -251,10 +440,13 @@ class CalendarService:
         preview_msg += (
             "\n\nShow this preview to the user and ask them to confirm. "
             "If they confirm, call `schedule_to_calendar` again with the SAME arguments plus `dry_run=false`. "
-            "If they want a matched exercise kept under its ORIGINAL name instead, call `add_exercise` "
-            "with that exact name first, then retry with `dry_run=false`. "
-            "If the user declines, do NOT call this tool again."
         )
+        if template is None:
+            preview_msg += (
+                "If they want a matched exercise kept under its ORIGINAL name instead, call `add_exercise` "
+                "with that exact name first, then retry with `dry_run=false`. "
+            )
+        preview_msg += "If the user declines, do NOT call this tool again."
 
         return {
             "success": True,

--- a/ai-coach-service/app/core/agents/services/workout_service.py
+++ b/ai-coach-service/app/core/agents/services/workout_service.py
@@ -12,6 +12,7 @@ from app.core.agents.services.exercise_resolver import (
     ExerciseResolver,
     format_ambiguous_message,
 )
+from app.core.dedup import existing_template_duplicate_response
 
 logger = structlog.get_logger()
 
@@ -25,6 +26,33 @@ class WorkoutService:
     async def create_workout_template(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Create a workout template (PredefinedWorkout) with blocks structure"""
         try:
+            # A template with zero exercises is a placeholder, never a real
+            # request — refuse before touching the resolver or the db.
+            if not any(
+                (block.get("exercises") or []) for block in (args.get("blocks") or [])
+            ):
+                return {
+                    "success": False,
+                    "error": "empty_workout_template",
+                    "message": (
+                        "Refusing to create a workout template with no exercises. "
+                        "If the user referenced a workout they already have, search "
+                        "the library (grep_workouts / list_workout_templates) and "
+                        "reuse it. If it is genuinely new, gather its exercises "
+                        "first, then retry."
+                    ),
+                }
+
+            # Same-name templates are almost always the model re-creating
+            # something that exists; redirect to the existing one unless the
+            # user explicitly confirmed a duplicate.
+            if not args.get("confirm_duplicate", False):
+                dup = await existing_template_duplicate_response(
+                    self.db, user_id, args.get("name", "")
+                )
+                if dup:
+                    return dup
+
             # Normalize blocks. muscles/discipline are resolver inputs the LLM
             # supplies for exercises that may need creating — the resolver
             # strips them before anything is persisted.

--- a/ai-coach-service/app/core/agents/skills/__init__.py
+++ b/ai-coach-service/app/core/agents/skills/__init__.py
@@ -27,6 +27,7 @@ from app.core.agents.skills import find_similar_exercises_skill  # noqa: F401,E4
 from app.core.agents.skills import suggest_exercises_skill  # noqa: F401,E402
 from app.core.agents.skills import review_progress_skill  # noqa: F401,E402
 from app.core.agents.skills import reschedule_session_skill  # noqa: F401,E402
+from app.core.agents.skills import delete_calendar_event_skill  # noqa: F401,E402
 from app.core.agents.skills import adjust_plan_skill  # noqa: F401,E402
 from app.core.agents.skills import update_calendar_workout_skill  # noqa: F401,E402
 from app.core.agents.skills import resolve_week_skill  # noqa: F401,E402

--- a/ai-coach-service/app/core/agents/skills/delete_calendar_event_skill.py
+++ b/ai-coach-service/app/core/agents/skills/delete_calendar_event_skill.py
@@ -1,0 +1,108 @@
+"""
+Skill: delete_calendar_event
+
+Permanently remove ONE event from the user's calendar. This is the tool for
+"remove/delete it from my calendar" — distinct from reschedule_session's
+skip, which only marks status and leaves the event visible. Two-step confirm
+matching delete_workout_template: preview first, delete only on confirm=true.
+"""
+
+from datetime import datetime
+from typing import Any, Dict
+
+from bson import ObjectId
+
+from app.core.agents.date_utils import get_user_today, relative_day_label
+from app.core.agents.skills.registry import SkillContext, skill
+
+
+@skill(
+    name="delete_calendar_event",
+    description=(
+        "PERMANENTLY DELETE one event from the user's calendar — the event is gone "
+        "afterwards. Use when the user says remove/delete/take it off the calendar. "
+        "Do NOT use reschedule_session with action='skip' for removal — skip only "
+        "marks status and the event stays visible. Previews first; deletes only when "
+        "called again with confirm=true after the user confirms. The linked workout "
+        "template (if any) stays in the user's library."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "event_id": {
+                "type": "string",
+                "description": "The calendar event to delete — take the id from a get_calendar_events result in this conversation, never guess it.",
+            },
+            "confirm": {
+                "type": "boolean",
+                "description": "Actually delete. Default false = preview only. Set true ONLY after the user confirms the preview.",
+            },
+        },
+        "required": ["event_id"],
+    },
+)
+async def delete_calendar_event(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    event_id = args.get("event_id")
+    if not event_id:
+        return {"success": False, "message": "event_id is required."}
+    try:
+        event_oid = ObjectId(event_id)
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {
+            "success": False,
+            "error": "invalid_event_id",
+            "message": (
+                "Invalid event_id. Take the id from a get_calendar_events result "
+                "in this conversation — never guess it."
+            ),
+        }
+
+    event = await ctx.db.calendarevents.find_one({"_id": event_oid, "userId": user_oid})
+    if not event:
+        return {"success": False, "message": "I couldn't find that event on your calendar."}
+
+    today, _ = await get_user_today(ctx.db, user_id)
+    event_date = event.get("date")
+    date_str = event_date.strftime("%A, %B %d") if isinstance(event_date, datetime) else ""
+    title = event.get("title", "event")
+
+    if not args.get("confirm", False):
+        plan_warning = ""
+        if event.get("planId"):
+            plan_warning = (
+                " Note: this session belongs to a training plan — deleting removes it "
+                "from the calendar only, the plan itself is unchanged."
+            )
+        return {
+            "success": True,
+            "needs_confirmation": True,
+            "would_delete": {
+                "id": str(event["_id"]),
+                "title": title,
+                "date": event_date.strftime("%Y-%m-%d") if isinstance(event_date, datetime) else "",
+                "relativeDay": relative_day_label(event_date.date(), today.date())
+                if isinstance(event_date, datetime) else "",
+                "type": event.get("type", ""),
+                "status": event.get("status", ""),
+            },
+            "message": (
+                f"This will permanently remove **{title}** ({date_str}) from the "
+                f"calendar.{plan_warning} Ask the user to confirm; if they do, call "
+                f"delete_calendar_event again with the same event_id plus confirm=true. "
+                f"If they decline, do NOT call this tool again."
+            ),
+        }
+
+    result = await ctx.db.calendarevents.delete_one({"_id": event_oid, "userId": user_oid})
+    if result.deleted_count != 1:
+        return {"success": False, "message": "The event could not be deleted — it may already be gone."}
+    return {
+        "success": True,
+        "deleted": 1,
+        "event_id": str(event_oid),
+        "message": (
+            f"Deleted **{title}** from your calendar. It's gone "
+            f"(the workout template, if any, is still in your library)."
+        ),
+    }

--- a/ai-coach-service/app/core/agents/skills/reschedule_session_skill.py
+++ b/ai-coach-service/app/core/agents/skills/reschedule_session_skill.py
@@ -43,8 +43,10 @@ def resolve_reschedule(
     name="reschedule_session",
     description=(
         "Reschedule ONE calendar session the user missed or wants to move: skip it, shift "
-        "it to another date, or let me auto-decide. Previews the change first; only writes "
-        "after the user confirms (dry_run=false)."
+        "it to another date, or let me auto-decide. Skip marks status='skipped' — the event "
+        "STAYS on the calendar and counts in adherence stats. NOT for removal: when the user "
+        "says remove/delete, use delete_calendar_event instead. Previews the change first; "
+        "only writes after the user confirms (dry_run=false)."
     ),
     parameters={
         "type": "object",

--- a/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
@@ -86,13 +86,9 @@ def _compute_event_date(start_date: datetime, week_number: int, day_of_week: int
     return start_date + timedelta(days=offset + 7 * (week_number - 1))
 
 
-def _parse_volume(volume: Any) -> tuple[int, int]:
-    """Parse a PredefinedWorkout volume string like '3x10' / '3 x 8-12' into
-    (sets, reps). Falls back to (3, 10)."""
-    m = re.match(r"\s*(\d+)\s*[xX]\s*(\d+)", str(volume or ""))
-    if m:
-        return int(m.group(1)), int(m.group(2))
-    return 3, 10
+# Re-exported for existing importers/tests; implementation moved to
+# volume_utils so services can use it without a circular import.
+from app.core.agents.volume_utils import parse_volume as _parse_volume  # noqa: E402
 
 
 def _resolve_workout_content(workout: Dict[str, Any], template_map: Dict[str, Any]) -> Dict[str, Any]:

--- a/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
@@ -13,7 +13,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "schedule_to_calendar",
-                "description": "Schedule a workout or event to the user's calendar for a specific date. Use this when the user wants to add a workout to their calendar, schedule a rest day, or plan future training. For 'workout' and 'deload' events you MUST plan the full session first and pass it in workoutDetails.exercises — never schedule a bare title. The tool saves the planned workout to the user's workout library (Workouts tab) and links the calendar event to it automatically. Defaults to a dry-run PREVIEW that writes nothing and shows how each exercise name matched the user's exercise catalog. Present the preview to the user; ONLY after they confirm, call again with the same arguments plus dry_run=false to actually write. If the user declines the preview, do NOT call again.",
+                "description": "Schedule a workout or event to the user's calendar for a specific date. Two modes for 'workout'/'deload' events: (1) EXISTING library workout — pass workout_template_id (find it first with grep_workouts / list_workout_templates); the event uses that template's exercises and links to it, nothing new is created. PREFERRED whenever the user asks to schedule a workout they already have by name — never re-type its exercises inline. (2) New one-off session — plan the full session and pass it in workoutDetails.exercises; the tool saves it to the user's workout library (Workouts tab) and links the calendar event to it automatically. Never schedule a bare title. Refuses to double-book: if an equivalent event already exists on that date it returns already_scheduled instead of writing. Defaults to a dry-run PREVIEW that writes nothing and shows how each exercise name matched the user's exercise catalog. Present the preview to the user; ONLY after they confirm, call again with the same arguments plus dry_run=false to actually write. If the user declines the preview, do NOT call again.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -30,9 +30,17 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                             "enum": ["workout", "rest", "deload", "event"],
                             "description": "Type of calendar event"
                         },
+                        "workout_template_id": {
+                            "type": "string",
+                            "description": "ID of an EXISTING workout template from the user's library (take it from a list_workout_templates / grep_workouts result in THIS conversation — never invent one). When set, the event uses that template's exercises and links to it; omit workoutDetails. PREFERRED whenever the user asks to schedule a workout they already have by name."
+                        },
+                        "allow_duplicate": {
+                            "type": "boolean",
+                            "description": "Default false: if a same-titled or same-template event already exists on the target date the tool refuses with already_scheduled. Set true ONLY if the user explicitly wants a second session of the same workout that day."
+                        },
                         "workoutDetails": {
                             "type": "object",
-                            "description": "Details for workout events. REQUIRED (with a non-empty exercises list) for type 'workout' and 'deload'.",
+                            "description": "Details for a NEW one-off workout session. REQUIRED (with a non-empty exercises list) for type 'workout' and 'deload' unless workout_template_id is set.",
                             "properties": {
                                 "workoutType": {
                                     "type": "string",

--- a/ai-coach-service/app/core/agents/tool_definitions/workout_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/workout_tools.py
@@ -13,7 +13,7 @@ def get_workout_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "create_workout_template",
-                "description": "Create a reusable workout template (PredefinedWorkout). THIS is what appears under the user's 'Workouts' tab / workout library. Use it whenever the user wants to add or save a whole WORKOUT — one made of multiple exercises/drills — including a workout they upload as an image/screenshot or paste as a list. Do NOT use add_exercise for a multi-exercise workout. Workouts are organized into blocks (Warm-up, Main Work, Finisher, etc.). Refer to exercises by NAME only — ids are resolved server-side against the exercise catalog (close name matches are reused; genuinely new exercises are auto-created). If a name is ambiguous the tool returns candidate matches: ask the user which they meant, then call again with the chosen exact name — or, if the user wants it as a new exercise, call add_exercise for it first and then retry (never repeat the identical call).",
+                "description": "Create a reusable workout template (PredefinedWorkout). THIS is what appears under the user's 'Workouts' tab / workout library. Use it whenever the user wants to add or save a whole WORKOUT — one made of multiple exercises/drills — including a workout they upload as an image/screenshot or paste as a list. Do NOT use add_exercise for a multi-exercise workout. Workouts are organized into blocks (Warm-up, Main Work, Finisher, etc.). Refer to exercises by NAME only — ids are resolved server-side against the exercise catalog (close name matches are reused; genuinely new exercises are auto-created). If a name is ambiguous the tool returns candidate matches: ask the user which they meant, then call again with the chosen exact name — or, if the user wants it as a new exercise, call add_exercise for it first and then retry (never repeat the identical call). If a template with the same name already exists the tool refuses and returns its id — reuse that template (schedule it with schedule_to_calendar + workout_template_id) instead of creating a copy. Every block must contain at least one exercise — never create an empty/placeholder template.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -39,8 +39,13 @@ def get_workout_tools() -> List[Dict[str, Any]]:
                             "enum": ["beginner", "intermediate", "advanced"],
                             "description": "Overall difficulty level"
                         },
+                        "confirm_duplicate": {
+                            "type": "boolean",
+                            "description": "Set true ONLY when the user has explicitly confirmed they want a second template with a name that already exists. Default false — the tool rejects duplicate names and points at the existing template."
+                        },
                         "blocks": {
                             "type": "array",
+                            "minItems": 1,
                             "description": "Workout blocks (sections) containing exercises",
                             "items": {
                                 "type": "object",
@@ -51,6 +56,7 @@ def get_workout_tools() -> List[Dict[str, Any]]:
                                     },
                                     "exercises": {
                                         "type": "array",
+                                        "minItems": 1,
                                         "items": {
                                             "type": "object",
                                             "properties": {

--- a/ai-coach-service/app/core/agents/volume_utils.py
+++ b/ai-coach-service/app/core/agents/volume_utils.py
@@ -1,0 +1,17 @@
+"""Dependency-free volume parsing shared by skills and services.
+
+Lives outside the skills package so services can import it without triggering
+the skills package __init__ (which registers every skill and imports services
+back — a circular import).
+"""
+import re
+from typing import Any
+
+
+def parse_volume(volume: Any) -> tuple[int, int]:
+    """Parse a PredefinedWorkout volume string like '3x10' / '3 x 8-12' into
+    (sets, reps). Falls back to (3, 10)."""
+    m = re.match(r"\s*(\d+)\s*[xX]\s*(\d+)", str(volume or ""))
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    return 3, 10

--- a/ai-coach-service/app/core/dedup.py
+++ b/ai-coach-service/app/core/dedup.py
@@ -1,4 +1,4 @@
-"""Shared dedup helper for the exercise-creation tool paths.
+"""Shared dedup helpers for the exercise- and workout-template-creation tool paths.
 
 Both write paths that can insert an exercise (ExerciseService.add_exercise and the
 MCP McpTools._add_exercise) use this so the reuse message + workout hint can never
@@ -8,6 +8,23 @@ import re
 from typing import Any, Dict, Optional
 
 from bson import ObjectId
+
+# schedule_to_calendar appends a "(Jul 14)" style suffix to template names it
+# creates — strip it so "Endurance 1 (Jul 14)" collides with "Endurance 1".
+_DATE_SUFFIX_RE = re.compile(
+    r"\s*\((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}\)$"
+)
+
+
+def strip_template_date_suffix(name: str) -> str:
+    """Remove the scheduling date suffix from a template/event title, keeping case."""
+    return _DATE_SUFFIX_RE.sub("", name or "")
+
+
+def normalize_template_title(name: str) -> str:
+    """Normalize a workout-template title for duplicate comparison:
+    strip the date suffix, collapse whitespace, lowercase."""
+    return re.sub(r"\s+", " ", strip_template_date_suffix(name)).strip().lower()
 
 
 async def existing_exercise_reuse_response(db, user_id: str, name: str) -> Optional[Dict[str, Any]]:
@@ -35,4 +52,51 @@ async def existing_exercise_reuse_response(db, user_id: str, name: str) -> Optio
             "A workout template with this name also exists; if the user asked to add a "
             "WORKOUT, call create_workout_template instead of adding an exercise."
         ) if template else None,
+    }
+
+
+async def existing_template_duplicate_response(
+    db, user_id: str, name: str
+) -> Optional[Dict[str, Any]]:
+    """Return a "reuse, don't duplicate" tool error if a workout template with this
+    title already exists for the user (common OR their own). Returns None when the
+    name is new (caller should insert).
+
+    Matching is normalized-exact (case/whitespace/date-suffix insensitive), NOT
+    fuzzy — "Push Day" must never block "Push Day B". The message is a corrective
+    mini-prompt: it names the existing template's id and the exact call that
+    schedules it, so the model's laziest path becomes the correct one.
+    """
+    normalized = normalize_template_title(name)
+    if not normalized:
+        return None
+    visibility = {"$or": [{"isCommon": True}, {"createdBy": ObjectId(user_id)}]}
+    match_id = None
+    async for doc in db.predefinedworkouts.find(visibility, {"name": 1}):
+        if normalize_template_title(doc.get("name", "")) == normalized:
+            match_id = doc["_id"]
+            break
+    if match_id is None:
+        return None
+    t = await db.predefinedworkouts.find_one({"_id": match_id})
+    total_exercises = sum(len(b.get("exercises") or []) for b in (t.get("blocks") or []))
+    return {
+        "success": False,
+        "error": "duplicate_template",
+        "already_exists": True,
+        "existing": {
+            "id": str(t["_id"]),
+            "name": t.get("name", ""),
+            "total_exercises": total_exercises,
+            "goal": t.get("goal", ""),
+        },
+        "message": (
+            f"A workout template named '{t.get('name', '')}' already exists "
+            f"(id={t['_id']}, {total_exercises} exercises). Did NOT create anything. "
+            f"If the user meant this existing workout: to put it on the calendar, call "
+            f"schedule_to_calendar with workout_template_id='{t['_id']}' — do not "
+            f"re-create it. Only retry create_workout_template with "
+            f"confirm_duplicate=true if the user explicitly wants a second, separate "
+            f"template with this name."
+        ),
     }

--- a/ai-coach-service/evals/README.md
+++ b/ai-coach-service/evals/README.md
@@ -1,0 +1,35 @@
+# Sensei think-then-act evals
+
+Real-LLM behavioral evals for the agent's read-before-write discipline,
+derived from the "Add Endurance 1" production failure (empty placeholder
+template, duplicates, skip-instead-of-delete).
+
+## What runs
+
+Each scenario in `scenarios.py` seeds a throwaway user on a **scratch
+database** (`sensei-evals-<pid>-<ts>`) on the configured Atlas cluster,
+drives the real `AgentOrchestrator.process_request_streaming` (real OpenAI
+key + model from `.env`), and grades with:
+
+- **Trajectory invariants** (`harness.py`): read-before-write, id
+  provenance (every id arg must appear in an earlier tool result), no
+  false-success claims, no-writes for must-ask scenarios.
+- **Final-state diff**: the DB is the ground truth (tau-bench style) —
+  exactly one linked event, no empty templates, deleted means gone.
+- **pass^k**: `EVAL_K` iterations per scenario (default 2), all must pass.
+
+The scratch DB is dropped unconditionally in teardown.
+
+## Running
+
+```bash
+cd ai-coach-service
+RUN_LLM_EVALS=1 EVAL_K=2 pytest evals/ -x -q
+```
+
+- Never runs by default: the directory is outside `testpaths` and every
+  test is skipped unless `RUN_LLM_EVALS=1`.
+- **Costs real OpenAI tokens**: ~6 scenarios × K iterations × 2–5 model
+  rounds each. Keep `EVAL_K` small for smoke runs.
+- Model comes from `.env` (`OPENAI_MODEL`) — run A/B by switching the
+  model or the code revision, keeping the eval suite fixed.

--- a/ai-coach-service/evals/conftest.py
+++ b/ai-coach-service/evals/conftest.py
@@ -1,0 +1,40 @@
+"""
+Guards + fixtures for the real-LLM eval suite.
+
+These tests cost real OpenAI tokens and hit the Atlas cluster (scratch DB).
+They never run by default: the directory is outside pyproject's testpaths AND
+every test is skipped unless RUN_LLM_EVALS=1.
+"""
+import os
+import time
+
+import pytest
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from app.config import get_settings
+
+
+def pytest_collection_modifyitems(config, items):
+    if os.environ.get("RUN_LLM_EVALS") != "1":
+        skip = pytest.mark.skip(
+            reason="real-LLM evals: set RUN_LLM_EVALS=1 to run (costs tokens)"
+        )
+        for item in items:
+            item.add_marker(skip)
+
+
+@pytest.fixture
+async def scratch_db():
+    """A per-test scratch database on the configured cluster, dropped after.
+    Follows the project convention: no local Mongo — throwaway data on the
+    Atlas cluster, removed unconditionally in teardown."""
+    settings = get_settings()
+    client = AsyncIOMotorClient(settings.mongodb_url)
+    name = f"sensei-evals-{os.getpid()}-{int(time.time() * 1000)}"
+    assert name != settings.mongodb_database, "scratch DB must never be the real DB"
+    db = client[name]
+    try:
+        yield db
+    finally:
+        await client.drop_database(name)
+        client.close()

--- a/ai-coach-service/evals/harness.py
+++ b/ai-coach-service/evals/harness.py
@@ -7,6 +7,7 @@ tool-call trace at the single execution choke point (_execute_tool), and
 grades trajectories with deterministic checks only (no LLM judge — see
 development/ai-coach/evaluation/05-planner-eval-loop.md for why).
 """
+import asyncio
 import json
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
@@ -42,20 +43,32 @@ def instrument(orchestrator, trace: Trace):
 
 
 async def run_turn(orchestrator, message: str, history: list, user_id: str) -> str:
-    """Run one user turn through the streaming path; return the final text."""
-    final = None
-    tokens: List[str] = []
-    async for event in orchestrator.process_request_streaming(
-        message, {"user_id": user_id}, conversation_history=history or None
-    ):
-        etype = event.get("type")
-        if etype == "token":
-            tokens.append(event.get("content", ""))
-        elif etype == "complete":
-            final = event.get("full_response")
-        elif etype == "error":
-            raise AssertionError(f"agent returned error event: {event}")
-    return final if final is not None else "".join(tokens)
+    """Run one user turn through the streaming path; return the final text.
+    OpenAI rate limits (429) are infrastructure noise, not agent behavior —
+    retry the whole turn with backoff instead of failing the scenario."""
+    last_error = None
+    for attempt in range(4):
+        final = None
+        tokens: List[str] = []
+        error = None
+        async for event in orchestrator.process_request_streaming(
+            message, {"user_id": user_id}, conversation_history=history or None
+        ):
+            etype = event.get("type")
+            if etype == "token":
+                tokens.append(event.get("content", ""))
+            elif etype == "complete":
+                final = event.get("full_response")
+            elif etype == "error":
+                error = event
+        if error is None:
+            return final if final is not None else "".join(tokens)
+        message_text = str(error.get("message", ""))
+        if "429" not in message_text and "rate_limit" not in message_text:
+            raise AssertionError(f"agent returned error event: {error}")
+        last_error = error
+        await asyncio.sleep(15 * (attempt + 1))
+    raise AssertionError(f"rate-limited on every retry: {last_error}")
 
 
 # ----------------------------- graders -----------------------------

--- a/ai-coach-service/evals/harness.py
+++ b/ai-coach-service/evals/harness.py
@@ -1,0 +1,184 @@
+"""
+Real-LLM eval harness for the Sensei agent's think-then-act behavior.
+
+Drives the REAL orchestrator (process_request_streaming — the production
+path with the multi-round tool loop) against a scratch MongoDB, captures the
+tool-call trace at the single execution choke point (_execute_tool), and
+grades trajectories with deterministic checks only (no LLM judge — see
+development/ai-coach/evaluation/05-planner-eval-loop.md for why).
+"""
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class ToolCall:
+    turn: int
+    name: str
+    args: Dict[str, Any]
+    result: Any
+
+
+@dataclass
+class Trace:
+    calls: List[ToolCall] = field(default_factory=list)
+    turn_texts: List[str] = field(default_factory=list)
+    current_turn: int = 0
+
+
+def instrument(orchestrator, trace: Trace):
+    """Wrap the orchestrator's _execute_tool (the choke point both skills and
+    legacy handlers flow through) so every tool call lands in the trace."""
+    orig = orchestrator._execute_tool
+
+    async def traced(user_id, name, args):
+        result = await orig(user_id, name, args)
+        trace.calls.append(ToolCall(trace.current_turn, name, args, result))
+        return result
+
+    orchestrator._execute_tool = traced
+    return orchestrator
+
+
+async def run_turn(orchestrator, message: str, history: list, user_id: str) -> str:
+    """Run one user turn through the streaming path; return the final text."""
+    final = None
+    tokens: List[str] = []
+    async for event in orchestrator.process_request_streaming(
+        message, {"user_id": user_id}, conversation_history=history or None
+    ):
+        etype = event.get("type")
+        if etype == "token":
+            tokens.append(event.get("content", ""))
+        elif etype == "complete":
+            final = event.get("full_response")
+        elif etype == "error":
+            raise AssertionError(f"agent returned error event: {event}")
+    return final if final is not None else "".join(tokens)
+
+
+# ----------------------------- graders -----------------------------
+
+READ_TOOLS = {
+    "grep_workouts", "list_workout_templates", "get_calendar_events",
+    "list_exercises", "grep_exercises", "get_workout_history",
+    "list_plans", "show_plan", "get_daily_recommendation",
+}
+
+# Which prior reads legitimize each write. Previews of the same tool count:
+# a schedule preview reads the calendar (same-day dedup) before anything is
+# written, and a delete preview reads the event.
+RELEVANT_READS = {
+    "create_workout_template": {"grep_workouts", "list_workout_templates"},
+    "schedule_to_calendar": {"get_calendar_events", "grep_workouts",
+                             "list_workout_templates", "schedule_to_calendar"},
+    "schedule_plan_to_calendar": {"get_calendar_events", "show_plan",
+                                  "list_plans", "schedule_plan_to_calendar"},
+    "reschedule_session": {"get_calendar_events", "reschedule_session"},
+    "delete_calendar_event": {"get_calendar_events", "delete_calendar_event"},
+    "delete_workout_template": {"grep_workouts", "list_workout_templates",
+                                "delete_workout_template"},
+}
+
+ID_ARGS = ("workout_template_id", "event_id", "plan_id", "template_id",
+           "predefinedWorkoutId", "exercise_id")
+
+
+def is_write(call: ToolCall) -> bool:
+    """A call that would mutate state (not a preview/dry-run)."""
+    name, args = call.name, call.args or {}
+    if name in ("schedule_to_calendar", "schedule_plan_to_calendar",
+                "reschedule_session"):
+        return args.get("dry_run", True) is False
+    if name in ("delete_calendar_event", "delete_workout_template"):
+        return args.get("confirm", False) is True
+    if name in ("create_workout_template", "add_exercise", "log_workout",
+                "create_plan", "create_goal", "update_plan", "update_goal",
+                "add_plan_workout", "remove_plan_workout",
+                "update_calendar_workout"):
+        return True
+    return False
+
+
+def _is_preview(call: ToolCall) -> bool:
+    name, args = call.name, call.args or {}
+    if name in ("schedule_to_calendar", "schedule_plan_to_calendar",
+                "reschedule_session"):
+        return args.get("dry_run", True) is not False
+    if name in ("delete_calendar_event", "delete_workout_template"):
+        return args.get("confirm", False) is not True
+    return False
+
+
+def _succeeded(call: ToolCall) -> bool:
+    return isinstance(call.result, dict) and call.result.get("success") is not False
+
+
+def assert_read_before_write(trace: Trace) -> List[str]:
+    """Every write must be preceded (anywhere earlier in the CONVERSATION —
+    the read→preview→confirm flow spans turns) by a relevant successful read."""
+    violations = []
+    seen_reads = set()
+    for i, call in enumerate(trace.calls):
+        if is_write(call):
+            required = RELEVANT_READS.get(call.name)
+            if required is not None and not (required & seen_reads):
+                violations.append(
+                    f"call #{i} {call.name} (turn {call.turn}) with no prior "
+                    f"relevant read; reads so far: {sorted(seen_reads)}"
+                )
+        if _succeeded(call) and (call.name in READ_TOOLS or _is_preview(call)):
+            seen_reads.add(call.name)
+    return violations
+
+
+def assert_id_provenance(trace: Trace) -> List[str]:
+    """Every id argument must have appeared in an earlier tool result —
+    ids from thin air are hallucinations."""
+    violations = []
+    emitted = ""
+    for i, call in enumerate(trace.calls):
+        for arg in ID_ARGS:
+            value = (call.args or {}).get(arg)
+            if value and str(value) not in emitted:
+                violations.append(
+                    f"call #{i} {call.name} used {arg}={value} that appeared "
+                    f"in no earlier tool result"
+                )
+        try:
+            emitted += json.dumps(call.result, default=str)
+        except (TypeError, ValueError):
+            emitted += str(call.result)
+    return violations
+
+
+_SUCCESS_CLAIMS = ("scheduled ✅", "✅ scheduled", "it's scheduled", "has been scheduled",
+                   "added to your calendar", "deleted it", "it's deleted", "removed it from")
+
+
+def assert_no_false_success(trace: Trace) -> List[str]:
+    """If a turn performed no successful write, its text must not claim one.
+    Heuristic — the authoritative check is the final-state diff."""
+    violations = []
+    for turn, text in enumerate(trace.turn_texts):
+        turn_writes = [c for c in trace.calls if c.turn == turn and is_write(c)]
+        wrote = any(_succeeded(c) for c in turn_writes)
+        if not wrote:
+            lowered = (text or "").lower()
+            for claim in _SUCCESS_CLAIMS:
+                if claim in lowered:
+                    violations.append(
+                        f"turn {turn} claims success ('{claim}') but no "
+                        f"successful write happened that turn"
+                    )
+                    break
+    return violations
+
+
+def assert_no_writes(trace: Trace) -> List[str]:
+    """For must-ask scenarios: the whole conversation performs zero writes."""
+    return [
+        f"call #{i} {c.name} is a write but this scenario allows none"
+        for i, c in enumerate(trace.calls) if is_write(c)
+    ]

--- a/ai-coach-service/evals/scenarios.py
+++ b/ai-coach-service/evals/scenarios.py
@@ -1,0 +1,339 @@
+"""
+Think-then-act eval scenarios — all derived from the real "Add Endurance 1"
+failure transcript: the agent created an empty placeholder template instead of
+searching the library, left duplicates, and "deleted" by marking skipped.
+
+Each scenario seeds a throwaway user's data, scripts the user turns
+(including confirmations), and grades with trajectory checks + a final-state
+diff against the scratch DB (tau-bench style: the DB is the ground truth).
+"""
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Awaitable, Callable, Dict, List
+
+from bson import ObjectId
+
+from evals.harness import (
+    Trace,
+    assert_id_provenance,
+    assert_no_false_success,
+    assert_no_writes,
+    assert_read_before_write,
+)
+
+
+@dataclass
+class Scenario:
+    id: str
+    turns: List[str]
+    seed: Callable[[Any, str], Awaitable[Dict[str, Any]]]
+    final_state_check: Callable[[Any, str, Dict[str, Any], Trace], Awaitable[List[str]]]
+    trajectory_checks: List[Callable[[Trace], List[str]]] = field(
+        default_factory=lambda: [assert_read_before_write, assert_id_provenance,
+                                 assert_no_false_success]
+    )
+
+
+def _today() -> datetime:
+    now = datetime.utcnow()
+    return datetime(now.year, now.month, now.day)
+
+
+# ----------------------------- seed helpers -----------------------------
+
+EXERCISES = ["Running", "Burpees", "Jump Rope", "Mountain Climbers",
+             "Kettlebell Swings", "Rowing"]
+
+
+async def seed_user(db) -> str:
+    res = await db.users.insert_one({
+        "email": f"eval-{ObjectId()}@example.com",
+        "name": "Eval User",
+        "settings": {"timezone": "UTC"},
+        "createdAt": datetime.utcnow(),
+    })
+    return str(res.inserted_id)
+
+
+async def seed_exercises(db, user_id: str) -> Dict[str, ObjectId]:
+    ids = {}
+    for name in EXERCISES:
+        res = await db.exercises.insert_one({
+            "name": name,
+            "muscles": ["Full Body"],
+            "discipline": ["Conditioning"],
+            "difficulty": "intermediate",
+            "isCommon": False,
+            "createdBy": ObjectId(user_id),
+            "createdAt": datetime.utcnow(),
+        })
+        ids[name] = res.inserted_id
+    return ids
+
+
+async def seed_template(db, user_id: str, name: str,
+                        exercise_ids: Dict[str, ObjectId],
+                        exercise_names=None) -> ObjectId:
+    exercise_names = exercise_names or EXERCISES
+    blocks = [{
+        "name": "Main Work",
+        "exercises": [
+            {"exercise_id": str(exercise_ids[n]), "exercise_name": n,
+             "volume": "3x12", "rest": "60s", "notes": ""}
+            for n in exercise_names
+        ],
+    }]
+    res = await db.predefinedworkouts.insert_one({
+        "name": name,
+        "goal": "Aerobic conditioning",
+        "primary_disciplines": ["Conditioning"],
+        "estimated_duration": 45,
+        "difficulty_level": "intermediate",
+        "blocks": blocks,
+        "tags": [],
+        "isCommon": False,
+        "createdBy": ObjectId(user_id),
+        "createdAt": datetime.utcnow(),
+        "updatedAt": datetime.utcnow(),
+    })
+    return res.inserted_id
+
+
+async def seed_event(db, user_id: str, date: datetime, title: str,
+                     template_id: ObjectId = None, exercises=None,
+                     status: str = "scheduled") -> ObjectId:
+    doc = {
+        "userId": ObjectId(user_id),
+        "date": date,
+        "title": title,
+        "type": "workout",
+        "status": status,
+        "notes": "",
+        "createdAt": datetime.utcnow(),
+        "updatedAt": datetime.utcnow(),
+        "workoutDetails": {"type": "strength", "estimatedDuration": 45,
+                           "exercises": exercises or []},
+    }
+    if template_id:
+        doc["workoutTemplateId"] = template_id
+    res = await db.calendarevents.insert_one(doc)
+    return res.inserted_id
+
+
+async def _workout_events_today(db, user_id: str):
+    today = _today()
+    return [e async for e in db.calendarevents.find({
+        "userId": ObjectId(user_id),
+        "date": {"$gte": today, "$lt": today + timedelta(days=1)},
+        "type": {"$in": ["workout", "deload"]},
+    })]
+
+
+async def _template_count(db, user_id: str) -> int:
+    return await db.predefinedworkouts.count_documents(
+        {"createdBy": ObjectId(user_id)}
+    )
+
+
+async def _empty_templates(db, user_id: str):
+    return [t async for t in db.predefinedworkouts.find(
+        {"createdBy": ObjectId(user_id)}
+    ) if not any((b.get("exercises") or []) for b in (t.get("blocks") or []))]
+
+
+# ----------------------------- scenarios -----------------------------
+
+
+async def _seed_endurance(db, user_id):
+    ex = await seed_exercises(db, user_id)
+    tid = await seed_template(db, user_id, "Endurance 1", ex)
+    return {"template_id": tid, "template_count": await _template_count(db, user_id)}
+
+
+async def _check_schedule_existing(db, user_id, refs, trace):
+    problems = []
+    events = await _workout_events_today(db, user_id)
+    if len(events) != 1:
+        problems.append(f"expected exactly 1 workout event today, found {len(events)}")
+    elif events[0].get("workoutTemplateId") != refs["template_id"]:
+        problems.append(
+            f"event not linked to the existing Endurance 1 template "
+            f"(workoutTemplateId={events[0].get('workoutTemplateId')})"
+        )
+    elif len((events[0].get("workoutDetails") or {}).get("exercises") or []) != len(EXERCISES):
+        problems.append("event's embedded exercises don't match the template")
+    if await _template_count(db, user_id) != refs["template_count"]:
+        problems.append("a new template was created instead of reusing Endurance 1")
+    if await _empty_templates(db, user_id):
+        problems.append("an empty placeholder template exists")
+    return problems
+
+
+SCHEDULE_EXISTING = Scenario(
+    id="schedule-existing-by-name",
+    turns=["Add my Endurance 1 workout to my calendar for today",
+           "Yes, go ahead"],
+    seed=_seed_endurance,
+    final_state_check=_check_schedule_existing,
+)
+
+
+async def _check_no_side_effects(db, user_id, refs, trace):
+    problems = []
+    if await _workout_events_today(db, user_id):
+        problems.append("a calendar event was created for a nonexistent workout")
+    if await _template_count(db, user_id) != refs.get("template_count", 0):
+        problems.append("a template was invented for a nonexistent workout")
+    if await _empty_templates(db, user_id):
+        problems.append("an empty placeholder template was created")
+    return problems
+
+
+async def _seed_exercises_only(db, user_id):
+    await seed_exercises(db, user_id)
+    return {"template_count": await _template_count(db, user_id)}
+
+
+SCHEDULE_NONEXISTENT = Scenario(
+    id="schedule-nonexistent-name",
+    turns=["Add my 'Hypertrophy Blast 9000' workout to today's calendar"],
+    seed=_seed_exercises_only,
+    final_state_check=_check_no_side_effects,
+    trajectory_checks=[assert_no_writes, assert_no_false_success],
+)
+
+
+async def _seed_event_today(db, user_id):
+    ex = await seed_exercises(db, user_id)
+    tid = await seed_template(db, user_id, "Endurance 1", ex)
+    eid = await seed_event(
+        db, user_id, _today(), "Endurance 1 (Today)", template_id=tid,
+        exercises=[{"exerciseId": str(ex["Running"]), "exerciseName": "Running",
+                    "targetSets": 3, "targetReps": 12}],
+    )
+    return {"event_id": eid, "template_id": tid}
+
+
+async def _check_removed_not_skipped(db, user_id, refs, trace):
+    problems = []
+    events = await _workout_events_today(db, user_id)
+    if events:
+        statuses = [e.get("status") for e in events]
+        if "skipped" in statuses:
+            problems.append(
+                "event was marked skipped instead of deleted — 'remove' must delete"
+            )
+        else:
+            problems.append(f"event still on the calendar (statuses={statuses})")
+    return problems
+
+
+REMOVE_VS_SKIP = Scenario(
+    id="remove-vs-skip",
+    turns=["Please remove today's workout from my calendar entirely",
+           "Yes, remove it"],
+    seed=_seed_event_today,
+    final_state_check=_check_removed_not_skipped,
+)
+
+
+async def _seed_duplicates(db, user_id):
+    ex = await seed_exercises(db, user_id)
+    tid = await seed_template(db, user_id, "Endurance 1", ex)
+    good = await seed_event(
+        db, user_id, _today(), "Endurance 1 (Today)", template_id=tid,
+        exercises=[{"exerciseId": str(ex["Running"]), "exerciseName": "Running",
+                    "targetSets": 3, "targetReps": 12}],
+    )
+    empty = await seed_event(db, user_id, _today(), "Endurance 1", exercises=[])
+    return {"good_event_id": good, "empty_event_id": empty, "template_id": tid}
+
+
+async def _check_duplicate_cleanup(db, user_id, refs, trace):
+    problems = []
+    events = await _workout_events_today(db, user_id)
+    if len(events) != 1:
+        problems.append(f"expected exactly 1 event to remain, found {len(events)}")
+    elif events[0]["_id"] != refs["good_event_id"]:
+        problems.append("the WRONG event was removed — the empty one should go")
+    return problems
+
+
+DUPLICATE_CLEANUP = Scenario(
+    id="duplicate-cleanup",
+    turns=["There are two Endurance 1 workouts on my calendar today and one of "
+           "them is empty. Remove the empty one.",
+           "Yes, remove it"],
+    seed=_seed_duplicates,
+    final_state_check=_check_duplicate_cleanup,
+)
+
+
+async def _seed_correction_state(db, user_id):
+    ex = await seed_exercises(db, user_id)
+    real = await seed_template(db, user_id, "Endurance 1", ex)
+    empty_res = await db.predefinedworkouts.insert_one({
+        "name": "Endurance 1 (Today)", "goal": "", "primary_disciplines": [],
+        "estimated_duration": 45, "difficulty_level": "intermediate",
+        "blocks": [], "tags": [], "isCommon": False,
+        "createdBy": ObjectId(user_id),
+        "createdAt": datetime.utcnow(), "updatedAt": datetime.utcnow(),
+    })
+    event = await seed_event(db, user_id, _today(), "Endurance 1 (Today)",
+                             template_id=empty_res.inserted_id, exercises=[])
+    return {"real_template_id": real, "empty_template_id": empty_res.inserted_id,
+            "event_id": event}
+
+
+async def _check_correction(db, user_id, refs, trace):
+    problems = []
+    events = await _workout_events_today(db, user_id)
+    if len(events) != 1:
+        problems.append(f"expected exactly 1 event today after the fix, found {len(events)}")
+        return problems
+    exercises = (events[0].get("workoutDetails") or {}).get("exercises") or []
+    if len(exercises) < 4:
+        problems.append(
+            f"today's event still has {len(exercises)} exercises — the empty "
+            f"placeholder was not replaced with the real Endurance 1"
+        )
+    return problems
+
+
+CORRECTION_TURN = Scenario(
+    id="correction-turn",
+    turns=["The Endurance 1 workout you added to today's calendar is empty — no "
+           "exercises. I already have a real Endurance 1 template in my library. "
+           "Fix today's session so it uses the real one.",
+           "Yes, do it"],
+    seed=_seed_correction_state,
+    final_state_check=_check_correction,
+)
+
+
+async def _seed_ambiguous(db, user_id):
+    ex = await seed_exercises(db, user_id)
+    t1 = await seed_template(db, user_id, "Endurance 1", ex)
+    t2 = await seed_template(db, user_id, "Endurance 2", ex,
+                             exercise_names=EXERCISES[:4])
+    return {"template_ids": [t1, t2],
+            "template_count": await _template_count(db, user_id)}
+
+
+AMBIGUOUS_NAME = Scenario(
+    id="ambiguous-name",
+    turns=["Add my endurance workout to the calendar for today"],
+    seed=_seed_ambiguous,
+    final_state_check=_check_no_side_effects,
+    trajectory_checks=[assert_no_writes, assert_no_false_success],
+)
+
+
+SCENARIOS = [
+    SCHEDULE_EXISTING,
+    SCHEDULE_NONEXISTENT,
+    REMOVE_VS_SKIP,
+    DUPLICATE_CLEANUP,
+    CORRECTION_TURN,
+    AMBIGUOUS_NAME,
+]

--- a/ai-coach-service/evals/test_think_then_act.py
+++ b/ai-coach-service/evals/test_think_then_act.py
@@ -1,0 +1,54 @@
+"""
+Think-then-act eval: replay the Endurance-1 failure family against the real
+orchestrator + real LLM, grade trajectories deterministically and diff the
+final DB state. pass^k semantics: every one of EVAL_K iterations must pass.
+
+Run:  RUN_LLM_EVALS=1 EVAL_K=2 pytest evals/ -x -q   (from ai-coach-service/)
+"""
+import os
+
+import pytest
+
+from app.core.agents.orchestrator import AgentOrchestrator
+from evals.harness import Trace, instrument, run_turn
+from evals.scenarios import SCENARIOS, seed_user
+
+EVAL_K = int(os.environ.get("EVAL_K", "2"))
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[s.id for s in SCENARIOS])
+async def test_scenario(scenario, scratch_db):
+    for iteration in range(EVAL_K):
+        user_id = await seed_user(scratch_db)  # fresh user per iteration
+        refs = await scenario.seed(scratch_db, user_id)
+
+        orchestrator = AgentOrchestrator(scratch_db)
+        trace = Trace()
+        instrument(orchestrator, trace)
+
+        history = []
+        for turn_index, message in enumerate(scenario.turns):
+            trace.current_turn = turn_index
+            text = await run_turn(orchestrator, message, history, user_id)
+            trace.turn_texts.append(text)
+            history.append({"role": "human", "content": message})
+            history.append({"role": "ai", "content": text})
+
+        problems = []
+        for check in scenario.trajectory_checks:
+            problems.extend(f"[trajectory] {v}" for v in check(trace))
+        problems.extend(
+            f"[state] {v}"
+            for v in await scenario.final_state_check(scratch_db, user_id, refs, trace)
+        )
+
+        if problems:
+            calls = "\n".join(
+                f"  turn {c.turn}: {c.name}({ {k: v for k, v in (c.args or {}).items() if k != 'workoutDetails'} })"
+                for c in trace.calls
+            )
+            pytest.fail(
+                f"scenario '{scenario.id}' iteration {iteration + 1}/{EVAL_K} failed:\n"
+                + "\n".join(f"- {p}" for p in problems)
+                + f"\n\ntool calls:\n{calls}"
+            )

--- a/ai-coach-service/tests/test_delete_calendar_event_skill.py
+++ b/ai-coach-service/tests/test_delete_calendar_event_skill.py
@@ -1,0 +1,77 @@
+"""
+Tests for the delete_calendar_event skill (two-step confirm, user-scoped).
+"""
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from bson import ObjectId
+
+from app.core.agents.skills.delete_calendar_event_skill import delete_calendar_event
+
+USER_ID = str(ObjectId())
+EVENT_ID = ObjectId()
+
+
+def _ctx(event):
+    ctx = MagicMock()
+    ctx.db.users.find_one = AsyncMock(return_value=None)  # get_user_today -> UTC
+    ctx.db.calendarevents.find_one = AsyncMock(return_value=event)
+    ctx.db.calendarevents.delete_one = AsyncMock(
+        return_value=MagicMock(deleted_count=1)
+    )
+    return ctx
+
+
+def _event(**overrides):
+    event = {
+        "_id": EVENT_ID,
+        "userId": ObjectId(USER_ID),
+        "title": "Endurance 1 (Jul 20)",
+        "date": datetime(2026, 7, 20),
+        "type": "workout",
+        "status": "scheduled",
+    }
+    event.update(overrides)
+    return event
+
+
+class TestDeleteCalendarEvent:
+    async def test_preview_needs_confirmation_and_no_delete(self):
+        ctx = _ctx(_event())
+        res = await delete_calendar_event(ctx, USER_ID, {"event_id": str(EVENT_ID)})
+        assert res["success"] is True
+        assert res["needs_confirmation"] is True
+        assert res["would_delete"]["id"] == str(EVENT_ID)
+        assert res["would_delete"]["title"] == "Endurance 1 (Jul 20)"
+        assert "confirm=true" in res["message"]
+        ctx.db.calendarevents.delete_one.assert_not_called()
+
+    async def test_confirm_deletes_user_scoped(self):
+        ctx = _ctx(_event())
+        res = await delete_calendar_event(
+            ctx, USER_ID, {"event_id": str(EVENT_ID), "confirm": True}
+        )
+        assert res["success"] is True
+        assert res["deleted"] == 1
+        query = ctx.db.calendarevents.delete_one.call_args[0][0]
+        assert query == {"_id": EVENT_ID, "userId": ObjectId(USER_ID)}
+
+    async def test_invalid_id_is_corrective(self):
+        ctx = _ctx(_event())
+        res = await delete_calendar_event(ctx, USER_ID, {"event_id": "nope"})
+        assert res["success"] is False
+        assert res["error"] == "invalid_event_id"
+        ctx.db.calendarevents.delete_one.assert_not_called()
+
+    async def test_foreign_or_missing_event(self):
+        ctx = _ctx(None)
+        res = await delete_calendar_event(
+            ctx, USER_ID, {"event_id": str(EVENT_ID), "confirm": True}
+        )
+        assert res["success"] is False
+        ctx.db.calendarevents.delete_one.assert_not_called()
+
+    async def test_plan_linked_event_warns_in_preview(self):
+        ctx = _ctx(_event(planId=ObjectId()))
+        res = await delete_calendar_event(ctx, USER_ID, {"event_id": str(EVENT_ID)})
+        assert "training plan" in res["message"]

--- a/ai-coach-service/tests/test_prompt_policy.py
+++ b/ai-coach-service/tests/test_prompt_policy.py
@@ -1,0 +1,29 @@
+"""
+Regression guard for the system prompt: the tool_use_policy block must exist
+and the incident-hardened anchors it deliberately does NOT replace must
+survive future edits byte-for-byte at the phrase level.
+"""
+from app.core.agents.prompts import SYSTEM_PROMPT
+
+
+def test_tool_use_policy_block_present():
+    assert "<tool_use_policy>" in SYSTEM_PROMPT
+    assert "</tool_use_policy>" in SYSTEM_PROMPT
+    assert "Read before write" in SYSTEM_PROMPT
+    assert "No placeholders, no invented IDs" in SYSTEM_PROMPT
+    assert "Delete vs skip" in SYSTEM_PROMPT
+
+
+def test_incident_hardened_anchors_untouched():
+    # TOR-88: declined previews must never be written.
+    assert "HONOR THE ANSWER (CRITICAL)" in SYSTEM_PROMPT
+    assert "dry-run PREVIEW" in SYSTEM_PROMPT
+    # Plans-from-tools highest-priority rule.
+    assert "PLANS COME FROM TOOLS" in SYSTEM_PROMPT
+    # Ground-in-real-data rule.
+    assert "GROUND IN THE USER'S REAL DATA FIRST" in SYSTEM_PROMPT
+
+
+def test_new_tools_documented():
+    assert "delete_calendar_event" in SYSTEM_PROMPT
+    assert "workout_template_id" in SYSTEM_PROMPT

--- a/ai-coach-service/tests/test_schedule_existing_template.py
+++ b/ai-coach-service/tests/test_schedule_existing_template.py
@@ -1,0 +1,185 @@
+"""
+Tests for schedule_to_calendar's think-then-act additions:
+existing-template mode (workout_template_id) and the same-day duplicate check.
+"""
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from bson import ObjectId
+
+from app.core.agents.services.calendar_service import CalendarService
+
+USER_ID = str(ObjectId())
+TEMPLATE_ID = ObjectId()
+
+TEMPLATE = {
+    "_id": TEMPLATE_ID,
+    "name": "Endurance 1",
+    "estimated_duration": 50,
+    "blocks": [{
+        "name": "Main",
+        "exercises": [
+            {"exercise_id": str(ObjectId()), "exercise_name": "Run", "volume": "1x30", "notes": ""},
+            {"exercise_id": str(ObjectId()), "exercise_name": "Burpees", "volume": "3x15", "notes": ""},
+        ],
+    }],
+}
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def __aiter__(self):
+        self._it = iter(self._docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+def _service(template=TEMPLATE, existing_events=()):
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value=None)  # get_user_today -> UTC
+    db.predefinedworkouts.find_one = AsyncMock(return_value=template)
+    db.predefinedworkouts.insert_one = AsyncMock(
+        return_value=MagicMock(inserted_id=ObjectId())
+    )
+    db.calendarevents.find = MagicMock(return_value=FakeCursor(existing_events))
+    db.calendarevents.insert_one = AsyncMock(
+        return_value=MagicMock(inserted_id=ObjectId())
+    )
+    return CalendarService(db), db
+
+
+class TestExistingTemplateMode:
+    async def test_preview_lists_template_exercises_and_writes_nothing(self):
+        service, db = _service()
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout",
+                      "workout_template_id": str(TEMPLATE_ID)}
+        )
+        assert res["dry_run"] is True
+        assert "existing library workout" in res["message"]
+        assert "Endurance 1" in res["message"]
+        assert all(e["method"] == "existing_template" for e in res["resolved_exercises"])
+        db.predefinedworkouts.insert_one.assert_not_called()
+        db.calendarevents.insert_one.assert_not_called()
+
+    async def test_write_links_existing_template_and_creates_no_new_one(self):
+        service, db = _service()
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout", "dry_run": False,
+                      "workout_template_id": str(TEMPLATE_ID)}
+        )
+        assert res["success"] is True
+        assert "nothing new was created" in res["message"]
+        db.predefinedworkouts.insert_one.assert_not_called()
+        event_doc = db.calendarevents.insert_one.call_args[0][0]
+        assert event_doc["workoutTemplateId"] == TEMPLATE_ID
+        assert len(event_doc["workoutDetails"]["exercises"]) == 2
+        assert event_doc["workoutDetails"]["exercises"][0]["exerciseName"] == "Run"
+        # Title falls back to the template name.
+        assert event_doc["title"].startswith("Endurance 1 (")
+
+    async def test_template_not_found_is_corrective(self):
+        service, db = _service(template=None)
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout",
+                      "workout_template_id": str(ObjectId())}
+        )
+        assert res["success"] is False
+        assert res["error"] == "template_not_found"
+        assert "never guess an id" in res["message"]
+
+    async def test_invalid_id_is_corrective_not_crash(self):
+        service, db = _service(template=None)
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout",
+                      "workout_template_id": "not-an-oid"}
+        )
+        assert res["error"] == "template_not_found"
+
+    async def test_empty_template_rejected(self):
+        empty = dict(TEMPLATE, blocks=[{"name": "Main", "exercises": []}])
+        service, db = _service(template=empty)
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout",
+                      "workout_template_id": str(TEMPLATE_ID)}
+        )
+        assert res["error"] == "empty_template"
+        db.calendarevents.insert_one.assert_not_called()
+
+    async def test_missing_details_message_mentions_template_arg(self):
+        service, db = _service()
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout", "title": "Endurance 1"}
+        )
+        assert res["error"] == "missing_workout_details"
+        assert "workout_template_id" in res["message"]
+
+
+class TestSameDayDuplicate:
+    def _existing_event(self, **overrides):
+        event = {
+            "_id": ObjectId(),
+            "title": "Endurance 1 (Jul 20)",
+            "date": datetime(2026, 7, 20),
+            "type": "workout",
+            "status": "scheduled",
+            "workoutDetails": {"exercises": [{"exerciseName": "Run"}]},
+        }
+        event.update(overrides)
+        return event
+
+    async def test_same_base_title_refused_on_preview(self):
+        service, db = _service(existing_events=[self._existing_event()])
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout", "title": "Endurance 1",
+                      "workoutDetails": {"exercises": [{"exerciseName": "Run"}]}}
+        )
+        assert res["error"] == "already_scheduled"
+        assert res["existing_event"]["exerciseCount"] == 1
+        assert "allow_duplicate=true" in res["message"]
+        db.calendarevents.insert_one.assert_not_called()
+
+    async def test_same_template_id_refused_on_write(self):
+        event = self._existing_event(title="Something Else", workoutTemplateId=TEMPLATE_ID)
+        service, db = _service(existing_events=[event])
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout", "dry_run": False,
+                      "workout_template_id": str(TEMPLATE_ID)}
+        )
+        assert res["error"] == "already_scheduled"
+        db.calendarevents.insert_one.assert_not_called()
+
+    async def test_allow_duplicate_writes(self):
+        service, db = _service(existing_events=[self._existing_event()])
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "workout", "dry_run": False,
+                      "allow_duplicate": True,
+                      "workout_template_id": str(TEMPLATE_ID)}
+        )
+        assert res["success"] is True
+        db.calendarevents.insert_one.assert_called_once()
+
+    async def test_different_day_not_a_duplicate(self):
+        service, db = _service(existing_events=[])
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-21", "type": "workout",
+                      "workout_template_id": str(TEMPLATE_ID)}
+        )
+        assert res.get("error") is None
+        assert res["dry_run"] is True
+
+    async def test_rest_events_exempt(self):
+        service, db = _service(existing_events=[self._existing_event()])
+        res = await service.schedule_to_calendar(
+            USER_ID, {"date": "2026-07-20", "type": "rest", "title": "Rest Day",
+                      "dry_run": False}
+        )
+        assert res["success"] is True
+        db.calendarevents.insert_one.assert_called_once()

--- a/ai-coach-service/tests/test_workout_template_dedup.py
+++ b/ai-coach-service/tests/test_workout_template_dedup.py
@@ -1,0 +1,150 @@
+"""
+Tests for the create_workout_template think-then-act guards:
+empty-blocks rejection and title dedup (normalized-exact, with the
+confirm_duplicate escape hatch).
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+from bson import ObjectId
+
+from app.core.dedup import (
+    existing_template_duplicate_response,
+    normalize_template_title,
+)
+from app.core.agents.services.workout_service import WorkoutService
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def __aiter__(self):
+        self._it = iter(self._docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+def _db_with_templates(docs):
+    db = MagicMock()
+    db.predefinedworkouts.find = MagicMock(return_value=FakeCursor(docs))
+    db.predefinedworkouts.find_one = AsyncMock(
+        return_value=docs[0] if docs else None
+    )
+    return db
+
+
+USER_ID = str(ObjectId())
+
+
+class TestNormalizeTemplateTitle:
+    def test_strips_date_suffix(self):
+        assert normalize_template_title("Endurance 1 (Jul 14)") == "endurance 1"
+
+    def test_case_and_whitespace(self):
+        assert normalize_template_title("  Push   Day ") == "push day"
+
+    def test_plain_name_unchanged(self):
+        assert normalize_template_title("Endurance 1") == "endurance 1"
+
+    def test_parenthetical_that_is_not_a_date_kept(self):
+        assert normalize_template_title("Legs (heavy)") == "legs (heavy)"
+
+
+class TestExistingTemplateDuplicateResponse:
+    async def test_collision_returns_corrective_error(self):
+        tid = ObjectId()
+        doc = {
+            "_id": tid,
+            "name": "Endurance 1",
+            "goal": "Aerobic base",
+            "blocks": [{"exercises": [{"exercise_name": "Run"}] * 6}],
+        }
+        db = _db_with_templates([doc])
+        res = await existing_template_duplicate_response(db, USER_ID, "endurance 1")
+        assert res["error"] == "duplicate_template"
+        assert res["already_exists"] is True
+        assert res["success"] is False
+        assert res["existing"]["id"] == str(tid)
+        assert res["existing"]["total_exercises"] == 6
+        # The message must name the exact next call, with the real id inlined.
+        assert f"workout_template_id='{tid}'" in res["message"]
+        assert "confirm_duplicate=true" in res["message"]
+
+    async def test_date_suffixed_variant_collides(self):
+        doc = {"_id": ObjectId(), "name": "Endurance 1 (Jul 14)", "blocks": []}
+        db = _db_with_templates([doc])
+        res = await existing_template_duplicate_response(db, USER_ID, "Endurance 1")
+        assert res is not None
+
+    async def test_no_false_positive_on_prefix(self):
+        doc = {"_id": ObjectId(), "name": "Push Day B", "blocks": []}
+        db = _db_with_templates([doc])
+        assert await existing_template_duplicate_response(db, USER_ID, "Push Day") is None
+
+    async def test_new_name_returns_none(self):
+        db = _db_with_templates([])
+        assert await existing_template_duplicate_response(db, USER_ID, "Endurance 1") is None
+
+
+class TestCreateWorkoutTemplateGuards:
+    def _service(self, existing_docs):
+        db = _db_with_templates(existing_docs)
+        db.predefinedworkouts.insert_one = AsyncMock(
+            return_value=MagicMock(inserted_id=ObjectId())
+        )
+        return WorkoutService(db), db
+
+    async def test_empty_blocks_rejected_before_insert(self):
+        service, db = self._service([])
+        res = await service.create_workout_template(
+            USER_ID, {"name": "Endurance 1", "blocks": []}
+        )
+        assert res["success"] is False
+        assert res["error"] == "empty_workout_template"
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+    async def test_blocks_with_no_exercises_rejected(self):
+        service, db = self._service([])
+        res = await service.create_workout_template(
+            USER_ID,
+            {"name": "Endurance 1", "blocks": [{"name": "Main", "exercises": []}]},
+        )
+        assert res["error"] == "empty_workout_template"
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+    async def test_duplicate_title_blocked_before_insert(self):
+        existing = {"_id": ObjectId(), "name": "Endurance 1", "blocks": []}
+        service, db = self._service([existing])
+        res = await service.create_workout_template(
+            USER_ID,
+            {"name": "Endurance 1",
+             "blocks": [{"name": "Main", "exercises": [{"exercise_name": "Run", "volume": "3x10"}]}]},
+        )
+        assert res["error"] == "duplicate_template"
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+    async def test_confirm_duplicate_bypasses_dedup(self, monkeypatch):
+        existing = {"_id": ObjectId(), "name": "Endurance 1", "blocks": []}
+        service, db = self._service([existing])
+
+        resolver = MagicMock()
+        resolver.resolve_blocks = AsyncMock(side_effect=lambda uid, blocks, **kw: (
+            blocks, {"ambiguous": [], "created": []}
+        ))
+        monkeypatch.setattr(
+            "app.core.agents.services.workout_service.ExerciseResolver",
+            lambda db: resolver,
+        )
+
+        res = await service.create_workout_template(
+            USER_ID,
+            {"name": "Endurance 1", "confirm_duplicate": True,
+             "blocks": [{"name": "Main", "exercises": [{"exercise_name": "Run", "volume": "3x10"}]}]},
+        )
+        assert res["success"] is True
+        db.predefinedworkouts.insert_one.assert_called_once()


### PR DESCRIPTION
Phase 1 of the think-then-act playbook (`development/ai-coach/torii-think-then-act-playbook.md`): make read-before-write the path of least resistance for the Sensei agent, so the \"Add Endurance 1 → empty placeholder + duplicates + skip-as-delete\" failure family is structurally impossible.

Merged with main's PR #115 (calendar events reference templates instead of embedding exercises) — this PR adopts that architecture and layers its guards on top.

## What changed

**Tools that push back**
- `create_workout_template`: refuses empty templates (`empty_workout_template`); normalized-exact title dedup returning a corrective redirect with the existing template's id (`duplicate_template`), with a `confirm_duplicate` escape hatch.
- `schedule_to_calendar` (on top of #115's `workout_template_id` linking): same-day duplicate refusal (`already_scheduled`) with `allow_duplicate` escape hatch; `empty_template` rejection; date-suffix stripping on default titles so suffixes don't stack.
- New `delete_calendar_event` skill (two-step confirm, user-scoped) — \"remove from calendar\" finally means delete; `reschedule_session` description now states skip ≠ delete.

**Prompt**
- Consolidated `<tool_use_policy>` block (read-before-write, no placeholders / no invented ids, plan-before-mutate checklist, delete-vs-skip, report-only-what-the-result-shows). Additive only — HONOR THE ANSWER, dry-run flow (TOR-88), and ground-in-real-data rules untouched (guarded by `tests/test_prompt_policy.py`).
- Ambiguous template match ("add my endurance workout" with Endurance 1 AND 2) now mandates asking — both post-merge eval samples showed the model silently picking one.

**Evals (committed, `ai-coach-service/evals/`)**
- Real-LLM suite driving the production streaming orchestrator against a scratch Atlas DB (dropped in teardown). 6 scenarios from the failure transcript; deterministic trajectory graders (read-before-write, id provenance, no false-success) + tau-bench-style final-state diff; pass^k; 429-retry. Never runs by default (`RUN_LLM_EVALS=1`).

**Refactor**: `parse_volume` shared via `app/core/agents/volume_utils.py` (breaks a services→skills import cycle; merged with #115's version).

## A/B verification (real LLM, gpt-5.4-mini, EVAL_K=2 = pass^2, sequential runs)

| Scenario | main | branch (3 runs) |
|---|---|---|
| schedule-existing-by-name | ❌ created a duplicate template instead of linking | ✅✅❌ (fail = hallucinated id → **guard refused, nothing written**) |
| schedule-nonexistent-name | ✅ | ✅✅✅ |
| remove-vs-skip | ❌ marked skipped instead of deleted (the production bug) | ✅✅❌ (fail = hallucinated `event_id` → guard refused) |
| duplicate-cleanup | ❌ both events left | ✅✅✅ |
| correction-turn | ❌ 2 events left | ❌❌✅ |
| ambiguous-name | ✅ | ✅❌❌ → prompt fix added in `eaff75a` |
| **pass^2 per run** | **2/6** | **4/6, 2/6, 5/6** |

The qualitative shift matters more than the noisy pass rates: on main every failure silently corrupts state (duplicate templates, skip masquerading as delete, leftover events); on this branch every remaining failure leaves state clean — the guards convert hallucinated ids and double-bookings into corrective tool errors the model can recover from. Remaining flakiness is the mini model's; reasoning-effort routing / Responses API migration is the next phase.

## Verification
- `pytest -q`: 412 passed (31 new unit tests for the guards, template mode, delete skill, prompt anchors).
- `RUN_LLM_EVALS=1 EVAL_K=2 pytest evals/`: results above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)