### PR TITLE
Dashboard loading states + coach-question cache (fix lazy pop-in)

### DIFF
--- a/ai-coach-service/app/api/v1/coach_question.py
+++ b/ai-coach-service/app/api/v1/coach_question.py
@@ -22,6 +22,7 @@ from app.middleware.auth import get_current_user
 from app.core.agents.data_reader import DataReaderAgent
 from app.core.agents.prompts import SYSTEM_PROMPT
 from app.core.agents.services import MemoryService
+from app.services.coach_question_service import CoachQuestionService
 from app.services.conversation_service import ConversationService
 from app.services.recommendation_service import RecommendationService
 from app.services.short_term_context_service import ShortTermContextService, spawn_background
@@ -68,10 +69,30 @@ async def get_coach_question(
 
     settings = get_settings()
     client = AsyncOpenAI(api_key=settings.openai_api_key)
-    data_reader = DataReaderAgent(db)
-    memory_service = MemoryService(db)
 
     user_id = current_user["user_id"]
+
+    # Serve the cached question while it's fresh (same local day, generated
+    # within the short TTL) so dashboard opens don't each pay an LLM call.
+    # Answering a question invalidates the cache (see post_coach_reply).
+    cache = CoachQuestionService(db)
+    cached = await cache.get_fresh(user_id)
+    if cached:
+        # This endpoint is one of only two triggers for the opportunistic
+        # stale-conversation summarizer — keep nudging it on cache hits too.
+        spawn_background(
+            ShortTermContextService(db).summarize_stale_conversations(user_id, client, settings)
+        )
+        return {
+            "success": True,
+            "question": cached.get("question"),
+            "chips": cached.get("chips") or [],
+            "source": cached.get("source") or "your training",
+            "cached": True,
+        }
+
+    data_reader = DataReaderAgent(db)
+    memory_service = MemoryService(db)
 
     try:
         user_context = {
@@ -189,6 +210,12 @@ USER DATA:
 
         logger.info(f"Generated coach question for user {user_id}: {question}")
 
+        # Cache only real generations — a transient failure must not pin the
+        # generic fallback question for the whole TTL window.
+        await cache.save(
+            user_id, today_date, timezone, question, chips, source or "your training"
+        )
+
         return {
             "success": True,
             "question": question,
@@ -291,6 +318,11 @@ async def post_coach_reply(
         # the answer across conversations (14-day TTL)
         await _save_checkin_entry(db, user_id, question, answer, reply, client, settings)
 
+        # Answered questions must not be re-served — drop the cache so the
+        # next dashboard open asks something new (which can reference this
+        # check-in via short-term context). Best-effort, never fails the reply.
+        await CoachQuestionService(db).invalidate(user_id)
+
         return {"success": True, "reply": reply}
 
     except Exception as e:
@@ -298,6 +330,7 @@ async def post_coach_reply(
         fallback_reply = "Got it — I've noted that. Tap continue if you want to talk it through."
         # The athlete's answer is the valuable part — persist it even on fallback
         await _save_checkin_entry(db, user_id, question, answer, fallback_reply, client, settings)
+        await CoachQuestionService(db).invalidate(user_id)
         return {
             "success": True,
             "reply": fallback_reply,

--- a/ai-coach-service/app/main.py
+++ b/ai-coach-service/app/main.py
@@ -8,6 +8,7 @@ import redis.asyncio as redis
 
 from app.config import get_settings, Settings
 from app.api.v1 import health, chat, chat_stream, conversations, documents, exercises, internal, progressions, suggestions, train_now, coach_question
+from app.services.coach_question_service import CoachQuestionService
 from app.services.conversation_service import ConversationService
 from app.services.recommendation_service import RecommendationService
 from app.services.short_term_context_service import ShortTermContextService
@@ -38,9 +39,11 @@ async def lifespan(app: FastAPI):
     conversation_service = ConversationService(db)
     await conversation_service.ensure_indexes()
 
-    # Ensure indexes for daily recommendations + short-term context (TTL collections)
+    # Ensure indexes for daily recommendations + short-term context + coach
+    # question cache (TTL collections)
     await RecommendationService(db).ensure_indexes()
     await ShortTermContextService(db).ensure_indexes()
+    await CoachQuestionService(db).ensure_indexes()
     
     # Connect to Redis
     try:

--- a/ai-coach-service/app/services/coach_question_service.py
+++ b/ai-coach-service/app/services/coach_question_service.py
@@ -1,0 +1,124 @@
+"""
+CoachQuestionService - short-TTL cache for the Today-dashboard coach check-in
+question, so repeated dashboard opens don't each pay a fresh LLM call.
+
+One live document per user (unique userId index; upsert replaces). A cached
+question is served only while fresh: generated within CACHE_TTL_MINUTES and
+still on the same user-local calendar day. Answering a question deletes the
+doc (see coach_question.py) so the next open generates a new question that
+can reference the check-in. A Mongo TTL index on expiresAt garbage-collects
+abandoned docs.
+"""
+
+from typing import Dict, Any, List, Optional
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+import structlog
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
+
+logger = structlog.get_logger()
+
+COLLECTION_NAME = "coachQuestions"
+
+CACHE_TTL_MINUTES = 45
+DOC_TTL_DAYS = 7
+
+
+class CoachQuestionService:
+    """Cache CRUD for the per-user Today-dashboard coach question."""
+
+    def __init__(self, db: AsyncIOMotorDatabase):
+        self.db = db
+        self.collection = db[COLLECTION_NAME]
+
+    async def ensure_indexes(self):
+        """Create indexes for the single-live-doc-per-user cache + TTL cleanup"""
+        try:
+            await self.collection.create_index(
+                "userId",
+                unique=True,
+                name="user_unique"
+            )
+
+            # TTL: Mongo deletes the doc once expiresAt passes
+            await self.collection.create_index(
+                "expiresAt",
+                expireAfterSeconds=0,
+                name="expires_at_ttl"
+            )
+
+            logger.info(f"Indexes ensured for {COLLECTION_NAME} collection")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to create {COLLECTION_NAME} indexes: {e}")
+            return False
+
+    async def get_fresh(self, user_id: str) -> Optional[Dict[str, Any]]:
+        """Return the cached question only while it's fresh: generated within
+        CACHE_TTL_MINUTES and still on the same user-local calendar day. The
+        doc carries its own timezone, so the hit path needs no profile load."""
+        try:
+            doc = await self.collection.find_one({"userId": ObjectId(user_id)})
+            if not doc:
+                return None
+            generated_at = doc.get("generatedAt")
+            if not isinstance(generated_at, datetime):
+                return None
+            if datetime.utcnow() - generated_at > timedelta(minutes=CACHE_TTL_MINUTES):
+                return None
+            try:
+                tz = ZoneInfo(doc.get("timezone") or "UTC")
+            except Exception:
+                tz = ZoneInfo("UTC")
+            if datetime.now(tz).strftime("%Y-%m-%d") != doc.get("localDate"):
+                return None
+            return doc
+        except Exception as e:
+            logger.error(f"Error fetching cached coach question for {user_id}: {e}")
+            return None
+
+    async def save(
+        self,
+        user_id: str,
+        local_date: str,
+        timezone: str,
+        question: str,
+        chips: List[str],
+        source: str,
+    ) -> bool:
+        """Upsert the user's cached question. Best-effort: callers must never
+        fail the user-facing response on a persist error."""
+        now = datetime.utcnow()
+        doc = {
+            "userId": ObjectId(user_id),
+            "localDate": local_date,
+            "timezone": timezone,
+            "question": question,
+            "chips": chips,
+            "source": source,
+            "generatedAt": now,
+            "updatedAt": now,
+            "expiresAt": now + timedelta(days=DOC_TTL_DAYS),
+        }
+        filter_ = {"userId": ObjectId(user_id)}
+        try:
+            try:
+                await self.collection.replace_one(filter_, {**doc, "createdAt": now}, upsert=True)
+            except DuplicateKeyError:
+                # Concurrent upsert race against the unique index — retry once,
+                # this time it's a plain replace (last-write-wins is fine).
+                await self.collection.replace_one(filter_, {**doc, "createdAt": now}, upsert=True)
+            return True
+        except Exception as e:
+            logger.error(f"Error saving coach question for {user_id}: {e}")
+            return False
+
+    async def invalidate(self, user_id: str) -> None:
+        """Best-effort: drop the cached question (the athlete answered it) so
+        the next dashboard open generates a fresh one."""
+        try:
+            await self.collection.delete_one({"userId": ObjectId(user_id)})
+        except Exception as e:
+            logger.error(f"Error invalidating coach question for {user_id}: {e}")

--- a/ai-coach-service/tests/test_coach_question_cache.py
+++ b/ai-coach-service/tests/test_coach_question_cache.py
@@ -1,0 +1,141 @@
+"""Tests for CoachQuestionService — the short-TTL cache behind the Today
+dashboard's coach check-in question (serve fresh hits, miss on staleness or
+date rollover, delete-on-answer invalidation)."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+from zoneinfo import ZoneInfo
+
+import pytest
+from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
+
+from app.services.coach_question_service import (
+    CACHE_TTL_MINUTES,
+    CoachQuestionService,
+)
+
+USER_ID = str(ObjectId())
+
+
+def _service(find_one_result=None, find_one_error=None):
+    collection = MagicMock()
+    if find_one_error is not None:
+        collection.find_one = AsyncMock(side_effect=find_one_error)
+    else:
+        collection.find_one = AsyncMock(return_value=find_one_result)
+    collection.replace_one = AsyncMock()
+    collection.delete_one = AsyncMock()
+    db = MagicMock()
+    db.__getitem__ = MagicMock(return_value=collection)
+    return CoachQuestionService(db), collection
+
+
+def _doc(generated_minutes_ago=1, local_date=None, timezone="UTC"):
+    now = datetime.utcnow()
+    return {
+        "userId": ObjectId(USER_ID),
+        "localDate": local_date or datetime.now(ZoneInfo(timezone)).strftime("%Y-%m-%d"),
+        "timezone": timezone,
+        "question": "How's the knee feeling before today's run?",
+        "chips": ["Good", "A bit sore", "Bad"],
+        "source": "knee injury note",
+        "generatedAt": now - timedelta(minutes=generated_minutes_ago),
+    }
+
+
+class TestGetFresh:
+    @pytest.mark.asyncio
+    async def test_fresh_doc_is_returned(self):
+        service, _ = _service(find_one_result=_doc())
+        doc = await service.get_fresh(USER_ID)
+        assert doc is not None
+        assert doc["question"] == "How's the knee feeling before today's run?"
+
+    @pytest.mark.asyncio
+    async def test_no_doc_returns_none(self):
+        service, _ = _service(find_one_result=None)
+        assert await service.get_fresh(USER_ID) is None
+
+    @pytest.mark.asyncio
+    async def test_stale_generated_at_misses(self):
+        service, _ = _service(
+            find_one_result=_doc(generated_minutes_ago=CACHE_TTL_MINUTES + 5)
+        )
+        assert await service.get_fresh(USER_ID) is None
+
+    @pytest.mark.asyncio
+    async def test_date_rollover_misses(self):
+        # Generated moments ago but stamped with yesterday's local date
+        # (e.g. cached just before the user's local midnight).
+        yesterday = (datetime.now(ZoneInfo("UTC")) - timedelta(days=1)).strftime("%Y-%m-%d")
+        service, _ = _service(find_one_result=_doc(local_date=yesterday))
+        assert await service.get_fresh(USER_ID) is None
+
+    @pytest.mark.asyncio
+    async def test_missing_generated_at_misses(self):
+        doc = _doc()
+        doc.pop("generatedAt")
+        service, _ = _service(find_one_result=doc)
+        assert await service.get_fresh(USER_ID) is None
+
+    @pytest.mark.asyncio
+    async def test_bad_timezone_falls_back_to_utc(self):
+        utc_today = datetime.now(ZoneInfo("UTC")).strftime("%Y-%m-%d")
+        service, _ = _service(
+            find_one_result=_doc(local_date=utc_today, timezone="Not/AZone")
+        )
+        assert await service.get_fresh(USER_ID) is not None
+
+    @pytest.mark.asyncio
+    async def test_fetch_error_returns_none(self):
+        service, _ = _service(find_one_error=RuntimeError("mongo down"))
+        assert await service.get_fresh(USER_ID) is None
+
+
+class TestSave:
+    @pytest.mark.asyncio
+    async def test_save_upserts_one_doc_per_user(self):
+        service, collection = _service()
+        ok = await service.save(
+            USER_ID, "2026-07-16", "UTC",
+            "Ready for intervals?", ["Yes", "Ease it"], "your Tuesday plan",
+        )
+        assert ok is True
+        filter_, doc = collection.replace_one.call_args[0]
+        assert filter_ == {"userId": ObjectId(USER_ID)}
+        assert doc["question"] == "Ready for intervals?"
+        assert doc["expiresAt"] > doc["generatedAt"]
+        assert collection.replace_one.call_args[1]["upsert"] is True
+
+    @pytest.mark.asyncio
+    async def test_save_retries_on_duplicate_key_race(self):
+        service, collection = _service()
+        collection.replace_one = AsyncMock(
+            side_effect=[DuplicateKeyError("race"), MagicMock()]
+        )
+        ok = await service.save(USER_ID, "2026-07-16", "UTC", "Q?", ["A"], "src")
+        assert ok is True
+        assert collection.replace_one.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_save_error_returns_false(self):
+        service, collection = _service()
+        collection.replace_one = AsyncMock(side_effect=RuntimeError("mongo down"))
+        ok = await service.save(USER_ID, "2026-07-16", "UTC", "Q?", ["A"], "src")
+        assert ok is False
+
+
+class TestInvalidate:
+    @pytest.mark.asyncio
+    async def test_invalidate_deletes_the_user_doc(self):
+        service, collection = _service()
+        await service.invalidate(USER_ID)
+        collection.delete_one.assert_awaited_once_with({"userId": ObjectId(USER_ID)})
+
+    @pytest.mark.asyncio
+    async def test_invalidate_swallows_errors(self):
+        service, collection = _service()
+        collection.delete_one = AsyncMock(side_effect=RuntimeError("mongo down"))
+        # Must not raise — invalidation is best-effort inside the reply path.
+        await service.invalidate(USER_ID)

--- a/frontend/src/components/dashboard/TodayView.jsx
+++ b/frontend/src/components/dashboard/TodayView.jsx
@@ -6,6 +6,7 @@ import apiService from "@/services/api";
 import aiService from "@/services/aiService";
 import { pickTodaySession } from "@/utils/todaySession";
 import SportsNewsCards from "./SportsNewsCards";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getDisciplineColor } from "@/styles/designTokens";
 import {
   Play, Sparkles, X, ChevronRight, ArrowRight, Check, Bike, Dumbbell,
@@ -40,10 +41,12 @@ function fmtTime(dateStr) {
 export default function TodayView() {
   const navigate = useNavigate();
   const [goals, setGoals] = useState([]);
+  const [goalsLoading, setGoalsLoading] = useState(true);
   const [session, setSession] = useState(null);
   const [sessionLoading, setSessionLoading] = useState(true);
   const [sessionDone, setSessionDone] = useState(false);
   const [coach, setCoach] = useState(null);
+  const [coachLoading, setCoachLoading] = useState(true);
   const [coachDismissed, setCoachDismissed] = useState(false);
   const [coachAnswer, setCoachAnswer] = useState(null);
   const [coachReply, setCoachReply] = useState(null);
@@ -63,8 +66,11 @@ export default function TodayView() {
           .filter((g) => g.is_active && !g.completed_date)
           .slice(0, 2);
         setGoals(active);
+        setGoalsLoading(false);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (alive) setGoalsLoading(false);
+      });
 
     // Today's session — calendar first (same selection rule as the TrainNow
     // page), then the same server-persisted AI suggestion TrainNow uses, so
@@ -137,9 +143,13 @@ export default function TodayView() {
     aiService
       .getCoachQuestion()
       .then((q) => {
-        if (alive && q) setCoach(q);
+        if (!alive) return;
+        if (q) setCoach(q);
+        setCoachLoading(false);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (alive) setCoachLoading(false);
+      });
 
     // Progression — first in-progress skill ladder
     apiService.progressions
@@ -211,7 +221,26 @@ export default function TodayView() {
           </span>
         </div>
         <div className="tv-goals">
-          {goals.length > 0 ? (
+          {goalsLoading ? (
+            [0, 1].map((i) => (
+              <div
+                key={i}
+                className="tv-goal"
+                style={{ "--goal-c": GOAL_COLORS.default }}
+              >
+                <div className="tv-goal-kicker">
+                  <Skeleton className="h-3 w-14" />
+                </div>
+                <div className="tv-goal-title">
+                  <Skeleton className="h-4 w-24" />
+                </div>
+                <div className="tv-goal-sub">
+                  <Skeleton className="h-3 w-16" />
+                </div>
+                <div className="tv-goal-track" />
+              </div>
+            ))
+          ) : goals.length > 0 ? (
             goals.map((g) => {
               const c = goalColor(g.category || "skill");
               const pct = Math.min(((g.current_level || 0) / 10) * 100, 100);
@@ -333,7 +362,22 @@ export default function TodayView() {
         </div>
 
         {/* COACH QUESTION — memory-driven */}
-        {coach && !coachDismissed && (
+        {coachLoading && !coachDismissed && (
+          <div className="tv-coach">
+            <span className="tv-sparkle">
+              <Sparkles className="tv-ico" />
+            </span>
+            <div className="tv-coach-body">
+              <div className="tv-coach-text" style={{ opacity: 0.55 }}>
+                Sensei is checking your status…
+              </div>
+              <div className="tv-coach-reply tv-typing">
+                <span /><span /><span />
+              </div>
+            </div>
+          </div>
+        )}
+        {!coachLoading && coach && !coachDismissed && (
           <div className="tv-coach">
             <span className="tv-sparkle">
               <Sparkles className="tv-ico" />

--- a/frontend/src/hooks/use-mobile.jsx
+++ b/frontend/src/hooks/use-mobile.jsx
@@ -3,15 +3,21 @@ import * as React from "react"
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState(undefined)
+  // Synchronous initializer: consumers gate whole component trees on this
+  // value, so the first render must already be correct for the viewport.
+  const [isMobile, setIsMobile] = React.useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`).matches
+  )
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(mql.matches)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(mql.matches)
     return () => mql.removeEventListener("change", onChange);
   }, [])
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Workout, UserGoalProgress, Plan } from "@/api/entities";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { Calendar, Target, ChevronRight, Activity, Trophy, Clock, Play, Users, MoreVertical, Trash2, FileText, Plus } from "lucide-react";
 import { format, startOfWeek, addDays, isToday, parseISO, isValid, isAfter } from "date-fns";
 import { Link, useNavigate } from "react-router-dom";
@@ -165,10 +166,18 @@ export default function Dashboard() {
   const [isLoading, setIsLoading] = useState(true);
   const [view, setView] = useState('overview'); // 'overview' or 'plan'
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  const loadedRef = useRef(false);
 
+  // Desktop-only data: mobile renders TodayView, which loads its own data.
+  // Load once when the viewport is (or becomes) desktop, so crossing the
+  // breakpoint after a mobile-first mount still populates the grid.
   useEffect(() => {
-    loadData();
-  }, []);
+    if (!isMobile && !loadedRef.current) {
+      loadedRef.current = true;
+      loadData();
+    }
+  }, [isMobile]);
 
   const loadData = async () => {
     setIsLoading(true);
@@ -225,35 +234,32 @@ export default function Dashboard() {
     }
   };
 
+  // Mobile: the redesigned Today view owns its own data — render only it so
+  // the hidden desktop grid (and its fetches) never mount.
+  if (isMobile) {
+    return (
+      <div className="-m-4">
+        <TodayView />
+      </div>
+    );
+  }
+
   if (isLoading) {
     return (
-      <>
-        {/* Mobile Today view loads its own data independently of the desktop dashboard */}
-        <div className="md:hidden -m-4">
-          <TodayView />
+      <div className="space-y-6">
+        <div className="animate-pulse h-8 bg-gray-200 rounded w-64"></div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {Array(3).fill(0).map((_, i) => (
+            <div key={i} className="animate-pulse bg-gray-200 h-24 rounded-xl"></div>
+          ))}
         </div>
-        <div className="hidden md:block space-y-6">
-          <div className="animate-pulse h-8 bg-gray-200 rounded w-64"></div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {Array(3).fill(0).map((_, i) => (
-              <div key={i} className="animate-pulse bg-gray-200 h-24 rounded-xl"></div>
-            ))}
-          </div>
-          <div className="animate-pulse h-64 bg-gray-200 rounded-xl"></div>
-        </div>
-      </>
+        <div className="animate-pulse h-64 bg-gray-200 rounded-xl"></div>
+      </div>
     );
   }
 
   return (
-    <>
-    {/* Mobile: redesigned Today view */}
-    <div className="md:hidden -m-4">
-      <TodayView />
-    </div>
-
-    {/* Desktop: existing dashboard */}
-    <div className="hidden md:block space-y-8">
+    <div className="space-y-8">
       {/* Header with View Toggle */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
@@ -578,6 +584,5 @@ export default function Dashboard() {
         </div>
       )}
     </div>
-    </>
   );
 }


### PR DESCRIPTION
Linear: TOR-94 — https://linear.app/torii-fitness/issue/TOR-94

## Problem

The dashboard (mobile Today view especially) felt like it was "lazy updating" — content silently popped in seconds after render with no loading indication:

- The **coach question** paid a fresh OpenAI call on **every** dashboard open (never cached) and had no loading indicator, so the card popped in 1–2s after everything else.
- **Goals** briefly flashed a false "Set a goal" empty state while fetching.
- `Dashboard.jsx` mounted **both** the mobile and desktop trees and hid one via CSS — desktop users silently paid for the coach LLM call + all TodayView fetches, and `/news` fired twice per visit.

## Changes

**Loading UX (frontend)**
- Coach card shows **"Sensei is checking your status…"** with the existing typing-dots animation while the question loads.
- Goals render skeleton cards while loading; the empty state only appears after the fetch resolves.
- `useIsMobile` now initializes synchronously (correct first paint) and listens on `mql.matches`.
- `Dashboard.jsx` renders mobile TodayView **or** the desktop grid via JS, not CSS hiding. Desktop `loadData()` fires once when the viewport is (or becomes) desktop, so crossing the 768px breakpoint never strands an unloaded tree.

**Speed (ai-coach-service)**
- New `CoachQuestionService`: 45-min per-user Mongo cache (`coachQuestions`, unique `userId` + TTL index) for the coach question.
- Answering a question invalidates the cache, so the next question reflects the check-in.
- Fallback questions are never cached; cache hits still nudge the lazy stale-conversation summarizer.

## Verification

- Playwright against the local stack (pm-test account): first load generates fresh; reload returns `cached: true` in ~600ms (vs multi-second generation); answering a chip → reload generates a **new** question referencing the check-in context.
- Loading states screenshot-verified with throttled responses; no "Set a goal" flash.
- Desktop: no `/coach-question` call, exactly one `/news` call; resize across 768px works in both directions (including mobile-first load → desktop).
- `pytest`: 454 passed (12 new tests in `test_coach_question_cache.py`); frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)