### PR TITLE
Sensei: reuse existing workout when scheduling to calendar (no more per-date duplicates)

### DIFF
--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -230,7 +230,7 @@ CALENDAR WORKFLOW:
 A calendar event only combines a workout with a date — it never carries its own exercise list.
 When user asks to add/schedule a workout for a specific date:
 1. FIRST check whether the workout already exists in the library (`list_workout_templates` / `grep_workouts`). If EXACTLY ONE matches, call `schedule_to_calendar` with its id as `workout_template_id` — do NOT resend its exercises; the event links to the existing workout and nothing is duplicated. If SEVERAL templates match (e.g. "endurance" matches Endurance 1 and Endurance 2), ask the user which one they meant — never pick one silently
-2. Only when the session is genuinely new: design it, get user approval, and pass the FULL exercise list in `workoutDetails` — this creates ONE new library workout and links the event to it. Never schedule a bare title
+2. Only when the session is genuinely new: design it, get user approval, and pass the FULL exercise list in `workoutDetails` — this creates ONE new library workout and links the event to it (if the content matches an existing library workout, the tool links that one automatically — never expect a second copy in the library). Never schedule a bare title
 3. The first `schedule_to_calendar` call returns a PREVIEW and writes nothing
 4. Show the user the preview — ESPECIALLY any exercise-name substitutions (e.g. their "Easy Run" matched to catalog "Treadmill Run") — and ask them to confirm. Only after they confirm, call `schedule_to_calendar` again with the same arguments plus `dry_run=false`. If they decline, do NOT write — adjust or drop the action
 5. If for today, ask if they want to start training now

--- a/ai-coach-service/app/core/agents/services/calendar_service.py
+++ b/ai-coach-service/app/core/agents/services/calendar_service.py
@@ -11,7 +11,7 @@ import structlog
 
 from app.core.agents.date_utils import get_user_today, relative_day_label
 from app.core.agents.services.exercise_resolver import ExerciseResolver
-from app.core.agents.volume_utils import flatten_template_exercises
+from app.core.agents.volume_utils import flatten_template_exercises, parse_volume
 from app.core.dedup import (
     find_reusable_template,
     normalize_template_title,
@@ -187,6 +187,17 @@ class CalendarService:
                     flatten_template_exercises({"blocks": blocks}),
                 )
                 if reused is not None:
+                    # The earlier same-day check ran without a template id (the
+                    # match didn't exist yet) — re-check so an inline-reuse of a
+                    # template already scheduled that day under another title is
+                    # refused exactly like an explicit workout_template_id.
+                    if not args.get("allow_duplicate", False):
+                        duplicate = await self._find_same_day_duplicate(
+                            user_id, event_date,
+                            normalize_template_title(title), reused["_id"], today,
+                        )
+                        if duplicate:
+                            return duplicate
                     existing_template = reused
                     reused_inline_match = True
                     workout_template_id = reused["_id"]
@@ -423,16 +434,21 @@ class CalendarService:
             # the lookup is skipped — the confirmed write re-checks anyway.)
             if not any(res["status"] == "create_pending" for res in resolutions):
                 base_title = strip_template_date_suffix(title_with_date)
+                # Coerce sets/reps through the same volume round-trip as the
+                # write path (str/float/None inputs must not change the verdict
+                # between the preview the user confirms and the actual write).
+                sig_exercises = []
+                for ex, res in zip(workout_exercises, resolutions):
+                    sets, reps = parse_volume(
+                        f"{ex.get('targetSets', 3)}x{ex.get('targetReps', 10)}"
+                    )
+                    sig_exercises.append({
+                        "exerciseName": res.get("matched_name") or ex.get("exerciseName", ""),
+                        "targetSets": sets,
+                        "targetReps": reps,
+                    })
                 reusable = await find_reusable_template(
-                    self.db, user_id, base_title,
-                    [
-                        {
-                            "exerciseName": res.get("matched_name") or ex.get("exerciseName", ""),
-                            "targetSets": ex.get("targetSets", 3),
-                            "targetReps": ex.get("targetReps", 10),
-                        }
-                        for ex, res in zip(workout_exercises, resolutions)
-                    ],
+                    self.db, user_id, base_title, sig_exercises
                 )
                 if reusable is not None:
                     reuses_template = {

--- a/ai-coach-service/app/core/agents/services/calendar_service.py
+++ b/ai-coach-service/app/core/agents/services/calendar_service.py
@@ -12,7 +12,11 @@ import structlog
 from app.core.agents.date_utils import get_user_today, relative_day_label
 from app.core.agents.services.exercise_resolver import ExerciseResolver
 from app.core.agents.volume_utils import flatten_template_exercises
-from app.core.dedup import normalize_template_title, strip_template_date_suffix
+from app.core.dedup import (
+    find_reusable_template,
+    normalize_template_title,
+    strip_template_date_suffix,
+)
 
 logger = structlog.get_logger()
 
@@ -141,6 +145,7 @@ class CalendarService:
                 )
 
             workout_template_id = None
+            reused_inline_match = False
 
             if existing_template is not None:
                 # Link the existing library workout — never duplicate it.
@@ -173,25 +178,45 @@ class CalendarService:
                     user_id, blocks, on_ambiguous="best_effort"
                 )
 
-                # Save workout to user's library (PredefinedWorkout collection)
-                workout_template = {
-                    "name": title_with_date,
-                    "goal": workout_details.get("goal", f"Workout for {date_suffix}"),
-                    "primary_disciplines": workout_details.get("disciplines", ["General Fitness"]),
-                    "estimated_duration": workout_details.get("estimatedDuration", 45),
-                    "difficulty_level": workout_details.get("difficulty", "intermediate"),
-                    "blocks": blocks,
-                    "tags": ["ai-generated", date_suffix.lower().replace(" ", "-")],
-                    "isCommon": False,
-                    "createdBy": ObjectId(user_id),
-                    "createdAt": datetime.utcnow(),
-                    "updatedAt": datetime.utcnow()
-                }
+                # Reuse-first (match AFTER resolution so canonical names are
+                # compared): identical content means the same session — link the
+                # existing library workout instead of minting a per-date copy.
+                # Only genuinely adjusted exercises warrant a new template.
+                reused = await find_reusable_template(
+                    self.db, user_id, title,
+                    flatten_template_exercises({"blocks": blocks}),
+                )
+                if reused is not None:
+                    existing_template = reused
+                    reused_inline_match = True
+                    workout_template_id = reused["_id"]
+                    logger.info(
+                        "schedule_to_calendar reused existing template",
+                        template_id=str(reused["_id"]), name=reused.get("name"),
+                    )
+                else:
+                    # New content → one library entry with a STABLE name (no
+                    # date suffix) so the next schedule of the same session
+                    # links this template instead of creating "X (Jul 21)".
+                    template_name = strip_template_date_suffix(title) or title
+                    workout_template = {
+                        "name": template_name,
+                        "goal": workout_details.get("goal", "Custom workout"),
+                        "primary_disciplines": workout_details.get("disciplines", ["General Fitness"]),
+                        "estimated_duration": workout_details.get("estimatedDuration", 45),
+                        "difficulty_level": workout_details.get("difficulty", "intermediate"),
+                        "blocks": blocks,
+                        "tags": ["ai-generated"],
+                        "isCommon": False,
+                        "createdBy": ObjectId(user_id),
+                        "createdAt": datetime.utcnow(),
+                        "updatedAt": datetime.utcnow()
+                    }
 
-                template_result = await self.db.predefinedworkouts.insert_one(workout_template)
-                if template_result.inserted_id:
-                    workout_template_id = template_result.inserted_id
-                    logger.info(f"Saved workout '{title_with_date}' to user's library")
+                    template_result = await self.db.predefinedworkouts.insert_one(workout_template)
+                    if template_result.inserted_id:
+                        workout_template_id = template_result.inserted_id
+                        logger.info(f"Saved workout '{template_name}' to user's library")
 
             # Build the calendar event document
             event_data = {
@@ -238,7 +263,12 @@ class CalendarService:
                     duration = workout_details.get("estimatedDuration", 45) if workout_details else 45
 
                 response_msg = f"Scheduled **{title_with_date}** for **{formatted_date}**!"
-                if existing_template is not None:
+                if reused_inline_match:
+                    response_msg += (
+                        f"\n\nLinked to your existing library workout "
+                        f"**{existing_template.get('name')}** — no duplicate was created."
+                    )
+                elif existing_template is not None:
                     response_msg += f"\n\nLinked to **{existing_template.get('name')}** from your workout library."
                 elif workout_template_id:
                     response_msg += "\n\n**Saved to your workout library** - you can reuse this workout anytime!"
@@ -334,6 +364,7 @@ class CalendarService:
         preview_msg = f"**Preview — nothing scheduled yet**\n\n**{title_with_date}** on **{formatted_date}** ({event_type})"
 
         resolved_exercises = []
+        reuses_template = None
         if existing_template is not None:
             # Linking a library workout: nothing to resolve — the template's
             # exercises are already canonical. Just show what gets linked.
@@ -386,6 +417,37 @@ class CalendarService:
             duration = workout_details.get("estimatedDuration", 45)
             preview_msg += f", ~{duration} min:\n" + "\n".join(lines)
 
+            # Keep the preview honest about the library side effect: identical
+            # content links an existing workout, only new content creates one.
+            # (create_pending exercises can't exist in any stored template, so
+            # the lookup is skipped — the confirmed write re-checks anyway.)
+            if not any(res["status"] == "create_pending" for res in resolutions):
+                base_title = strip_template_date_suffix(title_with_date)
+                reusable = await find_reusable_template(
+                    self.db, user_id, base_title,
+                    [
+                        {
+                            "exerciseName": res.get("matched_name") or ex.get("exerciseName", ""),
+                            "targetSets": ex.get("targetSets", 3),
+                            "targetReps": ex.get("targetReps", 10),
+                        }
+                        for ex, res in zip(workout_exercises, resolutions)
+                    ],
+                )
+                if reusable is not None:
+                    reuses_template = {
+                        "id": str(reusable["_id"]),
+                        "name": reusable.get("name", ""),
+                    }
+                    preview_msg += (
+                        f"\n\nWill LINK your existing library workout "
+                        f"**{reusable.get('name')}** — no new workout will be created."
+                    )
+                else:
+                    preview_msg += (
+                        f"\n\nWill create a new library workout **{base_title}**."
+                    )
+
         preview_msg += (
             "\n\nShow this preview to the user and ask them to confirm. "
             "If they confirm, call `schedule_to_calendar` again with the SAME arguments plus `dry_run=false`. "
@@ -405,6 +467,7 @@ class CalendarService:
                 "relativeDay": relative_day_label(event_date.date(), today.date()),
             },
             "resolved_exercises": resolved_exercises,
+            "reuses_template": reuses_template,
         }
 
     async def get_calendar_events(self, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/schedule_plan_skill.py
@@ -26,6 +26,11 @@ from bson import ObjectId
 
 from app.core.agents.services.exercise_resolver import ExerciseResolver
 from app.core.agents.skills.registry import SkillContext, skill
+from app.core.dedup import (
+    exercise_content_signature,
+    normalize_template_title,
+    template_doc_signature,
+)
 
 logger = structlog.get_logger()
 
@@ -289,25 +294,18 @@ def _slot_key(event: Dict[str, Any]) -> tuple:
 def _template_content_key(name: str, exercises: List[Dict[str, Any]]) -> tuple:
     """Identity of a workout's content: title + ordered exercise prescription.
     Used to dedupe template creation (same custom workout repeated across
-    weeks → one library entry) and to match plan-tagged templates on re-runs."""
-    return (
-        name,
-        tuple(
-            (ex.get("exerciseName", ""), ex.get("targetSets", 3), ex.get("targetReps", 10))
-            for ex in exercises
-        ),
-    )
+    weeks → one library entry) and to match plan-tagged templates on re-runs.
+    Thin wrapper over the shared dedup signature so this key can never drift
+    from schedule_to_calendar's reuse-first matching."""
+    return (normalize_template_title(name), exercise_content_signature(exercises))
 
 
 def _template_doc_key(doc: Dict[str, Any]) -> tuple:
     """The same content key, recomputed from a PredefinedWorkout document."""
-    exercises = []
-    for block in doc.get("blocks", []) or []:
-        for ex in block.get("exercises", []) or []:
-            sets, reps = _parse_volume(ex.get("volume"))
-            exercises.append({"exerciseName": ex.get("exercise_name", ""),
-                              "targetSets": sets, "targetReps": reps})
-    return _template_content_key(doc.get("name", ""), exercises)
+    return (
+        normalize_template_title(doc.get("name", "")),
+        template_doc_signature(doc),
+    )
 
 
 def _template_doc_exercise_ids(doc: Dict[str, Any]) -> List[Any]:

--- a/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/calendar_tools.py
@@ -13,7 +13,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "schedule_to_calendar",
-                "description": "Schedule a workout or event to the user's calendar for a specific date. A calendar event only combines a workout with a date — it never carries its own exercise list. For 'workout' and 'deload' events, EITHER pass workout_template_id for an existing library workout (find it with list_workout_templates / grep_workouts — ALWAYS prefer this; it links the event without creating anything new), OR plan a brand-new session and pass workoutDetails.exercises (this creates a new library workout and links it). Never schedule a bare title. Refuses to double-book: if an equivalent event already exists on that date it returns already_scheduled instead of writing. Defaults to a dry-run PREVIEW that writes nothing. Present the preview to the user; ONLY after they confirm, call again with the same arguments plus dry_run=false to actually write. If the user declines the preview, do NOT call again.",
+                "description": "Schedule a workout or event to the user's calendar for a specific date. A calendar event only combines a workout with a date — it never carries its own exercise list. For 'workout' and 'deload' events, EITHER pass workout_template_id for an existing library workout (find it with list_workout_templates / grep_workouts — ALWAYS prefer this; it links the event without creating anything new), OR plan a brand-new session and pass workoutDetails.exercises (this creates a new library workout and links it). Reuse-first is enforced in code: if the passed workoutDetails exactly match an existing library workout, the tool LINKS that workout instead of creating a duplicate — the preview and result say which happened; report that accurately. Never schedule a bare title. Refuses to double-book: if an equivalent event already exists on that date it returns already_scheduled instead of writing. Defaults to a dry-run PREVIEW that writes nothing. Present the preview to the user; ONLY after they confirm, call again with the same arguments plus dry_run=false to actually write. If the user declines the preview, do NOT call again.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -40,7 +40,7 @@ def get_calendar_tools() -> List[Dict[str, Any]]:
                         },
                         "workoutDetails": {
                             "type": "object",
-                            "description": "Details for a NEWLY designed workout session — creates a new library workout. For 'workout'/'deload' events, required only when workout_template_id is not given.",
+                            "description": "Details for a NEWLY designed workout session — creates a new library workout, UNLESS the exercises exactly match an existing one, in which case that workout is linked instead (no duplicate). For 'workout'/'deload' events, required only when workout_template_id is not given.",
                             "properties": {
                                 "workoutType": {
                                     "type": "string",

--- a/ai-coach-service/app/core/dedup.py
+++ b/ai-coach-service/app/core/dedup.py
@@ -5,9 +5,11 @@ MCP McpTools._add_exercise) use this so the reuse message + workout hint can nev
 drift between them.
 """
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from bson import ObjectId
+
+from app.core.agents.volume_utils import flatten_template_exercises
 
 # schedule_to_calendar appends a "(Jul 14)" style suffix to template names it
 # creates — strip it so "Endurance 1 (Jul 14)" collides with "Endurance 1".
@@ -25,6 +27,61 @@ def normalize_template_title(name: str) -> str:
     """Normalize a workout-template title for duplicate comparison:
     strip the date suffix, collapse whitespace, lowercase."""
     return re.sub(r"\s+", " ", strip_template_date_suffix(name)).strip().lower()
+
+
+def _normalize_exercise_name(name: str) -> str:
+    return re.sub(r"\s+", " ", name or "").strip().lower()
+
+
+def exercise_content_signature(exercises: List[Dict[str, Any]]) -> tuple:
+    """Identity of a workout's exercise content: the ordered prescription
+    (normalized name, sets, reps). Deliberately order-sensitive and blind to
+    rest/notes/duration — matching this means "the same session", so scheduling
+    it again must LINK the existing template, never mint a copy."""
+    return tuple(
+        (
+            _normalize_exercise_name(ex.get("exerciseName", "")),
+            ex.get("targetSets", 3),
+            ex.get("targetReps", 10),
+        )
+        for ex in exercises
+    )
+
+
+def template_doc_signature(doc: Dict[str, Any]) -> tuple:
+    """The same content signature, recomputed from a PredefinedWorkout doc
+    (blocks[].exercises[] with '3x10'-style volume strings)."""
+    return exercise_content_signature(flatten_template_exercises(doc))
+
+
+async def find_reusable_template(
+    db, user_id: str, name: str, exercises: List[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Find an existing library template (the user's own OR a common one) whose
+    exercise content exactly matches — the reuse-first rule for scheduling with
+    inline workoutDetails. Returns the best match, or None (caller inserts).
+
+    The hard rule: content must match exactly. A same-named template with
+    different exercises is an ADJUSTED workout and must NOT be linked. Name is
+    only a tie-breaker among content matches (then common over private, then
+    oldest), so repeated schedules converge on one stable template."""
+    signature = exercise_content_signature(exercises)
+    if not signature:
+        return None
+    normalized_name = normalize_template_title(name)
+    visibility = {"$or": [{"isCommon": True}, {"createdBy": ObjectId(user_id)}]}
+    matches = []
+    async for doc in db.predefinedworkouts.find(visibility):
+        if template_doc_signature(doc) == signature:
+            matches.append(doc)
+    if not matches:
+        return None
+    matches.sort(key=lambda d: (
+        normalize_template_title(d.get("name", "")) != normalized_name,
+        not d.get("isCommon", False),
+        str(d.get("_id", "")),
+    ))
+    return matches[0]
 
 
 async def existing_exercise_reuse_response(db, user_id: str, name: str) -> Optional[Dict[str, Any]]:

--- a/ai-coach-service/evals/scenarios.py
+++ b/ai-coach-service/evals/scenarios.py
@@ -343,6 +343,46 @@ AMBIGUOUS_NAME = Scenario(
 )
 
 
+async def _workout_events_on(db, user_id: str, date: datetime):
+    return [e async for e in db.calendarevents.find({
+        "userId": ObjectId(user_id),
+        "date": {"$gte": date, "$lt": date + timedelta(days=1)},
+        "type": {"$in": ["workout", "deload"]},
+    })]
+
+
+async def _check_twice_one_template(db, user_id, refs, trace):
+    """Scheduling the same workout on two days must yield two events linked to
+    ONE template — the original duplication bug minted a library copy per date."""
+    problems = []
+    for label, date in (("today", _today()), ("tomorrow", _today() + timedelta(days=1))):
+        events = await _workout_events_on(db, user_id, date)
+        if len(events) != 1:
+            problems.append(f"expected exactly 1 workout event {label}, found {len(events)}")
+        elif events[0].get("workoutTemplateId") != refs["template_id"]:
+            problems.append(
+                f"{label}'s event is not linked to the seeded Endurance 1 template "
+                f"(workoutTemplateId={events[0].get('workoutTemplateId')})"
+            )
+    if await _template_count(db, user_id) != refs["template_count"]:
+        problems.append(
+            "the library gained a template — scheduling twice must reuse "
+            "the ONE existing Endurance 1, never copy it per date"
+        )
+    return problems
+
+
+SCHEDULE_TWICE_ONE_TEMPLATE = Scenario(
+    id="schedule-twice-one-template",
+    turns=["Add my Endurance 1 workout to my calendar for today",
+           "Yes, go ahead",
+           "Great — put the same workout on my calendar for tomorrow too",
+           "Yes, confirm"],
+    seed=_seed_endurance,
+    final_state_check=_check_twice_one_template,
+)
+
+
 SCENARIOS = [
     SCHEDULE_EXISTING,
     SCHEDULE_NONEXISTENT,
@@ -350,4 +390,5 @@ SCENARIOS = [
     DUPLICATE_CLEANUP,
     CORRECTION_TURN,
     AMBIGUOUS_NAME,
+    SCHEDULE_TWICE_ONE_TEMPLATE,
 ]

--- a/ai-coach-service/tests/test_schedule_reuse_template.py
+++ b/ai-coach-service/tests/test_schedule_reuse_template.py
@@ -54,14 +54,14 @@ class FakeCursor:
             raise StopAsyncIteration
 
 
-def _service(library=(LIBRARY_TEMPLATE,)):
+def _service(library=(LIBRARY_TEMPLATE,), existing_events=()):
     db = MagicMock()
     db.users.find_one = AsyncMock(return_value=None)  # get_user_today -> UTC
     db.predefinedworkouts.find = MagicMock(return_value=FakeCursor(library))
     db.predefinedworkouts.insert_one = AsyncMock(
         return_value=MagicMock(inserted_id=ObjectId())
     )
-    db.calendarevents.find = MagicMock(return_value=FakeCursor([]))
+    db.calendarevents.find = MagicMock(return_value=FakeCursor(existing_events))
     db.calendarevents.insert_one = AsyncMock(
         return_value=MagicMock(inserted_id=ObjectId())
     )
@@ -148,6 +148,43 @@ class TestReuseFirstWrite:
         assert res["success"] is True
         db.predefinedworkouts.insert_one.assert_called_once()
         assert res["workout_template_id"] != str(TEMPLATE_ID)
+
+    async def test_reuse_hit_refuses_same_day_duplicate_of_matched_template(self, resolver):
+        """The pre-lookup same-day check runs with template_oid=None; once the
+        inline content matches a template already on that day (under ANY title),
+        the write must refuse exactly like an explicit workout_template_id."""
+        from datetime import datetime
+        existing = {
+            "_id": ObjectId(),
+            "title": "Something Else Entirely",
+            "date": datetime(2026, 7, 20),
+            "type": "workout",
+            "status": "scheduled",
+            "workoutTemplateId": TEMPLATE_ID,
+        }
+        service, db = _service(existing_events=[existing])
+        res = await service.schedule_to_calendar(
+            USER_ID, _schedule_args(title="Fresh Title", dry_run=False)
+        )
+        assert res["error"] == "already_scheduled"
+        db.calendarevents.insert_one.assert_not_called()
+
+    async def test_preview_signature_coerces_string_sets_reps(self, resolver):
+        """Preview and write must reach the same verdict when the model sends
+        sets/reps as strings — the preview coerces through parse_volume."""
+        service, db = _service()
+        details = {
+            "exercises": [
+                {"exerciseName": "Bench Press", "targetSets": "3", "targetReps": "8"},
+                {"exerciseName": "Push-Up", "targetSets": "3", "targetReps": "15"},
+            ],
+        }
+        res = await service.schedule_to_calendar(
+            USER_ID, _schedule_args(workoutDetails=details)
+        )
+        assert res["dry_run"] is True
+        assert "Will LINK" in res["message"]
+        assert res["reuses_template"]["id"] == str(TEMPLATE_ID)
 
     async def test_resolver_renamed_exercise_still_matches(self, resolver):
         """The library stores canonical names — matching runs AFTER resolution,

--- a/ai-coach-service/tests/test_schedule_reuse_template.py
+++ b/ai-coach-service/tests/test_schedule_reuse_template.py
@@ -1,0 +1,210 @@
+"""
+Tests for schedule_to_calendar's reuse-first rule: inline workoutDetails whose
+content exactly matches an existing library workout LINK that workout instead
+of inserting a per-date duplicate. Only adjusted content creates a template —
+and the one it creates has a stable, un-dated name.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bson import ObjectId
+
+from app.core.agents.services.calendar_service import CalendarService
+
+USER_ID = str(ObjectId())
+TEMPLATE_ID = ObjectId()
+
+LIBRARY_TEMPLATE = {
+    "_id": TEMPLATE_ID,
+    "name": "Push Day",
+    "isCommon": False,
+    "createdBy": ObjectId(USER_ID),
+    "estimated_duration": 50,
+    "primary_disciplines": ["Strength"],
+    "blocks": [{
+        "name": "Main",
+        "exercises": [
+            {"exercise_id": str(ObjectId()), "exercise_name": "Bench Press", "volume": "3x8", "notes": ""},
+            {"exercise_id": str(ObjectId()), "exercise_name": "Push-Up", "volume": "3x15", "notes": ""},
+        ],
+    }],
+}
+
+MATCHING_DETAILS = {
+    "estimatedDuration": 50,
+    "exercises": [
+        {"exerciseName": "Bench Press", "targetSets": 3, "targetReps": 8},
+        {"exerciseName": "Push-Up", "targetSets": 3, "targetReps": 15},
+    ],
+}
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def __aiter__(self):
+        self._it = iter(self._docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+def _service(library=(LIBRARY_TEMPLATE,)):
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value=None)  # get_user_today -> UTC
+    db.predefinedworkouts.find = MagicMock(return_value=FakeCursor(library))
+    db.predefinedworkouts.insert_one = AsyncMock(
+        return_value=MagicMock(inserted_id=ObjectId())
+    )
+    db.calendarevents.find = MagicMock(return_value=FakeCursor([]))
+    db.calendarevents.insert_one = AsyncMock(
+        return_value=MagicMock(inserted_id=ObjectId())
+    )
+    return CalendarService(db), db
+
+
+@pytest.fixture
+def resolver(monkeypatch):
+    """Pass-through resolver: names resolve to themselves as existing matches."""
+    resolver = MagicMock()
+    resolver.resolve_blocks = AsyncMock(
+        side_effect=lambda uid, blocks, **kw: (blocks, {"ambiguous": [], "created": []})
+    )
+
+    async def _resolve(uid, items, **kw):
+        return [
+            {"status": "auto_matched", "matched_name": item["exercise_name"], "method": "exact"}
+            for item in items
+        ]
+
+    resolver.resolve = AsyncMock(side_effect=_resolve)
+    monkeypatch.setattr(
+        "app.core.agents.services.calendar_service.ExerciseResolver",
+        lambda db: resolver,
+    )
+    return resolver
+
+
+def _schedule_args(**overrides):
+    args = {"date": "2026-07-20", "type": "workout", "title": "Push Day",
+            "workoutDetails": MATCHING_DETAILS}
+    args.update(overrides)
+    return args
+
+
+class TestReuseFirstWrite:
+    async def test_matching_content_links_without_insert(self, resolver):
+        service, db = _service()
+        res = await service.schedule_to_calendar(
+            USER_ID, _schedule_args(dry_run=False)
+        )
+        assert res["success"] is True
+        assert res["workout_template_id"] == str(TEMPLATE_ID)
+        assert "no duplicate" in res["message"]
+        db.predefinedworkouts.insert_one.assert_not_called()
+        event_doc = db.calendarevents.insert_one.call_args[0][0]
+        assert event_doc["workoutTemplateId"] == TEMPLATE_ID
+        assert "exercises" not in event_doc["workoutDetails"]
+
+    async def test_matching_common_template_links(self, resolver):
+        common = dict(LIBRARY_TEMPLATE, isCommon=True, createdBy=None)
+        service, db = _service(library=[common])
+        res = await service.schedule_to_calendar(
+            USER_ID, _schedule_args(dry_run=False)
+        )
+        assert res["workout_template_id"] == str(TEMPLATE_ID)
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+    async def test_no_match_inserts_with_stable_undated_name(self, resolver):
+        service, db = _service(library=[])
+        res = await service.schedule_to_calendar(
+            USER_ID, _schedule_args(title="Push Day (Jul 20)", dry_run=False)
+        )
+        assert res["success"] is True
+        db.predefinedworkouts.insert_one.assert_called_once()
+        template_doc = db.predefinedworkouts.insert_one.call_args[0][0]
+        # Stable name: the next schedule of this content must collide with it.
+        assert template_doc["name"] == "Push Day"
+        assert template_doc["tags"] == ["ai-generated"]
+
+    async def test_adjusted_content_creates_new_despite_same_name(self, resolver):
+        """Same title but different prescription = an ADJUSTED workout — it
+        must become its own template, never silently relink the old one."""
+        service, db = _service()
+        adjusted = {
+            "exercises": [
+                {"exerciseName": "Bench Press", "targetSets": 5, "targetReps": 5},
+                {"exerciseName": "Push-Up", "targetSets": 3, "targetReps": 15},
+            ],
+        }
+        res = await service.schedule_to_calendar(
+            USER_ID, _schedule_args(workoutDetails=adjusted, dry_run=False)
+        )
+        assert res["success"] is True
+        db.predefinedworkouts.insert_one.assert_called_once()
+        assert res["workout_template_id"] != str(TEMPLATE_ID)
+
+    async def test_resolver_renamed_exercise_still_matches(self, resolver):
+        """The library stores canonical names — matching runs AFTER resolution,
+        so 'Pushup' resolving to 'Push-Up' still links the existing template."""
+        def _rename(uid, blocks, **kw):
+            for block in blocks:
+                for ex in block["exercises"]:
+                    if ex["exercise_name"] == "Pushup":
+                        ex["exercise_name"] = "Push-Up"
+            return blocks, {"ambiguous": [], "created": []}
+
+        resolver.resolve_blocks = AsyncMock(side_effect=_rename)
+        service, db = _service()
+        details = {
+            "exercises": [
+                {"exerciseName": "Bench Press", "targetSets": 3, "targetReps": 8},
+                {"exerciseName": "Pushup", "targetSets": 3, "targetReps": 15},
+            ],
+        }
+        res = await service.schedule_to_calendar(
+            USER_ID, _schedule_args(workoutDetails=details, dry_run=False)
+        )
+        assert res["workout_template_id"] == str(TEMPLATE_ID)
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+
+class TestReuseFirstPreview:
+    async def test_preview_announces_link_and_writes_nothing(self, resolver):
+        service, db = _service()
+        res = await service.schedule_to_calendar(USER_ID, _schedule_args())
+        assert res["dry_run"] is True
+        assert "Will LINK" in res["message"]
+        assert "no new workout will be created" in res["message"]
+        assert res["reuses_template"] == {"id": str(TEMPLATE_ID), "name": "Push Day"}
+        db.predefinedworkouts.insert_one.assert_not_called()
+        db.calendarevents.insert_one.assert_not_called()
+
+    async def test_preview_announces_creation_when_no_match(self, resolver):
+        service, db = _service(library=[])
+        res = await service.schedule_to_calendar(USER_ID, _schedule_args())
+        assert res["dry_run"] is True
+        assert "Will create a new library workout" in res["message"]
+        assert res["reuses_template"] is None
+        db.predefinedworkouts.insert_one.assert_not_called()
+
+    async def test_preview_skips_lookup_when_exercise_is_new(self, resolver):
+        """A create_pending exercise can't exist in any stored template — the
+        preview must not claim a link OR a create verdict based on a stale scan."""
+        async def _resolve(uid, items, **kw):
+            return [
+                {"status": "create_pending", "matched_name": None, "method": None}
+                for _ in items
+            ]
+
+        resolver.resolve = AsyncMock(side_effect=_resolve)
+        service, db = _service()
+        res = await service.schedule_to_calendar(USER_ID, _schedule_args())
+        assert res["dry_run"] is True
+        assert "Will LINK" not in res["message"]
+        assert res["reuses_template"] is None

--- a/ai-coach-service/tests/test_workout_template_dedup.py
+++ b/ai-coach-service/tests/test_workout_template_dedup.py
@@ -8,8 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 from bson import ObjectId
 
 from app.core.dedup import (
+    exercise_content_signature,
     existing_template_duplicate_response,
+    find_reusable_template,
     normalize_template_title,
+    template_doc_signature,
 )
 from app.core.agents.services.workout_service import WorkoutService
 
@@ -89,6 +92,82 @@ class TestExistingTemplateDuplicateResponse:
     async def test_new_name_returns_none(self):
         db = _db_with_templates([])
         assert await existing_template_duplicate_response(db, USER_ID, "Endurance 1") is None
+
+
+def _exercises(*prescriptions):
+    return [
+        {"exerciseName": name, "targetSets": sets, "targetReps": reps}
+        for name, sets, reps in prescriptions
+    ]
+
+
+class TestContentSignature:
+    def test_name_normalization_case_and_whitespace(self):
+        assert exercise_content_signature(_exercises(("Bench  Press", 3, 8))) == \
+            exercise_content_signature(_exercises(("bench press ", 3, 8)))
+
+    def test_order_sensitive(self):
+        a = exercise_content_signature(_exercises(("Run", 1, 30), ("Burpees", 3, 15)))
+        b = exercise_content_signature(_exercises(("Burpees", 3, 15), ("Run", 1, 30)))
+        assert a != b
+
+    def test_prescription_change_changes_signature(self):
+        assert exercise_content_signature(_exercises(("Run", 3, 10))) != \
+            exercise_content_signature(_exercises(("Run", 5, 5)))
+
+    def test_doc_signature_matches_inline_signature(self):
+        doc = {"blocks": [{"exercises": [
+            {"exercise_name": "Run", "volume": "1x30"},
+            {"exercise_name": "Burpees", "volume": "3x15"},
+        ]}]}
+        assert template_doc_signature(doc) == \
+            exercise_content_signature(_exercises(("Run", 1, 30), ("Burpees", 3, 15)))
+
+
+class TestFindReusableTemplate:
+    EXERCISES = _exercises(("Run", 1, 30), ("Burpees", 3, 15))
+
+    def _doc(self, name, is_common=False, oid=None):
+        return {
+            "_id": oid or ObjectId(),
+            "name": name,
+            "isCommon": is_common,
+            "blocks": [{"exercises": [
+                {"exercise_name": "Run", "volume": "1x30"},
+                {"exercise_name": "Burpees", "volume": "3x15"},
+            ]}],
+        }
+
+    async def test_no_content_match_returns_none(self):
+        db = _db_with_templates([self._doc("Endurance 1")])
+        assert await find_reusable_template(
+            db, USER_ID, "Endurance 1", _exercises(("Run", 5, 5))
+        ) is None
+
+    async def test_empty_exercises_returns_none(self):
+        db = _db_with_templates([self._doc("Endurance 1")])
+        assert await find_reusable_template(db, USER_ID, "Endurance 1", []) is None
+
+    async def test_name_match_beats_common(self):
+        named = self._doc("Endurance 1 (Jul 07)")
+        common = self._doc("Aerobic Base", is_common=True)
+        db = _db_with_templates([common, named])
+        match = await find_reusable_template(db, USER_ID, "Endurance 1", self.EXERCISES)
+        assert match["_id"] == named["_id"]
+
+    async def test_common_beats_private_when_names_equal(self):
+        private = self._doc("Endurance 1")
+        common = self._doc("Endurance 1", is_common=True)
+        db = _db_with_templates([private, common])
+        match = await find_reusable_template(db, USER_ID, "Endurance 1", self.EXERCISES)
+        assert match["_id"] == common["_id"]
+
+    async def test_oldest_wins_as_final_tiebreak(self):
+        older = self._doc("Endurance 1", oid=ObjectId("6" + "0" * 23))
+        newer = self._doc("Endurance 1", oid=ObjectId("7" + "0" * 23))
+        db = _db_with_templates([newer, older])
+        match = await find_reusable_template(db, USER_ID, "Endurance 1", self.EXERCISES)
+        assert match["_id"] == older["_id"]
 
 
 class TestCreateWorkoutTemplateGuards:


### PR DESCRIPTION
## Problem

Asking Sensei to schedule a workout duplicated it: `schedule_to_calendar` with inline `workoutDetails` inserted a new date-suffixed `predefinedworkouts` doc **per call, per date**. Scheduling the same workout twice a week left 8 near-identical workouts/month in the Workouts tab.

## Fix — reuse-first, enforced in code

- **`app/core/dedup.py`**: shared content-signature helpers (`exercise_content_signature`, `template_doc_signature`, `find_reusable_template`). The hard rule: an event links an existing template iff the resolved exercise content matches **exactly** (order-sensitive). Name is only a tie-breaker among content matches (then common-over-private, then oldest) — a same-named workout with adjusted exercises still gets its own template.
- **`calendar_service.schedule_to_calendar`** write path: after exercise resolution, look up a reusable template (user's own or common) and link it; only genuinely new content inserts — now with a **stable un-dated name** (`"Push Day"`, not `"Push Day (Jul 14)"`) and no per-date tag, so repeats converge on one template.
- **Preview honesty**: dry-run says `Will LINK your existing library workout 'X' — no new workout will be created` vs `Will create a new library workout 'Y'`, plus a structured `reuses_template` field.
- **`schedule_plan_skill`** template keys are now thin wrappers over the shared signature — plan dedup and calendar dedup can't drift apart.
- Tool description + CALENDAR WORKFLOW prompt updated so the model reports the reuse accurately.

Multi-event linking is safe: completion writes to `WorkoutLog`, and per-event edits already copy-on-write via `templateMaterializer.applyExercisesCopyOnWrite`.

## Tests

- `tests/test_schedule_reuse_template.py`: link on exact match (user + common), no insert; adjusted content inserts new; resolver-renamed exercise still matches; preview link/create/skip-on-new-exercise cases; stable un-dated name on insert.
- `tests/test_workout_template_dedup.py`: signature order-sensitivity, doc/inline equivalence, tie-break order.
- Eval scenario `schedule-twice-one-template` (real-LLM suite): schedule the same workout today + tomorrow → two events, ONE template.
- Full unit suite: **429 passed**.

## Follow-ups (separate PR)

- Backend REST parity (`templateMaterializer.ensureTemplateForCustomEvent`) + `dedupe-predefined-workouts.js` migration to clean up existing duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)