### PR TITLE
Sports news on the dashboard: swipeable cards from cached ESPN feeds

### DIFF
--- a/backend/src/config/sportsNews.js
+++ b/backend/src/config/sportsNews.js
@@ -1,0 +1,46 @@
+/**
+ * Sports News configuration
+ *
+ * Canonical sport slugs and the ESPN feed endpoints that back them.
+ * Endpoints are relative to https://site.api.espn.com/apis/site/v2/sports/
+ * (unofficial ESPN API — no key required, but undocumented and can change).
+ *
+ * Sports with an empty feed list (no reliable ESPN coverage) are still valid
+ * user choices — they simply contribute no articles.
+ */
+
+const SPORT_FEEDS = {
+  soccer: ['soccer/eng.1/news', 'soccer/uefa.champions/news'],
+  basketball: ['basketball/nba/news'],
+  football: ['football/nfl/news'], // American football
+  baseball: ['baseball/mlb/news'],
+  hockey: ['hockey/nhl/news'],
+  tennis: ['tennis/atp/news', 'tennis/wta/news'],
+  golf: ['golf/pga/news'],
+  motorsport: ['racing/f1/news'],
+  mma: ['mma/ufc/news'],
+  cycling: [],
+  running: []
+};
+
+// Seasonal "everyone sees this" feeds. Entries outside their [from, to)
+// window are skipped by the job, so stale config degrades to "no top
+// stories" rather than wrong ones.
+const GLOBAL_TOP_FEEDS = [
+  {
+    endpoint: 'soccer/fifa.world/news',
+    label: 'World Cup',
+    from: '2026-06-01',
+    to: '2026-08-01'
+  }
+];
+
+const NEWS_TTL_DAYS = 3;
+const MAX_ARTICLES_PER_FEED = 10;
+
+module.exports = {
+  SPORT_FEEDS,
+  GLOBAL_TOP_FEEDS,
+  NEWS_TTL_DAYS,
+  MAX_ARTICLES_PER_FEED
+};

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -227,7 +227,16 @@ const updateProfile = async (req, res) => {
     }
     if (settings) {
       const existingSettings = req.user.settings ? (req.user.settings.toObject ? req.user.settings.toObject() : req.user.settings) : {};
-      updateData.settings = { ...existingSettings, ...settings };
+      // Deep merge sportsNews (like profile.preferences above): a partial
+      // update such as { sportsNews: { enabled: false } } must not wipe the
+      // user's followed-sports list.
+      updateData.settings = {
+        ...existingSettings,
+        ...settings,
+        ...(settings.sportsNews
+          ? { sportsNews: { ...(existingSettings.sportsNews || {}), ...settings.sportsNews } }
+          : {})
+      };
     }
 
     const user = await User.findByIdAndUpdate(

--- a/backend/src/jobs/scheduler.js
+++ b/backend/src/jobs/scheduler.js
@@ -1,4 +1,5 @@
 const CalendarConsistencyJob = require('./calendarConsistencyJob');
+const SportsNewsJob = require('./sportsNewsJob');
 
 /**
  * Job Scheduler
@@ -37,6 +38,18 @@ class JobScheduler {
       true // Run immediately on startup
     );
     this.intervals.push(calendarConsistencyInterval);
+
+    // Sports News Job - refreshes the cached ESPN feeds every 4 hours
+    const sportsNewsInterval = this.scheduleJob(
+      'SportsNewsFetch',
+      async () => {
+        const job = new SportsNewsJob(this.logger);
+        return await job.run();
+      },
+      4 * 60 * 60 * 1000, // 4 hours in milliseconds
+      true // Run immediately on startup
+    );
+    this.intervals.push(sportsNewsInterval);
 
     this.logger.info('[JobScheduler] Scheduler started successfully');
   }

--- a/backend/src/jobs/sportsNewsJob.js
+++ b/backend/src/jobs/sportsNewsJob.js
@@ -1,0 +1,75 @@
+const SportsNewsService = require('../services/SportsNewsService');
+const { SPORT_FEEDS } = require('../config/sportsNews');
+
+/**
+ * Sports News Job
+ *
+ * Fetches every configured ESPN news feed (per-sport feeds plus any
+ * seasonally-active global top-event feeds) into the newsarticles cache
+ * collection. Each feed is isolated: one failing feed is recorded in stats
+ * and never aborts the run, so partial data still lands and previously
+ * cached articles keep serving through source outages.
+ */
+
+class SportsNewsJob {
+  constructor(logger = console) {
+    this.logger = logger;
+    this.stats = {
+      feedsProcessed: 0,
+      feedsFailed: 0,
+      articlesUpserted: 0,
+      errors: []
+    };
+  }
+
+  async run() {
+    this.logger.info('[SportsNewsJob] Starting news fetch...');
+    const startTime = Date.now();
+
+    this.stats = {
+      feedsProcessed: 0,
+      feedsFailed: 0,
+      articlesUpserted: 0,
+      errors: []
+    };
+
+    const service = new SportsNewsService(this.logger);
+
+    const feeds = [];
+    for (const [sportSlug, endpoints] of Object.entries(SPORT_FEEDS)) {
+      for (const endpoint of endpoints) {
+        feeds.push({ endpoint, sportSlug, isTopEvent: false });
+      }
+    }
+    for (const feed of service.activeGlobalFeeds()) {
+      feeds.push({ endpoint: feed.endpoint, sportSlug: null, isTopEvent: true });
+    }
+
+    for (const { endpoint, sportSlug, isTopEvent } of feeds) {
+      try {
+        const articles = await service.fetchFeed(endpoint);
+        const upserted = await service.upsertArticles(articles, sportSlug, isTopEvent);
+        this.stats.feedsProcessed++;
+        this.stats.articlesUpserted += upserted;
+      } catch (error) {
+        this.stats.feedsFailed++;
+        this.stats.errors.push({ endpoint, error: error.message });
+        this.logger.error(`[SportsNewsJob] Feed failed: ${endpoint}`, { error: error.message });
+      }
+    }
+
+    const duration = Date.now() - startTime;
+    this.logger.info('[SportsNewsJob] News fetch completed', {
+      duration: `${duration}ms`,
+      stats: this.stats
+    });
+
+    return {
+      success: true,
+      duration,
+      stats: this.stats
+    };
+  }
+}
+
+module.exports = SportsNewsJob;

--- a/backend/src/models/NewsArticle.js
+++ b/backend/src/models/NewsArticle.js
@@ -1,0 +1,54 @@
+const mongoose = require('mongoose');
+
+/**
+ * Cached sports-news article fetched from an external feed (ESPN) by the
+ * SportsNewsFetch job. The collection is the cache: refetching an article
+ * refreshes `expiresAt`, so articles that stay in the source's feed outlive
+ * outages, and articles that drop out expire via the TTL index.
+ *
+ * The same story can appear in multiple league feeds; it is deduped on
+ * `articleUrl` and accumulates all matching sport slugs in `sports`.
+ */
+const newsArticleSchema = new mongoose.Schema({
+  articleUrl: {
+    type: String,
+    required: true,
+    unique: true
+  },
+  headline: {
+    type: String,
+    required: true
+  },
+  description: String,
+  imageUrl: String,
+  // Canonical sport slugs from config/sportsNews.js SPORT_FEEDS
+  sports: {
+    type: [String],
+    default: []
+  },
+  // Seen in an active GLOBAL_TOP_FEED (e.g. World Cup) — shown to everyone.
+  // Once true it is never un-flipped within the article's cache lifetime.
+  isTopEvent: {
+    type: Boolean,
+    default: false
+  },
+  source: {
+    type: String,
+    default: 'ESPN'
+  },
+  publishedAt: Date,
+  fetchedAt: Date,
+  expiresAt: {
+    type: Date,
+    required: true
+  }
+}, {
+  timestamps: true
+});
+
+// TTL index: articles no longer refreshed by the job are removed automatically.
+newsArticleSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+newsArticleSchema.index({ sports: 1, publishedAt: -1 });
+newsArticleSchema.index({ isTopEvent: 1, publishedAt: -1 });
+
+module.exports = mongoose.model('NewsArticle', newsArticleSchema);

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -108,6 +108,16 @@ const userSchema = new mongoose.Schema({
     timezone: {
       type: String,
       default: 'UTC' // e.g., 'Asia/Jerusalem', 'America/New_York'
+    },
+    // Sports-news dashboard widget. `sports` are the sports the user follows
+    // for news — distinct from profile.sportPreferences (sports they train),
+    // which feeds AI-coach context.
+    sportsNews: {
+      enabled: {
+        type: Boolean,
+        default: true
+      },
+      sports: [String] // canonical slugs from config/sportsNews.js
     }
   }
 }, {

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -6,6 +6,7 @@ const Exercise = require('../models/Exercise');
 const Goal = require('../models/Goal');
 const PredefinedWorkout = require('../models/PredefinedWorkout');
 const CalendarConsistencyJob = require('../jobs/calendarConsistencyJob');
+const SportsNewsJob = require('../jobs/sportsNewsJob');
 
 // All routes require authentication and admin role
 router.use(auth);
@@ -320,6 +321,30 @@ router.post('/jobs/calendar-consistency', async (req, res) => {
     res.json({
       success: result.success,
       message: result.success ? 'Calendar consistency job completed' : 'Job completed with errors',
+      data: {
+        duration: `${result.duration}ms`,
+        stats: result.stats
+      }
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: error.message
+    });
+  }
+});
+
+// @route   POST /api/v1/admin/jobs/sports-news
+// @desc    Run sports news fetch job (refresh cached ESPN feeds)
+// @access  Admin only
+router.post('/jobs/sports-news', async (req, res) => {
+  try {
+    const job = new SportsNewsJob(console);
+    const result = await job.run();
+
+    res.json({
+      success: result.success,
+      message: result.stats.feedsFailed === 0 ? 'Sports news job completed' : 'Job completed with errors',
       data: {
         duration: `${result.duration}ms`,
         stats: result.stats

--- a/backend/src/routes/news.js
+++ b/backend/src/routes/news.js
@@ -1,0 +1,76 @@
+const express = require('express');
+const NewsArticle = require('../models/NewsArticle');
+const { SPORT_FEEDS } = require('../config/sportsNews');
+const { auth } = require('../middleware/auth');
+const router = express.Router();
+
+// GET /api/v1/news - Sports news feed for the authenticated user:
+// seasonal top-event stories (shown to everyone) interleaved with articles
+// matching the sports the user follows (settings.sportsNews.sports).
+router.get('/', auth, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 15, 50);
+
+    const sportsNews = req.user.settings?.sportsNews || {};
+    if (sportsNews.enabled === false) {
+      return res.json({ success: true, data: { enabled: false, articles: [] } });
+    }
+
+    const followedSports = Array.isArray(sportsNews.sports) ? sportsNews.sports : [];
+
+    // Two queries instead of one isTopEvent-first sort: the swipe stack is
+    // strictly sequential, so uncapped top events (up to a whole feed's
+    // worth) would bury the user's own sports behind them.
+    const TOP_EVENT_CAP = 4;
+    const topEvents = await NewsArticle.find({ isTopEvent: true })
+      .sort({ publishedAt: -1 })
+      .limit(TOP_EVENT_CAP)
+      .lean();
+
+    let personal = [];
+    if (followedSports.length > 0) {
+      personal = await NewsArticle.find({
+        _id: { $nin: topEvents.map((a) => a._id) },
+        sports: { $in: followedSports }
+      })
+        .sort({ publishedAt: -1 })
+        .limit(limit)
+        .lean();
+    }
+
+    // Interleave 1 top : 2 personal, remainder appended
+    const merged = [];
+    let t = 0;
+    let p = 0;
+    while (merged.length < limit && (t < topEvents.length || p < personal.length)) {
+      if (t < topEvents.length) merged.push(topEvents[t++]);
+      for (let i = 0; i < 2 && merged.length < limit && p < personal.length; i++) {
+        merged.push(personal[p++]);
+      }
+    }
+
+    const articles = merged.map((a) => ({
+      id: a._id,
+      headline: a.headline,
+      description: a.description,
+      imageUrl: a.imageUrl,
+      articleUrl: a.articleUrl,
+      sports: a.sports,
+      isTopEvent: a.isTopEvent,
+      source: a.source,
+      publishedAt: a.publishedAt
+    }));
+
+    // Only feed-backed sports count: a user following only sports with no
+    // configured feed should get the "pick sports" nudge, not silence.
+    const followsSports = followedSports.some((s) => (SPORT_FEEDS[s] || []).length > 0);
+    res.json({
+      success: true,
+      data: { enabled: true, followsSports, articles }
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -57,6 +57,7 @@ const webhookRoutes = require('./routes/webhooks');
 const workoutLogRoutes = require('./routes/workoutLogs');
 const trainNowRoutes = require('./routes/trainNow');
 const coachQuestionRoutes = require('./routes/coachQuestion');
+const newsRoutes = require('./routes/news');
 const mcpAuthRoutes = require('./routes/mcpAuth');
 const mcpRoutes = require('./routes/mcp');
 
@@ -290,6 +291,7 @@ app.use('/api/v1/webhooks', webhookRoutes);
 app.use('/api/v1/workout-logs', workoutLogRoutes);
 app.use('/api/v1/train-now', trainNowRoutes);
 app.use('/api/v1/coach-question', coachQuestionRoutes);
+app.use('/api/v1/news', newsRoutes);
 
 // MCP connector: OAuth authorization-server routes (mounted at root — the
 // `.well-known` discovery documents are origin-rooted) and the /mcp endpoint.

--- a/backend/src/services/SportsNewsService.js
+++ b/backend/src/services/SportsNewsService.js
@@ -1,0 +1,120 @@
+const axios = require('axios');
+const NewsArticle = require('../models/NewsArticle');
+const {
+  GLOBAL_TOP_FEEDS,
+  NEWS_TTL_DAYS,
+  MAX_ARTICLES_PER_FEED
+} = require('../config/sportsNews');
+
+const ESPN_BASE_URL = 'https://site.api.espn.com/apis/site/v2/sports';
+
+/**
+ * Fetches sports news from ESPN's unofficial API and caches it in the
+ * newsarticles collection. The API is undocumented, so parsing is defensive:
+ * malformed articles are skipped, requests time out at 10s, and a failed
+ * feed never throws past its caller's per-feed error isolation.
+ */
+class SportsNewsService {
+  constructor(logger = console) {
+    this.logger = logger;
+  }
+
+  /**
+   * Fetch one ESPN news feed and map it to NewsArticle-shaped objects.
+   * Filters out items unusable as news cards: missing url/headline,
+   * ESPN+ premium (paywalled), and video clips.
+   * @param {string} endpoint - e.g. 'racing/f1/news'
+   * @returns {Promise<Array>} mapped articles (possibly empty)
+   */
+  async fetchFeed(endpoint) {
+    const response = await axios.get(`${ESPN_BASE_URL}/${endpoint}`, {
+      timeout: 10000,
+      params: { limit: MAX_ARTICLES_PER_FEED }
+    });
+
+    const articles = Array.isArray(response.data?.articles) ? response.data.articles : [];
+
+    return articles
+      .map((a) => ({
+        articleUrl: a.links?.web?.href,
+        headline: a.headline,
+        description: a.description,
+        imageUrl: a.images?.[0]?.url,
+        publishedAt: a.published ? new Date(a.published) : undefined,
+        type: a.type,
+        premium: a.premium
+      }))
+      .filter((a) => {
+        if (!a.articleUrl || !a.headline) return false;
+        if (a.premium === true) return false;
+        // Video clips make bad reading cards (autoplay pages, no article body)
+        if (a.articleUrl.includes('/video/')) return false;
+        if (a.type === 'Media' || a.type === 'Clip') return false;
+        return true;
+      })
+      .map(({ type, premium, ...article }) => article);
+  }
+
+  /**
+   * Upsert a feed's articles, deduping on articleUrl. A story seen in
+   * several feeds accumulates all their sport slugs; refetching refreshes
+   * expiresAt so the cache survives source outages.
+   * @param {Array} articles - output of fetchFeed
+   * @param {string|null} sportSlug - canonical slug, or null for global feeds
+   * @param {boolean} isTopEvent - whether the feed is an active global top feed
+   * @returns {Promise<number>} number of articles upserted
+   */
+  async upsertArticles(articles, sportSlug, isTopEvent) {
+    if (articles.length === 0) return 0;
+
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + NEWS_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+    const ops = articles.map((article) => {
+      const update = {
+        $set: {
+          headline: article.headline,
+          description: article.description,
+          imageUrl: article.imageUrl,
+          ...(article.publishedAt ? { publishedAt: article.publishedAt } : {}),
+          fetchedAt: now,
+          expiresAt
+        }
+      };
+      if (sportSlug) {
+        update.$addToSet = { sports: sportSlug };
+      }
+      if (isTopEvent) {
+        // A top-feed sighting flips the flag and it stays flipped
+        update.$set.isTopEvent = true;
+      } else {
+        // $setOnInsert (not $set) so a regular-feed sighting of the same
+        // story never un-flips an earlier top-event flag
+        update.$setOnInsert = { isTopEvent: false };
+      }
+      return {
+        updateOne: {
+          filter: { articleUrl: article.articleUrl },
+          update,
+          upsert: true
+        }
+      };
+    });
+
+    const result = await NewsArticle.bulkWrite(ops, { ordered: false });
+    return (result.upsertedCount || 0) + (result.modifiedCount || 0);
+  }
+
+  /**
+   * Global top-event feeds whose seasonal window contains `now`.
+   */
+  activeGlobalFeeds(now = new Date()) {
+    return GLOBAL_TOP_FEEDS.filter((feed) => {
+      const from = new Date(feed.from);
+      const to = new Date(feed.to);
+      return now >= from && now < to;
+    });
+  }
+}
+
+module.exports = SportsNewsService;

--- a/frontend/src/components/dashboard/SportsNewsCards.jsx
+++ b/frontend/src/components/dashboard/SportsNewsCards.jsx
@@ -1,0 +1,225 @@
+import React, { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { createPageUrl } from "@/utils";
+import apiService from "@/services/api";
+import { motion, AnimatePresence } from "framer-motion";
+import { Newspaper, Star, ChevronRight, X } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+
+const DISMISSED_KEY = "sportsNews.dismissed";
+// Once the user closes the "pick sports" nudge it never comes back (no TTL)
+const NUDGE_DISMISSED_KEY = "sportsNews.nudgeDismissed";
+// On touch devices, two-axis drag makes framer-motion set touch-action:none,
+// turning the card into a page-scroll dead-zone. Horizontal-only drag there
+// keeps vertical thumbs scrolling; mouse users keep any-direction swipes.
+const IS_COARSE_POINTER =
+  typeof window !== "undefined" && window.matchMedia?.("(pointer: coarse)")?.matches;
+const DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000; // articles can outlive their
+// nominal cache TTL (refetch extends it), so prune well past it
+const SWIPE_DISTANCE = 120;
+const SWIPE_VELOCITY = 800;
+
+function loadDismissed() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(DISMISSED_KEY)) || [];
+    const fresh = raw.filter((d) => Date.now() - d.ts < DISMISS_TTL_MS);
+    if (fresh.length !== raw.length) {
+      localStorage.setItem(DISMISSED_KEY, JSON.stringify(fresh));
+    }
+    return new Set(fresh.map((d) => d.id));
+  } catch {
+    return new Set();
+  }
+}
+
+function saveDismissed(id) {
+  try {
+    const raw = JSON.parse(localStorage.getItem(DISMISSED_KEY)) || [];
+    localStorage.setItem(DISMISSED_KEY, JSON.stringify([...raw, { id, ts: Date.now() }]));
+  } catch {
+    // localStorage unavailable — dismissals just won't persist
+  }
+}
+
+export default function SportsNewsCards() {
+  const navigate = useNavigate();
+  const [stack, setStack] = useState([]);
+  const [state, setState] = useState("loading"); // loading | ready | nudge | hidden
+  // Direction of the last dismissing swipe, read by the exit animation
+  const flyOut = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await apiService.news.list();
+        if (cancelled) return;
+        if (data?.enabled === false) {
+          setState("hidden");
+          return;
+        }
+        const dismissed = loadDismissed();
+        const articles = (data?.articles || []).filter((a) => !dismissed.has(a.id));
+        if (articles.length > 0) {
+          setStack(articles);
+          setState("ready");
+        } else if (!data?.followsSports && !localStorage.getItem(NUDGE_DISMISSED_KEY)) {
+          setState("nudge");
+        } else {
+          setState("hidden");
+        }
+      } catch {
+        // News must never break the dashboard
+        if (!cancelled) setState("hidden");
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleDragEnd = (_event, info) => {
+    const distance = Math.hypot(info.offset.x, info.offset.y);
+    const speed = Math.hypot(info.velocity.x, info.velocity.y);
+    if (distance > SWIPE_DISTANCE || speed > SWIPE_VELOCITY) {
+      flyOut.current = {
+        x: info.offset.x + info.velocity.x * 0.2,
+        y: info.offset.y + info.velocity.y * 0.2
+      };
+      const top = stack[0];
+      saveDismissed(top.id);
+      setStack((prev) => prev.slice(1));
+    }
+  };
+
+  if (state === "loading" || state === "hidden") return null;
+
+  if (state === "nudge") {
+    return (
+      <div className="mt-2">
+        <SectionHeader />
+        <div className="relative">
+          <button
+            onClick={() => navigate(createPageUrl("Settings"))}
+            className="w-full flex items-center justify-between bg-white rounded-2xl border border-gray-200 shadow-sm p-4 pr-16 text-left hover:bg-gray-50 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-gray-900">Follow your sports</p>
+              <p className="text-sm text-gray-500">Pick sports you follow to see news here</p>
+            </div>
+            <ChevronRight className="w-5 h-5 text-gray-400 flex-shrink-0" />
+          </button>
+          <button
+            onClick={() => {
+              try { localStorage.setItem(NUDGE_DISMISSED_KEY, "1"); } catch { /* non-persistent */ }
+              setState("hidden");
+            }}
+            className="absolute top-2 right-2 p-1.5 text-gray-400 hover:text-gray-600 rounded-full hover:bg-gray-100 transition-colors"
+            title="Don't show again"
+            aria-label="Dismiss"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (stack.length === 0) return null;
+
+  return (
+    <div className="mt-2">
+      <SectionHeader />
+      <div className="relative h-60 select-none">
+        <AnimatePresence>
+          {stack.slice(0, 3).map((article, i) => (
+            <NewsCard
+              key={article.id}
+              article={article}
+              depth={i}
+              flyOut={flyOut}
+              onDragEnd={handleDragEnd}
+            />
+          )).reverse()}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader() {
+  return (
+    <div className="flex items-center gap-2 mb-3">
+      <Newspaper className="w-4 h-4 text-gray-500" />
+      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Sports news</h3>
+    </div>
+  );
+}
+
+function NewsCard({ article, depth, flyOut, onDragEnd }) {
+  const isTop = depth === 0;
+  // The card follows the pointer while dragging, so the pointer never leaves
+  // it and framer-motion's tap gesture fires even at the end of a swipe.
+  // Gate the tap on actual pointer travel: only a still press opens the link.
+  const dragDistance = useRef(0);
+  const sport = article.sports?.[0];
+  const publishedAgo = article.publishedAt
+    ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
+    : null;
+
+  return (
+    <motion.div
+      className="absolute inset-0 rounded-2xl overflow-hidden shadow-md bg-gray-900"
+      style={{ cursor: isTop ? "grab" : "auto", zIndex: 10 - depth }}
+      initial={{ scale: 1 - (depth + 1) * 0.05, y: (depth + 1) * 10, opacity: depth >= 2 ? 0 : 1 }}
+      animate={{ scale: 1 - depth * 0.05, y: depth * 10, opacity: depth >= 2 ? 0.6 : 1 }}
+      exit={{
+        x: flyOut.current.x * 3,
+        y: flyOut.current.y * 3,
+        rotate: flyOut.current.x > 0 ? 20 : -20,
+        opacity: 0,
+        transition: { duration: 0.3 }
+      }}
+      drag={isTop && (IS_COARSE_POINTER ? "x" : true)}
+      dragElastic={0.7}
+      dragSnapToOrigin
+      onDragEnd={isTop ? onDragEnd : undefined}
+      whileDrag={{ cursor: "grabbing", scale: 1.02 }}
+      onTapStart={isTop ? () => { dragDistance.current = 0; } : undefined}
+      onDrag={isTop ? (_e, info) => { dragDistance.current = Math.hypot(info.offset.x, info.offset.y); } : undefined}
+      onTap={isTop ? () => {
+        if (dragDistance.current < 5) {
+          window.open(article.articleUrl, "_blank", "noopener");
+        }
+      } : undefined}
+    >
+      {article.imageUrl ? (
+        <img
+          src={article.imageUrl}
+          alt=""
+          className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+          draggable={false}
+        />
+      ) : (
+        <div className="absolute inset-0 bg-gradient-to-br from-indigo-600 to-purple-700" />
+      )}
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/90 via-black/60 to-transparent pt-12 pb-3 px-4">
+        <div className="flex items-center gap-2 mb-1.5">
+          {article.isTopEvent && (
+            <span className="inline-flex items-center gap-1 bg-amber-400/95 text-amber-950 text-[11px] font-semibold px-2 py-0.5 rounded-full">
+              <Star className="w-3 h-3" /> Top story
+            </span>
+          )}
+          {sport && (
+            <span className="bg-white/20 backdrop-blur-sm text-white text-[11px] font-medium px-2 py-0.5 rounded-full capitalize">
+              {sport}
+            </span>
+          )}
+        </div>
+        <p className="text-white font-semibold leading-snug line-clamp-2">{article.headline}</p>
+        <p className="text-white/60 text-xs mt-1">
+          {article.source}
+          {publishedAgo ? ` · ${publishedAgo}` : ""}
+        </p>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/dashboard/TodayView.jsx
+++ b/frontend/src/components/dashboard/TodayView.jsx
@@ -5,6 +5,7 @@ import { CalendarEvent, UserGoalProgress } from "@/api/entities";
 import apiService from "@/services/api";
 import aiService from "@/services/aiService";
 import { pickTodaySession } from "@/utils/todaySession";
+import SportsNewsCards from "./SportsNewsCards";
 import { getDisciplineColor } from "@/styles/designTokens";
 import {
   Play, Sparkles, X, ChevronRight, ArrowRight, Check, Bike, Dumbbell,
@@ -432,6 +433,9 @@ export default function TodayView() {
             </div>
           </>
         )}
+
+        {/* SPORTS NEWS — swipeable cards */}
+        <SportsNewsCards />
       </div>
     </div>
   );

--- a/frontend/src/pages/AdminJobs.jsx
+++ b/frontend/src/pages/AdminJobs.jsx
@@ -11,7 +11,8 @@ import {
   AlertTriangle,
   Clock,
   RefreshCw,
-  User
+  User,
+  Newspaper
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -219,6 +220,19 @@ export default function AdminJobs() {
           return await apiService.adminJobs.runCalendarConsistencyForUser(userId);
         }
         return await apiService.adminJobs.runCalendarConsistency();
+      }
+    },
+    {
+      id: 'sports-news',
+      name: 'Sports News Fetch',
+      description: 'Refreshes the cached sports-news articles from ESPN feeds',
+      details: 'Fetches every configured per-sport ESPN news feed plus any seasonally-active top-event feeds (e.g. World Cup) into the newsarticles cache collection. Failing feeds are recorded in stats without aborting the run.',
+      icon: <Newspaper className="w-5 h-5 text-white" />,
+      color: 'bg-emerald-500',
+      schedule: 'Every 4 hours',
+      supportsUser: false,
+      run: async () => {
+        return await apiService.adminJobs.runSportsNews();
       }
     }
   ];

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -8,6 +8,7 @@ import { createPageUrl } from "@/utils";
 import BodyRegionChart from "../components/dashboard/BodyRegionChart";
 import WeeklyOptimization from "../components/dashboard/WeeklyOptimization"; // New import
 import TodayView from "../components/dashboard/TodayView";
+import SportsNewsCards from "../components/dashboard/SportsNewsCards";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -457,6 +458,9 @@ export default function Dashboard() {
                   </div>
                 )}
               </div>
+
+              {/* Sports News */}
+              <SportsNewsCards />
             </div>
           </div>
         </>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Camera, Moon, Sun, Loader2, Brain, Link, Unlink, RefreshCw, CheckCircle, AlertCircle, Trash2, Copy, Sparkles, KeyRound, X, Target, HeartPulse } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Camera, Moon, Sun, Loader2, Brain, Link, Unlink, RefreshCw, CheckCircle, AlertCircle, Trash2, Copy, Sparkles, KeyRound, X, Target, HeartPulse, Newspaper } from 'lucide-react';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Switch } from '@/components/ui/switch';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -15,6 +15,15 @@ import {
   AlertDialogFooter,
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog';
+
+// Canonical sport slugs for the news feature — must match keys of
+// SPORT_FEEDS in backend/src/config/sportsNews.js that have at least one
+// feed. Sports with no feed (cycling, running) are omitted: a chip that can
+// never produce an article would be a silent dead end.
+const NEWS_SPORTS = [
+  'soccer', 'basketball', 'football', 'baseball', 'hockey',
+  'tennis', 'golf', 'motorsport', 'mma'
+];
 
 export default function Settings() {
   const navigate = useNavigate();
@@ -62,7 +71,8 @@ export default function Settings() {
       notifications: true,
       theme: 'light',
       weekStartDay: 0, // 0 = Sunday, 1 = Monday
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      sportsNews: { enabled: true, sports: [] }
     }
   });
 
@@ -143,7 +153,11 @@ export default function Settings() {
             notifications: userData.settings?.notifications ?? true,
             theme: userData.settings?.theme || 'light',
             weekStartDay: userData.settings?.weekStartDay ?? 0,
-            timezone: userData.settings?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
+            timezone: userData.settings?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+            sportsNews: {
+              enabled: userData.settings?.sportsNews?.enabled ?? true,
+              sports: userData.settings?.sportsNews?.sports || []
+            }
           }
         });
       }
@@ -230,6 +244,43 @@ export default function Settings() {
     } finally {
       setIsSaving(false);
     }
+  };
+
+  // Persist a full settings object immediately (like commitProfile). Always
+  // sends the complete sportsNews sub-object — the server deep-merges it, and
+  // a partial send must never wipe the followed-sports list.
+  const commitSettings = async (nextSettings) => {
+    setFormData((prev) => ({ ...prev, settings: nextSettings }));
+    setIsSaving(true);
+    try {
+      const token = localStorage.getItem('authToken');
+      const response = await fetch(`${import.meta.env.VITE_API_URL || 'http://localhost:5001'}/api/v1/auth/profile`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ settings: nextSettings })
+      });
+      if (response.ok) {
+        const data = await response.json();
+        const authUser = JSON.parse(localStorage.getItem('authUser') || '{}');
+        localStorage.setItem('authUser', JSON.stringify({ ...authUser, ...data.data.user }));
+        setUser(data.data.user);
+      }
+    } catch (error) {
+      console.error('Error saving settings:', error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const toggleFollowedSport = (slug) => {
+    const current = formData.settings.sportsNews?.sports || [];
+    const next = current.includes(slug)
+      ? current.filter((s) => s !== slug)
+      : [...current, slug];
+    commitSettings({
+      ...formData.settings,
+      sportsNews: { ...formData.settings.sportsNews, sports: next }
+    });
   };
 
   const addProfileItem = (key, value, clear) => {
@@ -643,6 +694,63 @@ export default function Settings() {
           <div className="space-y-1">
             {renderChipEditor('Goals', 'goals', Target, newGoal, setNewGoal, 'e.g. 20 consecutive pull-ups')}
             {renderChipEditor('Injuries', 'injuries', HeartPulse, newInjury, setNewInjury, 'e.g. right shoulder — avoid overhead')}
+          </div>
+        </div>
+
+        {/* Sports News Section */}
+        <div className="mt-8">
+          <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">Sports News</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            News from sports you follow shows up as cards on your dashboard.
+          </p>
+          <div className="space-y-1">
+            <div className="py-4 border-b border-gray-100 dark:border-gray-800">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Newspaper className="w-5 h-5 text-primary-400" />
+                  <div>
+                    <p className="text-sm font-bold text-gray-500 dark:text-gray-400 tracking-wide">
+                      Show Sports News
+                    </p>
+                    <p className="text-base font-medium text-gray-900 dark:text-white mt-1">
+                      {formData.settings.sportsNews?.enabled ? 'Enabled' : 'Disabled'}
+                    </p>
+                  </div>
+                </div>
+                <Switch
+                  checked={formData.settings.sportsNews?.enabled ?? true}
+                  onCheckedChange={(checked) => commitSettings({
+                    ...formData.settings,
+                    sportsNews: { ...formData.settings.sportsNews, enabled: checked }
+                  })}
+                  className="data-[state=checked]:bg-primary-400"
+                />
+              </div>
+            </div>
+            <div className="py-4 border-b border-gray-100 dark:border-gray-800">
+              <p className="text-sm font-bold text-gray-500 dark:text-gray-400 tracking-wide mb-2">
+                Sports I Follow
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {NEWS_SPORTS.map((slug) => {
+                  const selected = (formData.settings.sportsNews?.sports || []).includes(slug);
+                  return (
+                    <button
+                      key={slug}
+                      onClick={() => toggleFollowedSport(slug)}
+                      disabled={isSaving}
+                      className={`px-3 py-1 rounded-full text-sm capitalize transition-colors ${
+                        selected
+                          ? 'bg-primary-400 text-gray-900 font-semibold'
+                          : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                      }`}
+                    >
+                      {slug}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -534,7 +534,15 @@ class APIService {
     }),
     runCalendarConsistencyForUser: (userId) => this.request(`/admin/jobs/calendar-consistency/user/${userId}`, {
       method: 'POST'
+    }),
+    runSportsNews: () => this.request('/admin/jobs/sports-news', {
+      method: 'POST'
     })
+  };
+
+  // Sports news endpoints
+  news = {
+    list: (limit = 15) => this.request(`/news?limit=${limit}`)
   };
 
   // Alias endpoints for naming compatibility


### PR DESCRIPTION
## What

Adds a sports-news section to the dashboard: image-forward news cards the user can swipe away to reveal the next story, mixing globally important stories (World Cup now, seasonal config for Olympics later) with news from sports the user follows.

## How

**Backend**
- `SportsNewsFetch` job (in-process scheduler, every 4h + `POST /admin/jobs/sports-news` manual trigger with an AdminJobs card) fetches ESPN's unofficial per-sport news feeds plus seasonally-active top-event feeds into a TTL-cached `newsarticles` collection (3-day TTL, refreshed on refetch so the cache serves through ESPN outages). Per-feed error isolation: one bad feed never kills the run.
- Content filtering: premium (ESPN+) items and video-clip links are skipped — cards always land on readable story pages.
- `GET /api/v1/news`: interleaves top events (capped at 4) 1:2 with articles matching the user's followed sports, so top stories can't bury personal interests in a sequential swipe stack.
- `settings.sportsNews { enabled, sports }` on the User schema; `updateProfile` deep-merges the sub-object (mirroring the existing `profile.preferences` merge) so a partial `{enabled:false}` write can't wipe the followed-sports list. Followed sports are deliberately separate from `profile.sportPreferences` (sports the user *trains*, which feeds AI-coach context).

**Frontend**
- `SportsNewsCards`: framer-motion drag-to-dismiss card stack (any direction with a mouse; horizontal-only on touch devices so vertical page scroll survives framer's `touch-action: none`). Tap opens the article — gated on pointer travel <5px because a dragged card follows the pointer and framer's tap gesture would otherwise fire at the end of every swipe. Dismissals persist in localStorage (14-day prune, outliving the article TTL that refetch extends). Placed in TodayView (mobile) and the desktop grid.
- Empty state: users following no sports (e.g. post-World Cup) get a "Follow your sports" nudge card linking to Settings, permanently dismissible via its X.
- Settings: "Show Sports News" switch + predefined followed-sports chips (only feed-backed sports are offered; `followsSports` in the API counts only feed-backed slugs so a dead-end selection still shows the nudge instead of silence).

## Verification (all on a scratch DB + throwaway user, dropped after)

- Job run: 12 feeds, 0 failures, 86 unique articles, 100% with images, 0 video links, 9 top-event flags, TTL + query indexes confirmed.
- API: top-events-only for a no-sports user; 1:2 interleave with followed sports; `limit` capped at 50; disabled → empty payload; partial `{enabled:false}` PUT preserved the sports list.
- Failure drill: bogus feed recorded in `stats.errors`, run still succeeded, other feeds upserted.
- Playwright (desktop + 390px iPhone viewport): swipe dismisses in all directions without opening the article, tap opens ESPN in a new tab, dismissals survive reload and are shared across mobile/desktop instances, Settings toggle/chips persist server-side, disabled hides the widget, nudge shows/navigates/permanently dismisses.

## Risk / follow-ups

- ESPN's API is unofficial; mitigations are per-feed isolation, the TTL-extended cache, defensive parsing, and a 10s timeout. Documented fallback: NewsData.io (free commercial tier) behind the same service interface.
- `GLOBAL_TOP_FEEDS` date windows self-expire (worst case "no top stories", never wrong ones); add the Olympics entry when relevant.
- Both dashboard variants mount their own card instance (one extra `GET /news` per load) — harmless, could be media-query-gated later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)