### PR TITLE
Mobile dashboard widget system: reorder/hide TodayView sections

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -235,6 +235,12 @@ const updateProfile = async (req, res) => {
         ...settings,
         ...(settings.sportsNews
           ? { sportsNews: { ...(existingSettings.sportsNews || {}), ...settings.sportsNews } }
+          : {}),
+        // One merge level only: clients must send each layout (e.g.
+        // mobileLayout) complete — a partial { mobileLayout: { hidden } }
+        // would wipe that layout's order.
+        ...(settings.dashboard
+          ? { dashboard: { ...(existingSettings.dashboard || {}), ...settings.dashboard } }
           : {})
       };
     }

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -118,6 +118,15 @@ const userSchema = new mongoose.Schema({
         default: true
       },
       sports: [String] // canonical slugs from config/sportsNews.js
+    },
+    // Per-user dashboard widget layout. Ids reference the frontend widget
+    // registry (frontend/src/components/dashboard/widgets/registry.js);
+    // unknown/missing ids are reconciled client-side.
+    dashboard: {
+      mobileLayout: {
+        order: { type: [String], default: undefined },
+        hidden: { type: [String], default: undefined }
+      }
     }
   }
 }, {

--- a/frontend/scripts/check-widget-registry.mjs
+++ b/frontend/scripts/check-widget-registry.mjs
@@ -1,0 +1,67 @@
+// Position-asserting checks for the dashboard widget registry's resolveLayout
+// (the self-healing merge of a saved layout with the registry). There is no
+// test runner in frontend/ yet, so this runs standalone:
+//
+//   node scripts/check-widget-registry.mjs
+//
+// Re-run after adding/removing/reordering widgets in
+// src/components/dashboard/widgets/registry.js — the insertion logic
+// (missing widget lands after its nearest PRESENT default-order predecessor)
+// is the part most likely to regress.
+import assert from "node:assert/strict";
+import { resolveLayout, DASHBOARD_WIDGETS } from "../src/components/dashboard/widgets/registry.js";
+
+const DEFAULT = DASHBOARD_WIDGETS.map((w) => w.id);
+assert.deepEqual(
+  DEFAULT,
+  ["goals", "todaySession", "coachQuestion", "progression", "sportsNews"],
+  "registry default order (update this file when the registry changes)"
+);
+
+// No saved config -> default order, nothing hidden
+assert.deepEqual(resolveLayout(undefined), { order: DEFAULT, hidden: [] });
+assert.deepEqual(resolveLayout({}), { order: DEFAULT, hidden: [] });
+
+// Unknown id in saved order -> dropped
+assert.deepEqual(
+  resolveLayout({ order: ["bogus", ...DEFAULT], hidden: [] }).order,
+  DEFAULT
+);
+
+// Saved order missing a middle widget -> inserted immediately after its
+// nearest present default-order predecessor, NOT appended
+assert.deepEqual(
+  resolveLayout({
+    order: ["sportsNews", "goals", "todaySession", "progression"],
+    hidden: [],
+  }).order,
+  ["sportsNews", "goals", "todaySession", "coachQuestion", "progression"]
+);
+
+// Missing widget whose default predecessors are all absent -> lands first
+assert.deepEqual(
+  resolveLayout({
+    order: ["coachQuestion", "progression", "sportsNews"],
+    hidden: [],
+  }).order,
+  DEFAULT
+);
+
+// Two adjacent missing widgets -> both land in default relative order
+assert.deepEqual(
+  resolveLayout({ order: ["sportsNews", "goals", "progression"], hidden: [] })
+    .order,
+  ["sportsNews", "goals", "todaySession", "coachQuestion", "progression"]
+);
+
+// Unknown ids in hidden -> filtered; known ids kept
+assert.deepEqual(
+  resolveLayout({ order: DEFAULT, hidden: ["ghost", "progression"] }).hidden,
+  ["progression"]
+);
+
+// Resolving a resolved layout is a no-op
+const once = resolveLayout({ order: ["sportsNews", "goals"], hidden: ["goals"] });
+assert.deepEqual(resolveLayout(once), once);
+
+console.log("check-widget-registry: all resolveLayout checks passed");

--- a/frontend/src/components/dashboard/DashboardEditMode.jsx
+++ b/frontend/src/components/dashboard/DashboardEditMode.jsx
@@ -1,0 +1,123 @@
+import { useNavigate } from "react-router-dom";
+import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
+import { GripVertical, Eye, EyeOff } from "lucide-react";
+import { createPageUrl } from "@/utils";
+import { WIDGETS_BY_ID, resolveLayout } from "./widgets/registry";
+
+// Drag-to-reorder / hide-show editor for the mobile dashboard. Renders
+// collapsed cards, not live widgets: the hero card is too tall to drag on a
+// phone, and SportsNewsCards' own horizontal swipe would fight the drag.
+export default function DashboardEditMode({
+  layout,
+  sportsNewsEnabled,
+  onChange,
+  onDone,
+}) {
+  const navigate = useNavigate();
+
+  // Functional updates: rapid taps/drops can outrun a re-render, and building
+  // from the `layout` prop would silently drop the earlier change.
+  const onDragEnd = (result) => {
+    if (!result.destination) return;
+    onChange((prev) => {
+      const order = [...prev.order];
+      const [moved] = order.splice(result.source.index, 1);
+      order.splice(result.destination.index, 0, moved);
+      return { ...prev, order };
+    });
+  };
+
+  const toggleHidden = (id) =>
+    onChange((prev) => ({
+      ...prev,
+      hidden: prev.hidden.includes(id)
+        ? prev.hidden.filter((h) => h !== id)
+        : [...prev.hidden, id],
+    }));
+
+  return (
+    <div className="tv-edit">
+      <div className="tv-edit-head">
+        <span className="tv-h">Edit layout</span>
+        <div className="tv-edit-actions">
+          <button
+            className="tv-edit-reset"
+            onClick={() => onChange(resolveLayout(undefined))}
+          >
+            Reset to default
+          </button>
+          <button className="tv-edit-done" onClick={onDone}>
+            Done
+          </button>
+        </div>
+      </div>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Droppable droppableId="tv-widgets">
+          {(provided) => (
+            <div
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              className="tv-edit-list"
+            >
+              {layout.order.map((id, index) => {
+                const meta = WIDGETS_BY_ID[id];
+                if (!meta) return null;
+                const isHidden = layout.hidden.includes(id);
+                // The sports-news widget can't appear while its Settings kill
+                // switch is off — don't offer an eye toggle that does nothing.
+                const settingsOff = id === "sportsNews" && !sportsNewsEnabled;
+                return (
+                  <Draggable key={id} draggableId={id} index={index}>
+                    {(prov, snapshot) => (
+                      <div
+                        ref={prov.innerRef}
+                        {...prov.draggableProps}
+                        className={`tv-edit-card${
+                          isHidden || settingsOff ? " is-hidden" : ""
+                        }${snapshot.isDragging ? " is-dragging" : ""}`}
+                      >
+                        <span className="tv-edit-grip" {...prov.dragHandleProps}>
+                          <GripVertical className="tv-ico" />
+                        </span>
+                        <span className="tv-edit-info">
+                          <span className="tv-edit-title">{meta.title}</span>
+                          {settingsOff ? (
+                            <span
+                              className="tv-edit-sub tv-edit-sub-link"
+                              onClick={() => navigate(createPageUrl("Settings"))}
+                            >
+                              Off in Settings
+                            </span>
+                          ) : (
+                            meta.availabilityHint && (
+                              <span className="tv-edit-sub">
+                                {meta.availabilityHint}
+                              </span>
+                            )
+                          )}
+                        </span>
+                        <button
+                          className="tv-edit-eye"
+                          disabled={settingsOff}
+                          aria-label={isHidden ? "Show widget" : "Hide widget"}
+                          onClick={() => toggleHidden(id)}
+                        >
+                          {isHidden || settingsOff ? (
+                            <EyeOff className="tv-ico" />
+                          ) : (
+                            <Eye className="tv-ico" />
+                          )}
+                        </button>
+                      </div>
+                    )}
+                  </Draggable>
+                );
+              })}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/TodayView.css
+++ b/frontend/src/components/dashboard/TodayView.css
@@ -210,3 +210,57 @@
 }
 .tv-rung:first-child::before { display: none; }
 .tv-rung.done::before, .tv-rung.now::before { background: var(--rung-c); }
+
+/* ---- Edit layout (widget reorder/hide) ---- */
+.tv-edit-row { display: flex; justify-content: flex-end; margin-bottom: -6px; }
+.tv-edit-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; border-radius: 8px;
+  background: transparent; border: 1px solid var(--tv-border);
+  color: var(--tv-text-muted); cursor: pointer;
+}
+.tv-save-error {
+  font-size: 12px; color: var(--tv-accent-strong);
+  background: var(--tv-surface-2); border: 1px solid var(--tv-border);
+  border-radius: 10px; padding: 8px 10px;
+}
+
+.tv-edit { display: flex; flex-direction: column; gap: 12px; }
+.tv-edit-head { display: flex; align-items: center; justify-content: space-between; }
+.tv-edit-actions { display: flex; align-items: center; gap: 12px; }
+.tv-edit-reset {
+  background: none; border: none; padding: 0; cursor: pointer;
+  font-size: 11px; color: var(--tv-text-muted);
+}
+.tv-edit-done {
+  background: var(--tv-fill-primary); color: var(--tv-on-primary);
+  border: none; border-radius: 999px; padding: 6px 16px;
+  font-size: 13px; font-weight: 600; cursor: pointer;
+}
+
+.tv-edit-list { display: flex; flex-direction: column; gap: 8px; }
+.tv-edit-card {
+  display: flex; align-items: center; gap: 10px;
+  background: var(--tv-surface-2); border: 1px solid var(--tv-border);
+  border-radius: 14px; padding: 12px;
+}
+.tv-edit-card.is-hidden { opacity: 0.45; }
+.tv-edit-card.is-dragging {
+  border-color: var(--tv-border-stronger);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+}
+.tv-edit-grip {
+  display: inline-flex; color: var(--tv-text-muted);
+  touch-action: none; cursor: grab;
+}
+.tv-edit-info { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.tv-edit-title { font-size: 14px; font-weight: 600; }
+.tv-edit-sub { font-size: 11px; color: var(--tv-text-muted); }
+.tv-edit-sub-link { text-decoration: underline; cursor: pointer; }
+.tv-edit-eye {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px; border-radius: 8px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--tv-text-secondary);
+}
+.tv-edit-eye:disabled { color: var(--tv-text-muted); cursor: default; }

--- a/frontend/src/components/dashboard/TodayView.jsx
+++ b/frontend/src/components/dashboard/TodayView.jsx
@@ -1,14 +1,17 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { createPageUrl } from "@/utils";
 import { CalendarEvent, UserGoalProgress } from "@/api/entities";
 import apiService from "@/services/api";
 import aiService from "@/services/aiService";
+import { useDashboardLayout } from "@/hooks/useDashboardLayout";
 import { pickTodaySession } from "@/utils/todaySession";
 import SportsNewsCards from "./SportsNewsCards";
+import DashboardEditMode from "./DashboardEditMode";
 import { getDisciplineColor } from "@/styles/designTokens";
 import {
   Play, Sparkles, X, ChevronRight, ArrowRight, Check, Bike, Dumbbell,
+  SlidersHorizontal,
 } from "lucide-react";
 import { format, parseISO, isValid } from "date-fns";
 import "./TodayView.css";
@@ -51,6 +54,35 @@ export default function TodayView() {
   const [continuing, setContinuing] = useState(false);
   const [progression, setProgression] = useState(null);
   const [horizon, setHorizon] = useState([]);
+  const [editing, setEditing] = useState(false);
+  const {
+    layout,
+    updateLayout,
+    saveLayout,
+    beginEdit,
+    saveError,
+    sportsNewsEnabled,
+  } = useDashboardLayout();
+  // Layout as it was when edit mode opened — Done skips the PUT if unchanged.
+  const editSnapshot = useRef(null);
+  // Once-per-mount guards for the visibility-gated fetches below, so a widget
+  // unhidden via Done fetches its data exactly once.
+  const sessionFetched = useRef(false);
+  const coachFetched = useRef(false);
+  // Liveness for those fetches is scoped to the MOUNT, not to each effect run:
+  // a hiddenKey change must not abandon an in-flight fetch (the fetched ref
+  // already blocks any retry, so abandoning it would strand the loading state).
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const isVisible = (id) => !layout.hidden.includes(id);
+  // Stable dep for the gated effects — hidden is a fresh array each resolve.
+  const hiddenKey = layout.hidden.join(",");
 
   useEffect(() => {
     let alive = true;
@@ -66,12 +98,37 @@ export default function TodayView() {
       })
       .catch(() => {});
 
-    // Today's session — calendar first (same selection rule as the TrainNow
-    // page), then the same server-persisted AI suggestion TrainNow uses, so
-    // both surfaces always show the same thing.
+    // Progression — first in-progress skill ladder
+    apiService.progressions
+      .list()
+      .then((data) => {
+        if (!alive) return;
+        const list = Array.isArray(data) ? data : [];
+        const active =
+          list.find((p) => p.userProgress?.status === "in_progress") || list[0];
+        if (active) setProgression(active);
+      })
+      .catch(() => {});
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Today's session — gated on the widget being visible because the
+  // no-calendar-event path generates a persisted AI suggestion (an LLM call);
+  // a hidden widget must not keep paying for it. Also paused while editing so
+  // eye-toggles don't fire the paid call before Done commits them.
+  useEffect(() => {
+    if (editing || !isVisible("todaySession") || sessionFetched.current) return;
+    sessionFetched.current = true;
+
+    // Calendar first (same selection rule as the TrainNow page), then the
+    // same server-persisted AI suggestion TrainNow uses, so both surfaces
+    // always show the same thing.
     CalendarEvent.today()
       .then(async (events) => {
-        if (!alive) return;
+        if (!mounted.current) return;
         const { scheduledEvent, completedToday } = pickTodaySession(events);
         if (scheduledEvent) {
           setSession({
@@ -107,7 +164,7 @@ export default function TodayView() {
         }
         // No calendar event — fetch (or generate) today's persisted suggestion
         const data = await aiService.getTodayWorkout();
-        if (!alive) return;
+        if (!mounted.current) return;
         if (data?.suggestion) {
           const s = data.suggestion;
           if (s.type === "rest") {
@@ -130,33 +187,25 @@ export default function TodayView() {
         setSessionLoading(false);
       })
       .catch(() => {
-        if (alive) setSessionLoading(false);
+        if (mounted.current) setSessionLoading(false);
       });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hiddenKey, editing]);
 
-    // Coach question — memory-driven
+  // Coach question — memory-driven; hits the ai-coach service, so gated the
+  // same way as the session fetch above.
+  useEffect(() => {
+    if (editing || !isVisible("coachQuestion") || coachFetched.current) return;
+    coachFetched.current = true;
+
     aiService
       .getCoachQuestion()
       .then((q) => {
-        if (alive && q) setCoach(q);
+        if (mounted.current && q) setCoach(q);
       })
       .catch(() => {});
-
-    // Progression — first in-progress skill ladder
-    apiService.progressions
-      .list()
-      .then((data) => {
-        if (!alive) return;
-        const list = Array.isArray(data) ? data : [];
-        const active =
-          list.find((p) => p.userProgress?.status === "in_progress") || list[0];
-        if (active) setProgression(active);
-      })
-      .catch(() => {});
-
-    return () => {
-      alive = false;
-    };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hiddenKey, editing]);
 
   const startSession = () => {
     // TrainNow shows calendar-scheduled sessions as the "Scheduled Today" card
@@ -200,10 +249,11 @@ export default function TodayView() {
   // Build a compact ladder (<=5 rungs) centered on the current step
   const rungs = buildRungs(progression);
 
-  return (
-    <div className="today-view">
-      <div className="tv-stack">
-        {/* GOALS — on top */}
+  // Widget renderers, keyed by registry id. Order/visibility come from the
+  // saved layout; adding a widget = registry entry + renderer here.
+  const sections = {
+    goals: () => (
+      <React.Fragment key="goals">
         <div className="tv-goals-head">
           <span className="tv-h">Your goals</span>
           <span className="tv-all" onClick={() => navigate(createPageUrl("Goals"))}>
@@ -247,9 +297,11 @@ export default function TodayView() {
             </div>
           )}
         </div>
+      </React.Fragment>
+    ),
 
-        {/* HERO SESSION */}
-        <div className="tv-hero">
+    todaySession: () => (
+      <div className="tv-hero" key="todaySession">
           {sessionLoading ? (
             <>
               <div className="tv-hero-kicker" style={{ color: "var(--tv-accent)" }}>
@@ -331,10 +383,12 @@ export default function TodayView() {
             </div>
           )}
         </div>
+    ),
 
-        {/* COACH QUESTION — memory-driven */}
-        {coach && !coachDismissed && (
-          <div className="tv-coach">
+    // Memory-driven; self-hides when there's no question or it was dismissed
+    coachQuestion: () =>
+      coach && !coachDismissed && (
+          <div className="tv-coach" key="coachQuestion">
             <span className="tv-sparkle">
               <Sparkles className="tv-ico" />
             </span>
@@ -388,11 +442,12 @@ export default function TodayView() {
               <X className="tv-ico-sm" />
             </span>
           </div>
-        )}
+      ),
 
-        {/* PROGRESSION — horizontal ladder */}
-        {progression && rungs.length > 0 && (
-          <>
+    // Self-hides when there's no active ladder
+    progression: () =>
+      progression && rungs.length > 0 && (
+          <React.Fragment key="progression">
             <div className="tv-goals-head">
               <span className="tv-h">Progression</span>
               <span
@@ -431,11 +486,58 @@ export default function TodayView() {
                 ))}
               </div>
             </div>
-          </>
-        )}
+          </React.Fragment>
+      ),
 
-        {/* SPORTS NEWS — swipeable cards */}
-        <SportsNewsCards />
+    // Swipeable cards; self-hides on error or when disabled in Settings
+    sportsNews: () => <SportsNewsCards key="sportsNews" />,
+  };
+
+  if (editing) {
+    return (
+      <div className="today-view">
+        <DashboardEditMode
+          layout={layout}
+          sportsNewsEnabled={sportsNewsEnabled}
+          onChange={updateLayout}
+          onDone={() => {
+            setEditing(false);
+            // Skip the PUT when nothing changed — unless an earlier save
+            // failed, in which case Done doubles as the retry.
+            if (saveError || JSON.stringify(layout) !== editSnapshot.current) {
+              saveLayout(layout);
+            }
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="today-view">
+      <div className="tv-stack">
+        <div className="tv-edit-row">
+          <button
+            className="tv-edit-btn"
+            aria-label="Edit layout"
+            onClick={() => {
+              beginEdit();
+              editSnapshot.current = JSON.stringify(layout);
+              setEditing(true);
+            }}
+          >
+            <SlidersHorizontal className="tv-ico-sm" />
+          </button>
+        </div>
+        {saveError && (
+          <div className="tv-save-error">
+            Couldn&rsquo;t save your layout — it may reset when you leave this
+            page. Edit again to retry.
+          </div>
+        )}
+        {layout.order
+          .filter((id) => !layout.hidden.includes(id))
+          .map((id) => sections[id]?.() || null)}
       </div>
     </div>
   );

--- a/frontend/src/components/dashboard/widgets/registry.js
+++ b/frontend/src/components/dashboard/widgets/registry.js
@@ -1,0 +1,59 @@
+// Registry of mobile-dashboard widgets. Order here is the default layout.
+// Adding a widget = one entry here + a renderer in TodayView's `sections` map
+// (or, once widgets become standalone self-fetching components, a `component`
+// field — SportsNewsCards already fits that shape).
+export const DASHBOARD_WIDGETS = [
+  { id: "goals", title: "Your goals", defaultVisible: true },
+  { id: "todaySession", title: "Today's session", defaultVisible: true },
+  {
+    id: "coachQuestion",
+    title: "Coach check-in",
+    defaultVisible: true,
+    availabilityHint: "Shows when available"
+  },
+  {
+    id: "progression",
+    title: "Progression",
+    defaultVisible: true,
+    availabilityHint: "Shows when available"
+  },
+  { id: "sportsNews", title: "Sports news", defaultVisible: true }
+];
+
+export const WIDGETS_BY_ID = Object.fromEntries(
+  DASHBOARD_WIDGETS.map((w) => [w.id, w])
+);
+
+// Reconcile a saved { order, hidden } config with the registry:
+// - saved ids that no longer exist in the registry are dropped
+// - registry widgets missing from the saved order are inserted after their
+//   nearest default-order predecessor that IS present, so a widget shipped
+//   between two existing ones lands between them, not at the end
+// - hidden is filtered to known ids; defaultVisible:false widgets the user
+//   never configured start hidden
+// Always returns a complete, valid layout — callers never need a fallback.
+export function resolveLayout(saved) {
+  const savedOrder = (saved?.order || []).filter((id) => WIDGETS_BY_ID[id]);
+  const order = [...savedOrder];
+  DASHBOARD_WIDGETS.forEach((w, defaultIdx) => {
+    if (order.includes(w.id)) return;
+    let insertAt = 0;
+    for (let i = defaultIdx - 1; i >= 0; i--) {
+      const pos = order.indexOf(DASHBOARD_WIDGETS[i].id);
+      if (pos !== -1) {
+        insertAt = pos + 1;
+        break;
+      }
+    }
+    order.splice(insertAt, 0, w.id);
+  });
+
+  const hidden = (saved?.hidden || []).filter((id) => WIDGETS_BY_ID[id]);
+  DASHBOARD_WIDGETS.forEach((w) => {
+    if (!w.defaultVisible && !savedOrder.includes(w.id) && !hidden.includes(w.id)) {
+      hidden.push(w.id);
+    }
+  });
+
+  return { order, hidden };
+}

--- a/frontend/src/hooks/useDashboardLayout.js
+++ b/frontend/src/hooks/useDashboardLayout.js
@@ -1,0 +1,93 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import apiService from "@/services/api";
+import { resolveLayout } from "@/components/dashboard/widgets/registry";
+
+const readCachedSettings = () => {
+  try {
+    return JSON.parse(localStorage.getItem("authUser") || "{}")?.settings;
+  } catch {
+    return undefined;
+  }
+};
+
+// Cache writes always store the full server user (top-level merge, same as
+// Settings.jsx) — never a hand-crafted nested `settings` object, so cached
+// theme/units/sportsNews can't be dropped by a partial write.
+const cacheServerUser = (user) => {
+  try {
+    const cached = JSON.parse(localStorage.getItem("authUser") || "{}");
+    localStorage.setItem("authUser", JSON.stringify({ ...cached, ...user }));
+  } catch {
+    /* cache only */
+  }
+};
+
+// Mobile-dashboard widget layout: synchronous init from the authUser cache
+// (no flash of default order), background server refresh, server-first save.
+export function useDashboardLayout() {
+  const [layout, setLayout] = useState(() =>
+    resolveLayout(readCachedSettings()?.dashboard?.mobileLayout)
+  );
+  // The sports-news Settings kill switch, exposed so the layout editor can
+  // disable that widget's eye toggle. Kept in sync by the me() refresh so an
+  // out-of-band change (another device, Settings in another tab) shows up.
+  const [sportsNewsEnabled, setSportsNewsEnabled] = useState(
+    () => readCachedSettings()?.sportsNews?.enabled !== false
+  );
+  const [saveError, setSaveError] = useState(false);
+  // Once the user enters edit mode (or a save fails), the background refresh
+  // must not clobber their in-memory layout.
+  const dirty = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiService.auth
+      .me()
+      .then((res) => {
+        // apiService.request unwraps the { success, data } envelope
+        const user = res?.user;
+        if (!user || cancelled) return;
+        setSportsNewsEnabled(user.settings?.sportsNews?.enabled !== false);
+        if (dirty.current) return;
+        cacheServerUser(user);
+        setLayout(resolveLayout(user.settings?.dashboard?.mobileLayout));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const beginEdit = useCallback(() => {
+    dirty.current = true;
+  }, []);
+
+  const updateLayout = useCallback((next) => {
+    setLayout(next);
+  }, []);
+
+  const saveLayout = useCallback(async (next) => {
+    try {
+      const res = await apiService.auth.updateProfile({
+        settings: { dashboard: { mobileLayout: next } }
+      });
+      if (res?.user) cacheServerUser(res.user);
+      setSaveError(false);
+      dirty.current = false;
+    } catch (e) {
+      // Keep the in-memory layout for this session, leave the cache and dirty
+      // flag alone so nothing silently reverts it, and let the UI say so.
+      console.error("Failed to save dashboard layout:", e);
+      setSaveError(true);
+    }
+  }, []);
+
+  return {
+    layout,
+    updateLayout,
+    saveLayout,
+    beginEdit,
+    saveError,
+    sportsNewsEnabled,
+  };
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -81,6 +81,10 @@ class APIService {
       return Promise.resolve();
     },
     me: () => this.request('/auth/profile'),
+    updateProfile: (payload) => this.request('/auth/profile', {
+      method: 'PUT',
+      body: JSON.stringify(payload)
+    }),
     // Set (Google-only account) or change the account password.
     // `currentPassword` is only needed when the account already has one.
     setPassword: (newPassword, currentPassword) => this.request('/auth/set-password', {


### PR DESCRIPTION
## What

Makes the mobile dashboard (TodayView) user-adjustable: an **Edit layout** mode with drag-to-reorder (`@hello-pangea/dnd`) and per-widget hide/show, persisted per user in `settings.dashboard.mobileLayout`. This lets the news section (or any section) be moved up/down, and gives future widgets a one-entry registration path.

## How

- **`widgets/registry.js`** — widget registry (id, title, defaultVisible, availabilityHint) + `resolveLayout`, a self-healing merge of saved config with the registry: unknown ids dropped, widgets missing from a saved order inserted after their nearest present default-order predecessor. Position-asserting checks in `frontend/scripts/check-widget-registry.mjs` (`node scripts/check-widget-registry.mjs`).
- **`useDashboardLayout`** — synchronous init from the `authUser` cache (no flash of default order), background `auth.me()` refresh, **server-first save** (cache only updated from the server response after the PUT succeeds; failures show a notice instead of silently reverting later). A dirty flag set on *entering* edit mode stops the background refresh from reshuffling mid-edit. Also exposes `sportsNewsEnabled`, kept in sync by the refresh.
- **TodayView** — section JSX moved verbatim into a registry-keyed `sections` map, rendered by saved order/visibility. The two paid AI fetches (`/train-now` generation, `/coach-question`) are skipped for hidden widgets, paused during editing, and fired once on unhide. Cheap reads stay unconditional.
- **DashboardEditMode** — collapsed drag cards (live widgets are too tall to drag on a phone, and the news card's own swipe would fight the drag); widget ids as `draggableId`; functional state updates so rapid taps can't drop a toggle; the sports-news eye is disabled with an "Off in Settings" link while `settings.sportsNews.enabled` is false.
- **Backend** — `settings.dashboard` sub-schema on User + one-level deep-merge in `updateProfile`, mirroring the `sportsNews` contract (client always sends `mobileLayout` complete).

## Verification (pm-test account, local stack against prod DB, non-destructive)

- `resolveLayout` position checks pass (bogus ids, middle-widget insertion, adjacent-missing ordering, idempotence)
- Backend contract: dashboard PUT preserves sibling settings; sportsNews-only PUT preserves dashboard
- Playwright (390×844): default render → drag news to top (keyboard DnD) → hide widget → Done fires exactly one PUT → reload persists → cache-cleared reload reapplies server layout → save-failure shows notice, leaves cache untouched, next Done retries → corrupt saved config self-heals without crash → hidden widgets fire no `/train-now`/`/coach-question`; unhide fetches once after Done, never mid-edit
- Desktop 1280px dashboard unchanged; lint delta clean vs baseline; `npm run build` passes

## Notes

- Known conflict ahead with the coach-question-cache branch (TodayView.jsx) — whichever lands second should rebase that file deliberately since this PR moves the coach JSX into the sections map.
- Follow-ups (not in this PR): unify the sports-news eye with `settings.sportsNews.enabled`; desktop layout as a `desktopLayout` sibling; standalone self-fetching widget components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)