### PR TITLE
Sensei memory: user-deletable short-term context, tombstoned deletes, leaner summaries

### DIFF
--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -193,6 +193,7 @@ WHEN TO USE EACH:
     - RIGHT: User says "I'm okay now" after being sick → UPDATE memory to "User was sick from Nov 28 - Dec 3, 2025. Now recovered."
     - This history is VALUABLE for understanding recovery patterns, training load tolerance, and future health decisions
   - For health condition changes, use `update_memory` to record the evolution, NOT delete
+  - BUT: the user always has the final say over their own data. If they EXPLICITLY ask to delete/forget a memory — including a health memory ("delete the memory about my wrist", "forget my injuries") — you may note once that keeping a recovery timeline can help, then honor the request without arguing. Deleted means deleted: do not re-save the fact later from old conversations.
 - `update_memory`: Update an EXISTING memory. Only use when there's already a saved memory to modify.
 - `list_memories`: List what you remember about the user. Use when user asks "what do you know about me?" or "what have you memorized?"
 - IMPORTANT: The user's name, weight, height etc. come from their PROFILE (shown in USER PROFILE above), NOT from memories.

--- a/ai-coach-service/app/core/agents/services/memory_service.py
+++ b/ai-coach-service/app/core/agents/services/memory_service.py
@@ -127,8 +127,11 @@ class MemoryService:
             if not user_memory:
                 return []
 
-            # Filter to only active memories and sort by importance
-            active_memories = [m for m in user_memory.get("memories", []) if m.get("isActive", True)]
+            # Filter to only active, non-tombstoned memories and sort by importance
+            active_memories = [
+                m for m in user_memory.get("memories", [])
+                if m.get("isActive", True) and not m.get("deleted")
+            ]
 
             # Sort by importance (high first), breaking ties by recency (newest
             # first). Only the top ~15 are injected into the prompt, so an
@@ -162,12 +165,19 @@ class MemoryService:
             if not doc:
                 return
             memories = doc.get("memories", [])
-            overflow = len(memories) - max_per_user
+            # Tombstones don't count toward the cap and must never be evicted —
+            # dropping one re-opens the auto-promotion re-learn hole
+            live_memories = [m for m in memories if not m.get("deleted")]
+            overflow = len(live_memories) - max_per_user
             if overflow <= 0:
                 return
 
             def _evictable(m):
-                return m.get("category") != "health" and m.get("importance") != "high"
+                return (
+                    not m.get("deleted")
+                    and m.get("category") != "health"
+                    and m.get("importance") != "high"
+                )
 
             def _created(m):
                 ts = m.get("createdAt")
@@ -211,20 +221,23 @@ class MemoryService:
                 return {"success": False, "message": "No memories found"}
 
             memories = user_memory.get("memories", [])
-            original_count = len(memories)
 
-            # Find memories matching the search text
-            memories_to_keep = []
+            # Tombstone matching memories instead of removing them: the
+            # auto-promotion dedup reads the raw array, so a hard-deleted fact
+            # would get re-learned from old conversations
             deleted_memories = []
 
             for mem in memories:
+                if mem.get("deleted"):
+                    continue
                 content_lower = mem.get("content", "").lower()
                 category_match = not category_filter or mem.get("category") == category_filter
 
                 if search_text in content_lower and category_match:
+                    mem["deleted"] = True
+                    mem["deletedAt"] = datetime.utcnow()
+                    mem["isActive"] = False
                     deleted_memories.append(mem)
-                else:
-                    memories_to_keep.append(mem)
 
             if not deleted_memories:
                 return {"success": False, "message": f"No memories found matching '{search_text}'"}
@@ -234,7 +247,7 @@ class MemoryService:
                 {"user": ObjectId(user_id)},
                 {
                     "$set": {
-                        "memories": memories_to_keep,
+                        "memories": memories,
                         "updatedAt": datetime.utcnow()
                     }
                 }
@@ -275,8 +288,10 @@ class MemoryService:
             if category_filter:
                 memories = [m for m in memories if m.get("category") == category_filter]
 
-            # Filter to active only
-            active_memories = [m for m in memories if m.get("isActive", True)]
+            # Filter to active only (tombstoned memories stay hidden)
+            active_memories = [
+                m for m in memories if m.get("isActive", True) and not m.get("deleted")
+            ]
 
             if not active_memories:
                 if category_filter:
@@ -349,6 +364,8 @@ class MemoryService:
             updated = False
 
             for mem in memories:
+                if mem.get("deleted"):
+                    continue
                 content_lower = mem.get("content", "").lower()
                 if search_text in content_lower:
                     # Preserve old content in history for audit trail

--- a/ai-coach-service/app/services/short_term_context_service.py
+++ b/ai-coach-service/app/services/short_term_context_service.py
@@ -29,10 +29,17 @@ CONTENT_MAX_CHARS = 400
 STALE_CONVERSATION_MINUTES = 30
 
 SUMMARIZE_PROMPT = (
-    "Summarize this coaching conversation in 2-3 sentences. Focus on what the "
-    "athlete reported (fatigue, soreness, injuries, mood), decisions made, and "
-    "anything the coach should remember over the next two weeks. Write in third "
-    "person ('The athlete...'). Return ONLY the summary text."
+    "Summarize what happened in THIS coaching conversation in 1-3 sentences, "
+    "written in third person ('The athlete...'). Include only NEW information "
+    "from this conversation: symptoms or conditions the athlete newly reported "
+    "or said had changed, decisions made, and commitments for the coming days. "
+    "Do NOT restate standing facts the coach already has on file (existing "
+    "injuries, profile details, long-term goals) unless the athlete said they "
+    "changed. Do NOT pad with negatives like 'no fatigue, soreness, or injuries "
+    "were reported' — simply omit topics that didn't come up. If the "
+    "conversation contains nothing worth remembering (greetings, small talk, a "
+    "simple question the coach answered), respond with exactly: SKIP. "
+    "Otherwise return ONLY the summary text."
 )
 
 EXTRACT_DURABLE_FACTS_PROMPT = (
@@ -133,7 +140,11 @@ class ShortTermContextService:
         if not entries:
             return ""
         kind_labels = {"checkin": "check-in", "conversation_summary": "conversation"}
-        lines = ["RECENT CONTEXT (short-term notes from the last 14 days, newest first):"]
+        lines = [
+            "RECENT CONTEXT (short-term notes from the last 14 days, newest first "
+            "— if a note conflicts with the profile or memories above, the "
+            "profile/memories are current):"
+        ]
         for entry in entries:
             created = entry.get("createdAt")
             date_str = created.strftime("%b %d") if isinstance(created, datetime) else ""
@@ -192,10 +203,11 @@ class ShortTermContextService:
             # Load current memories fresh — both as dedup context for the extractor
             # and for the substring backstop. Callers may promote several sources
             # in a row, so this must be re-read per call, not cached.
-            # Dedup must consider ALL memories, including DEACTIVATED ones: a memory
-            # the user toggled off would otherwise be re-promoted every time the
-            # fact is mentioned again. (get_user_memories filters to active — used
-            # only for prompt injection — so read the raw doc here instead.)
+            # Dedup must consider ALL memories, including DEACTIVATED and
+            # TOMBSTONED (deleted:true) ones: a memory the user toggled off or
+            # deleted would otherwise be re-promoted every time the fact is
+            # mentioned again. (get_user_memories filters those out — it's for
+            # prompt injection — so read the raw doc here instead.)
             mem_doc = await self.db.usermemories.find_one({"user": ObjectId(user_id)})
             all_memories = (mem_doc or {}).get("memories", [])
             existing_contents = [m.get("content", "") for m in all_memories if m.get("content")]
@@ -331,6 +343,16 @@ class ShortTermContextService:
                     summary = response.choices[0].message.content.strip()
                     if not summary:
                         raise ValueError("Empty summary")
+
+                    # Trivial conversation — keep the claim (must NOT go through
+                    # the ValueError path, which releases it and retries forever)
+                    # and skip promotion too: nothing durable in small talk.
+                    if summary.strip().strip(".").upper() == "SKIP":
+                        logger.info(
+                            f"Summary skipped (trivial) for conversation "
+                            f"{conv.get('conversation_id')}"
+                        )
+                        continue
 
                     inserted = await self.add_entry(
                         user_id,

--- a/ai-coach-service/tests/test_memory_tombstones.py
+++ b/ai-coach-service/tests/test_memory_tombstones.py
@@ -1,0 +1,213 @@
+"""Tombstone soft-delete for user memories + SKIP handling in the summarizer.
+
+A user-deleted memory must stay deleted: it is tombstoned (deleted=True) rather
+than removed, so promote_durable_facts' dedup — which reads the raw memories
+array — can still see it and never re-learns the fact from old conversations.
+Trivial conversations summarize to SKIP and produce no context entry.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bson import ObjectId
+
+from app.core.agents.services.memory_service import MemoryService
+from app.services.short_term_context_service import ShortTermContextService
+
+USER_ID = str(ObjectId())
+
+
+def _mem(content, deleted=False, is_active=True, category="health", importance="high"):
+    m = {
+        "_id": ObjectId(),
+        "content": content,
+        "category": category,
+        "importance": importance,
+        "isActive": is_active,
+        "createdAt": datetime(2026, 7, 1),
+    }
+    if deleted:
+        m["deleted"] = True
+        m["deletedAt"] = datetime(2026, 7, 10)
+        m["isActive"] = False
+    return m
+
+
+def _db_with_memories(memories):
+    db = MagicMock()
+    db.usermemories.find_one = AsyncMock(
+        return_value={"user": ObjectId(USER_ID), "memories": memories}
+    )
+    db.usermemories.update_one = AsyncMock(
+        return_value=MagicMock(modified_count=1)
+    )
+    return db
+
+
+class TestGetUserMemories:
+    @pytest.mark.asyncio
+    async def test_filters_tombstoned_memories(self):
+        db = _db_with_memories([
+            _mem("Has a broken leg", deleted=True),
+            _mem("Prefers morning workouts", category="preference"),
+        ])
+        result = await MemoryService(db).get_user_memories(USER_ID)
+        contents = [m["content"] for m in result]
+        assert contents == ["Prefers morning workouts"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_memories_without_deleted_field_still_returned(self):
+        db = _db_with_memories([_mem("Sore wrists")])
+        result = await MemoryService(db).get_user_memories(USER_ID)
+        assert len(result) == 1
+
+
+class TestDeleteMemoryTombstones:
+    @pytest.mark.asyncio
+    async def test_delete_tombstones_instead_of_removing(self):
+        memories = [_mem("Has a broken leg"), _mem("Prefers mornings", category="preference")]
+        db = _db_with_memories(memories)
+
+        result = await MemoryService(db).delete_memory(USER_ID, {"search_text": "broken leg"})
+
+        assert result["success"] is True
+        written = db.usermemories.update_one.call_args[0][1]["$set"]["memories"]
+        assert len(written) == 2  # nothing spliced out
+        tombstone = next(m for m in written if m["content"] == "Has a broken leg")
+        assert tombstone["deleted"] is True
+        assert tombstone["isActive"] is False
+        assert isinstance(tombstone["deletedAt"], datetime)
+
+    @pytest.mark.asyncio
+    async def test_already_tombstoned_memory_is_not_matched(self):
+        db = _db_with_memories([_mem("Has a broken leg", deleted=True)])
+        result = await MemoryService(db).delete_memory(USER_ID, {"search_text": "broken leg"})
+        assert result["success"] is False
+        db.usermemories.update_one.assert_not_awaited()
+
+
+class TestEnforceCapIgnoresTombstones:
+    @pytest.mark.asyncio
+    async def test_tombstones_dont_count_and_are_never_evicted(self):
+        # 2 live + 3 tombstoned, cap of 2: live count is at the cap, so nothing
+        # may be evicted even though the raw array exceeds it.
+        memories = [
+            _mem("old note 1", category="general", importance="low"),
+            _mem("old note 2", category="general", importance="low"),
+            _mem("deleted 1", deleted=True, category="general", importance="low"),
+            _mem("deleted 2", deleted=True, category="general", importance="low"),
+            _mem("deleted 3", deleted=True, category="general", importance="low"),
+        ]
+        db = _db_with_memories(memories)
+        await MemoryService(db).enforce_cap(USER_ID, max_per_user=2)
+        db.usermemories.update_one.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_overflow_evicts_live_low_value_but_not_tombstones(self):
+        memories = [
+            _mem("oldest live", category="general", importance="low"),
+            _mem("newer live", category="general", importance="low"),
+            _mem("deleted", deleted=True, category="general", importance="low"),
+        ]
+        memories[1]["createdAt"] = datetime(2026, 7, 5)
+        db = _db_with_memories(memories)
+        await MemoryService(db).enforce_cap(USER_ID, max_per_user=1)
+        pulled_ids = db.usermemories.update_one.call_args[0][1]["$pull"]["memories"]["_id"]["$in"]
+        assert pulled_ids == [memories[0]["_id"]]
+
+
+def _openai_returning(content):
+    client = MagicMock()
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content=content))]
+    client.chat.completions.create = AsyncMock(return_value=response)
+    return client
+
+
+def _settings():
+    settings = MagicMock()
+    settings.memory_auto_promote_enabled = True
+    settings.memory_max_per_user = 60
+    settings.openai_model_fast = "test-model"
+    settings.llm_tuning_params = MagicMock(return_value={})
+    return settings
+
+
+class TestPromotionDedupsAgainstTombstones:
+    @pytest.mark.asyncio
+    async def test_deleted_fact_is_not_re_promoted(self):
+        injury = "The athlete has a history of a sore back and a broken leg."
+        db = _db_with_memories([_mem(injury, deleted=True)])
+        db.users.find_one = AsyncMock(return_value={"_id": ObjectId(USER_ID)})
+        service = ShortTermContextService(db)
+
+        extractor_output = json.dumps(
+            {"facts": [{"content": injury, "category": "health", "importance": "high"}]}
+        )
+        saved = await service.promote_durable_facts(
+            USER_ID,
+            source_text="Athlete: my back is sore\nCoach: noted",
+            openai_client=_openai_returning(extractor_output),
+            settings=_settings(),
+        )
+
+        assert saved == 0
+        db.usermemories.update_one.assert_not_awaited()
+
+
+class TestSummarizerSkip:
+    def _service_with_stale_conversation(self, db):
+        service = ShortTermContextService(db)
+        conv = {
+            "_id": ObjectId(),
+            "conversation_id": "conv-1",
+            "title": "Hey",
+            "messages": [
+                {"role": "human", "content": "hey"},
+                {"role": "ai", "content": "Hey! How can I help?"},
+            ],
+        }
+        cursor = MagicMock()
+        cursor.sort.return_value = cursor
+        cursor.to_list = AsyncMock(return_value=[{"_id": conv["_id"]}])
+        service.conversations = MagicMock()
+        service.conversations.find.return_value = cursor
+        service.conversations.find_one_and_update = AsyncMock(return_value=conv)
+        service.conversations.update_one = AsyncMock()
+        return service
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("skip_text", ["SKIP", "SKIP.", "skip"])
+    async def test_skip_keeps_claim_and_writes_nothing(self, skip_text):
+        db = MagicMock()
+        service = self._service_with_stale_conversation(db)
+        service.add_entry = AsyncMock()
+        service.promote_durable_facts = AsyncMock()
+
+        await service.summarize_stale_conversations(
+            USER_ID, openai_client=_openai_returning(skip_text), settings=_settings()
+        )
+
+        service.add_entry.assert_not_awaited()
+        service.promote_durable_facts.assert_not_awaited()
+        # Claim must be kept — releasing it would retry the trivial chat forever
+        service.conversations.update_one.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_real_summary_still_inserted(self):
+        db = MagicMock()
+        service = self._service_with_stale_conversation(db)
+        service.add_entry = AsyncMock(return_value=True)
+        service.promote_durable_facts = AsyncMock(return_value=0)
+
+        await service.summarize_stale_conversations(
+            USER_ID,
+            openai_client=_openai_returning("The athlete scheduled a run for today."),
+            settings=_settings(),
+        )
+
+        service.add_entry.assert_awaited_once()
+        service.promote_durable_facts.assert_awaited_once()
+        service.conversations.update_one.assert_not_awaited()

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,5 +1,6 @@
 const User = require('../models/User');
 const { validationResult } = require('express-validator');
+const { invalidateTodaysPick } = require('../utils/invalidateTodaysPick');
 
 // Register new user
 const register = async (req, res) => {
@@ -234,6 +235,14 @@ const updateProfile = async (req, res) => {
       updateData,
       { new: true, runValidators: true }
     );
+
+    // The day's cached AI pick bakes in the injury list it was generated with
+    if (profile && profile.injuries !== undefined) {
+      const oldInjuries = JSON.stringify(req.user.profile?.injuries || []);
+      if (JSON.stringify(profile.injuries) !== oldInjuries) {
+        invalidateTodaysPick(req.user._id);
+      }
+    }
 
     res.json({
       success: true,

--- a/backend/src/models/UserMemory.js
+++ b/backend/src/models/UserMemory.js
@@ -30,6 +30,15 @@ const memoryItemSchema = new mongoose.Schema({
   isActive: {
     type: Boolean,
     default: true
+  },
+  // Tombstone: deleted memories stay in the array (hidden everywhere) so the
+  // auto-promotion dedup can see them and never re-learns a deleted fact
+  deleted: {
+    type: Boolean,
+    default: false
+  },
+  deletedAt: {
+    type: Date
   }
 }, {
   timestamps: true

--- a/backend/src/routes/context.js
+++ b/backend/src/routes/context.js
@@ -2,11 +2,15 @@ const express = require('express');
 const router = express.Router();
 const mongoose = require('mongoose');
 const { auth } = require('../middleware/auth');
+const { invalidateTodaysPick } = require('../utils/invalidateTodaysPick');
 
-// GET /api/v1/context/recent - Read-only view of the coach's short-term working
-// memory (dashboard check-ins + auto-generated conversation summaries). This
-// collection is WRITTEN by the Python ai-coach-service (shortTermContext), not by
-// this API, so we read the raw collection directly rather than via a Mongoose model.
+// The coach's short-term working memory (dashboard check-ins + auto-generated
+// conversation summaries). This collection is WRITTEN by the Python
+// ai-coach-service (shortTermContext), not by this API, so we operate on the raw
+// collection directly rather than via a Mongoose model. Users can delete entries
+// here — it's the only way to make the coach drop a stale short-term note.
+
+// GET /api/v1/context/recent
 router.get('/recent', auth, async (req, res) => {
   try {
     const userId = new mongoose.Types.ObjectId(req.user.id);
@@ -34,6 +38,77 @@ router.get('/recent', auth, async (req, res) => {
     res.status(500).json({
       success: false,
       message: 'Failed to fetch recent context',
+      error: error.message
+    });
+  }
+});
+
+// DELETE /api/v1/context/:entryId - Remove one short-term context entry.
+// Hard delete is fine: these are ephemeral 14-day notes and nothing dedups
+// against them. Do NOT unset summarized_at on the source conversation — that
+// would re-summarize it and resurrect the entry.
+router.delete('/:entryId', auth, async (req, res) => {
+  try {
+    const { entryId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(entryId)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid entry ID'
+      });
+    }
+
+    // Compound filter is the user-scoping guard — never delete by _id alone
+    const result = await mongoose.connection.db
+      .collection('shortTermContext')
+      .deleteOne({
+        _id: new mongoose.Types.ObjectId(entryId),
+        userId: new mongoose.Types.ObjectId(req.user.id)
+      });
+
+    if (result.deletedCount === 0) {
+      return res.status(404).json({
+        success: false,
+        message: 'Context entry not found'
+      });
+    }
+
+    // Summaries/check-ins can carry health info the day's cached pick was built on
+    invalidateTodaysPick(req.user.id);
+
+    res.json({
+      success: true,
+      message: 'Context entry deleted successfully'
+    });
+  } catch (error) {
+    console.error('Error deleting context entry:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to delete context entry',
+      error: error.message
+    });
+  }
+});
+
+// DELETE /api/v1/context - Clear ALL of the user's short-term context
+router.delete('/', auth, async (req, res) => {
+  try {
+    const result = await mongoose.connection.db
+      .collection('shortTermContext')
+      .deleteMany({ userId: new mongoose.Types.ObjectId(req.user.id) });
+
+    invalidateTodaysPick(req.user.id);
+
+    res.json({
+      success: true,
+      message: 'Recent context cleared successfully',
+      data: { deletedCount: result.deletedCount }
+    });
+  } catch (error) {
+    console.error('Error clearing context:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to clear recent context',
       error: error.message
     });
   }

--- a/backend/src/routes/memories.js
+++ b/backend/src/routes/memories.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const mongoose = require('mongoose');
 const UserMemory = require('../models/UserMemory');
 const { auth } = require('../middleware/auth');
+const { invalidateTodaysPick } = require('../utils/invalidateTodaysPick');
 
 // GET /api/v1/memories - Get all memories for the authenticated user
 router.get('/', auth, async (req, res) => {
@@ -21,7 +22,7 @@ router.get('/', auth, async (req, res) => {
       });
     }
 
-    let memories = userMemory.memories;
+    let memories = userMemory.memories.filter(m => !m.deleted);
 
     // Apply filters
     if (category) {
@@ -76,7 +77,7 @@ router.get('/active', auth, async (req, res) => {
       });
     }
 
-    const activeMemories = userMemory.memories.filter(m => m.isActive);
+    const activeMemories = userMemory.memories.filter(m => m.isActive && !m.deleted);
 
     // Sort by importance
     const importanceOrder = { high: 0, medium: 1, low: 2 };
@@ -183,7 +184,7 @@ router.put('/:memoryId', auth, async (req, res) => {
 
     const memory = userMemory.memories.id(memoryId);
 
-    if (!memory) {
+    if (!memory || memory.deleted) {
       return res.status(404).json({
         success: false,
         message: 'Memory not found'
@@ -251,7 +252,7 @@ router.patch('/:memoryId/toggle', auth, async (req, res) => {
 
     const memory = userMemory.memories.id(memoryId);
 
-    if (!memory) {
+    if (!memory || memory.deleted) {
       return res.status(404).json({
         success: false,
         message: 'Memory not found'
@@ -297,19 +298,25 @@ router.delete('/:memoryId', auth, async (req, res) => {
       });
     }
 
-    const memoryIndex = userMemory.memories.findIndex(
-      m => m._id.toString() === memoryId
-    );
+    const memory = userMemory.memories.id(memoryId);
 
-    if (memoryIndex === -1) {
+    if (!memory || memory.deleted) {
       return res.status(404).json({
         success: false,
         message: 'Memory not found'
       });
     }
 
-    userMemory.memories.splice(memoryIndex, 1);
+    // Tombstone instead of splice: auto-promotion dedups against the raw
+    // array, so a hard-deleted fact would get re-learned from old chats
+    memory.deleted = true;
+    memory.deletedAt = new Date();
+    memory.isActive = false;
     await userMemory.save();
+
+    if (memory.category === 'health') {
+      invalidateTodaysPick(req.user.id);
+    }
 
     res.json({
       success: true,

--- a/backend/src/utils/invalidateTodaysPick.js
+++ b/backend/src/utils/invalidateTodaysPick.js
@@ -1,0 +1,44 @@
+/**
+ * Invalidate the user's cached "Today's Pick" daily recommendation.
+ *
+ * The pick is generated once per local day (Python ai-coach-service,
+ * dailyRecommendations collection) and its reasoning bakes in the health
+ * context available at generation time. When that context changes — a health
+ * memory is deleted, profile injuries are edited, short-term context is
+ * cleared — the cached pick can keep citing stale injuries for the rest of
+ * the day, so we delete it and let the next dashboard load regenerate it.
+ *
+ * Fire-and-forget: callers must never fail their own request because of this.
+ */
+
+const mongoose = require('mongoose');
+const User = require('../models/User');
+
+function localDateString(timeZone) {
+  try {
+    // en-CA formats as YYYY-MM-DD, matching dailyRecommendations.localDate
+    return new Date().toLocaleDateString('en-CA', { timeZone });
+  } catch (e) {
+    return new Date().toLocaleDateString('en-CA', { timeZone: 'UTC' });
+  }
+}
+
+function invalidateTodaysPick(userId) {
+  (async () => {
+    const user = await User.findById(userId).select('settings.timezone').lean();
+    const timezone = user?.settings?.timezone || 'UTC';
+    // $in with the UTC date too — covers the timezone-edge ambiguity cheaply
+    const dates = [...new Set([localDateString(timezone), localDateString('UTC')])];
+    const result = await mongoose.connection.db
+      .collection('dailyRecommendations')
+      .deleteMany({
+        userId: new mongoose.Types.ObjectId(userId),
+        localDate: { $in: dates }
+      });
+    if (result.deletedCount > 0) {
+      console.log(`Invalidated today's pick for user ${userId} (${dates.join(', ')})`);
+    }
+  })().catch(err => console.error('Failed to invalidate today\'s pick:', err));
+}
+
+module.exports = { invalidateTodaysPick };

--- a/frontend/src/pages/MemoriesSettings.jsx
+++ b/frontend/src/pages/MemoriesSettings.jsx
@@ -170,6 +170,28 @@ export default function MemoriesSettings() {
     }
   };
 
+  const handleDeleteContextEntry = async (entryId) => {
+    if (!confirm('Remove this note from Sensei\'s recent context?')) return;
+
+    try {
+      await apiService.context.delete(entryId);
+      await fetchRecentContext();
+    } catch (error) {
+      console.error('Error deleting context entry:', error);
+    }
+  };
+
+  const handleClearAllContext = async () => {
+    if (!confirm('Clear ALL recent context? Sensei will forget its short-term notes from the last 14 days.')) return;
+
+    try {
+      await apiService.context.clearAll();
+      await fetchRecentContext();
+    } catch (error) {
+      console.error('Error clearing recent context:', error);
+    }
+  };
+
   const startEditing = (memory) => {
     setEditingMemory(memory);
     setFormData({
@@ -505,19 +527,27 @@ export default function MemoriesSettings() {
           )}
         </div>
 
-        {/* Recent context — the coach's short-term working memory (read-only) */}
+        {/* Recent context — the coach's short-term working memory */}
         {recentContext.length > 0 && (
           <div className="mt-8">
-            <div className="flex items-center gap-2 mb-2">
-              <Clock className="w-4 h-4 text-gray-400" />
-              <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
-                Recent context
-              </h2>
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                <Clock className="w-4 h-4 text-gray-400" />
+                <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
+                  Recent context
+                </h2>
+              </div>
+              <button
+                onClick={handleClearAllContext}
+                className="text-xs font-medium text-red-400 hover:text-red-500 transition-colors"
+              >
+                Clear all
+              </button>
             </div>
             <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
               Notes Sensei is working from right now — check-ins and conversation summaries.
-              These are short-term and automatically expire after 14 days. Anything worth keeping
-              longer becomes a memory above.
+              These are short-term and automatically expire after 14 days. Delete any note
+              that&apos;s outdated and Sensei will stop using it immediately.
             </p>
             <div className="space-y-2">
               {recentContext.map((entry) => {
@@ -539,6 +569,13 @@ export default function MemoriesSettings() {
                       <span className="text-xs text-gray-400">
                         {formatContextDate(entry.createdAt)}
                       </span>
+                      <button
+                        onClick={() => handleDeleteContextEntry(entry._id)}
+                        className="ml-auto p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors"
+                        title="Delete note"
+                      >
+                        <Trash2 className="w-3.5 h-3.5 text-red-400" />
+                      </button>
                     </div>
                     <p className="text-sm text-gray-700 dark:text-gray-300">
                       {entry.content}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -485,12 +485,18 @@ class APIService {
     })
   };
 
-  // Short-term context (the coach's 14-day working memory) — read-only
+  // Short-term context (the coach's 14-day working memory)
   context = {
     recent: async () => {
       const response = await this.request('/context/recent');
       return response.entries || response;
-    }
+    },
+    delete: (id) => this.request(`/context/${id}`, {
+      method: 'DELETE'
+    }),
+    clearAll: () => this.request('/context', {
+      method: 'DELETE'
+    })
   };
 
   // Workout Logs endpoints (completed workouts from TrainNow)


### PR DESCRIPTION
## Problem

A user deleted their injuries (profile + user memories), but the sensei kept citing them. Root cause (verified in prod):

1. `shortTermContext` conversation summaries restated the injuries for 14 days, were injected into every prompt, and had **no delete endpoint or UI**. Each new conversation's summary re-asserted them, rolling the TTL forward indefinitely.
2. `promote_durable_facts` dedups against the raw memories array — a **hard-deleted** memory is invisible to it, so the deleted injury fact could be re-promoted into `usermemories` from old transcripts.
3. The day's cached Today's Pick (`dailyRecommendations`) embedded the injury context and was served for the rest of the day.

## Changes

- **User-deletable short-term context**: `DELETE /api/v1/context/:entryId` + `DELETE /api/v1/context` (clear all), user-scoped; Recent context section in MemoriesSettings gains per-entry delete and Clear all.
- **Deleted means deleted**: memory deletion (REST + sensei tool) tombstones (`deleted`, `deletedAt`, `isActive:false`) instead of splicing, so promotion dedup still sees the fact and never re-learns it. All read paths (API, prompt injection, list/update tools) filter tombstones; `enforce_cap` neither counts nor evicts them.
- **Leaner summaries**: rewritten `SUMMARIZE_PROMPT` — only NEW info from this conversation, never restate facts on file, no "no injuries reported" padding, `SKIP` for trivial chats (claim kept, promotion skipped). RECENT CONTEXT header now says profile/memories win on conflict.
- **Cache invalidation**: `invalidateTodaysPick()` drops today's cached pick when a health memory is deleted, profile injuries change, or short-term context is deleted.
- **Prompt policy**: the coach honors explicit user requests to delete health memories without arguing (keeps the don't-auto-delete-on-recovery default).

## Tests

- New `ai-coach-service/tests/test_memory_tombstones.py` (11 tests): tombstone filtering, delete-as-tombstone, cap enforcement, promotion dedup against deleted facts, SKIP handling (claim retention).
- Full suite: 422 passed; the single failure (`test_add_exercise_dedup`) also fails on clean origin/main (pre-existing, unrelated).

## Notes

- Tombstones block auto-promotion of the same fact permanently; a genuine re-injury must be saved explicitly. Revisit with an age window if needed.
- Follow-up (out of scope): `chatConversations` transcripts are never user-deletable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)