### PR TITLE
Sports news: oneFeed leagues — MotoGP, cricket, Olympics, boxing + 6 more

### DIFF
--- a/backend/scripts/bootstrap-espn-leagues.js
+++ b/backend/scripts/bootstrap-espn-leagues.js
@@ -9,6 +9,12 @@
  * leagues whose news feed actually responds with a well-formed articles
  * array (the whole point of the whitelist is "feeds you can follow").
  *
+ * Also appends the curated ONEFEED_LEAGUES below — sports ESPN covers only
+ * through the oneFeed content API behind hub pages (espn.com/motogp/ etc.),
+ * not as site/v2 leagues. Each is validated live (resultsCount > 0) before
+ * inclusion. Extend that list by probing:
+ *   curl 'https://onefeed.fan.api.espn.com/apis/v3/cached/contentEngine/oneFeed/leagues/<key>?limit=5'
+ *
  * Usage: node scripts/bootstrap-espn-leagues.js [--out src/config/espnLeagues.json]
  */
 
@@ -17,7 +23,39 @@ const path = require('path');
 
 const CORE_BASE = 'https://sports.core.api.espn.com/v2/sports';
 const SITE_BASE = 'https://site.api.espn.com/apis/site/v2/sports';
+const ONEFEED_BASE = 'https://onefeed.fan.api.espn.com/apis/v3/cached/contentEngine/oneFeed/leagues';
 const DELAY_MS = 120;
+
+// Curated oneFeed leagues (see header). Probed 2026-07-16 across ~90 sport
+// keys; these were the ones with a real corpus. Freshness varies: cricket /
+// olympics / boxing / wwe / poker publish weekly, motogp / x-games / nhra /
+// tgl are seasonal or big-stories-only.
+const ONEFEED_LEAGUES = [
+  { slug: 'onefeed:boxing', sport: 'boxing', name: 'Boxing', aliases: [] },
+  { slug: 'onefeed:cricket', sport: 'cricket', name: 'Cricket', aliases: [] },
+  { slug: 'onefeed:horse-racing', sport: 'horse-racing', name: 'Horse Racing', aliases: [] },
+  { slug: 'onefeed:motogp', sport: 'racing', name: 'MotoGP', aliases: ['Moto GP', 'MotoGP World Championship'] },
+  { slug: 'onefeed:nhra', sport: 'racing', name: 'NHRA', aliases: ['Drag Racing'] },
+  { slug: 'onefeed:olympics', sport: 'olympics', name: 'Olympics', aliases: ['Olympic Games'] },
+  { slug: 'onefeed:poker', sport: 'poker', name: 'Poker', aliases: [] },
+  { slug: 'onefeed:tgl', sport: 'golf', name: 'TGL', aliases: ['TGL Golf'] },
+  { slug: 'onefeed:wwe', sport: 'wrestling', name: 'WWE', aliases: ['Pro Wrestling', 'Wrestling'] },
+  { slug: 'onefeed:x-games', sport: 'action-sports', name: 'X Games', aliases: ['Action Sports', 'Skateboarding', 'BMX'] }
+];
+
+async function oneFeedIsAlive(key) {
+  try {
+    const res = await fetch(`${ONEFEED_BASE}/${key}?limit=5`, {
+      headers: { 'User-Agent': 'Mozilla/5.0' },
+      signal: AbortSignal.timeout(10000)
+    });
+    if (!res.ok) return false;
+    const data = await res.json();
+    return (data.resultsCount || 0) > 0;
+  } catch {
+    return false;
+  }
+}
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -101,6 +139,19 @@ async function main() {
         .filter((a) => a && a !== name);
       leagues.push({ slug: `${sport}/${leagueSlug}`, sport, name, aliases });
       console.log(`  + ${sport}/${leagueSlug} — ${name}`);
+    }
+  }
+
+  console.log('\nValidating curated oneFeed leagues:');
+  for (const entry of ONEFEED_LEAGUES) {
+    await sleep(DELAY_MS);
+    const key = entry.slug.replace(/^onefeed:/, '');
+    if (await oneFeedIsAlive(key)) {
+      leagues.push(entry);
+      console.log(`  + ${entry.slug} — ${entry.name}`);
+    } else {
+      dropped++;
+      console.warn(`  - ${entry.slug}: empty/unreachable, dropped`);
     }
   }
 

--- a/backend/src/config/espnLeagues.json
+++ b/backend/src/config/espnLeagues.json
@@ -834,6 +834,82 @@
     ]
   },
   {
+    "slug": "onefeed:boxing",
+    "sport": "boxing",
+    "name": "Boxing",
+    "aliases": []
+  },
+  {
+    "slug": "onefeed:cricket",
+    "sport": "cricket",
+    "name": "Cricket",
+    "aliases": []
+  },
+  {
+    "slug": "onefeed:horse-racing",
+    "sport": "horse-racing",
+    "name": "Horse Racing",
+    "aliases": []
+  },
+  {
+    "slug": "onefeed:motogp",
+    "sport": "racing",
+    "name": "MotoGP",
+    "aliases": [
+      "Moto GP",
+      "MotoGP World Championship"
+    ]
+  },
+  {
+    "slug": "onefeed:nhra",
+    "sport": "racing",
+    "name": "NHRA",
+    "aliases": [
+      "Drag Racing"
+    ]
+  },
+  {
+    "slug": "onefeed:olympics",
+    "sport": "olympics",
+    "name": "Olympics",
+    "aliases": [
+      "Olympic Games"
+    ]
+  },
+  {
+    "slug": "onefeed:poker",
+    "sport": "poker",
+    "name": "Poker",
+    "aliases": []
+  },
+  {
+    "slug": "onefeed:tgl",
+    "sport": "golf",
+    "name": "TGL",
+    "aliases": [
+      "TGL Golf"
+    ]
+  },
+  {
+    "slug": "onefeed:wwe",
+    "sport": "wrestling",
+    "name": "WWE",
+    "aliases": [
+      "Pro Wrestling",
+      "Wrestling"
+    ]
+  },
+  {
+    "slug": "onefeed:x-games",
+    "sport": "action-sports",
+    "name": "X Games",
+    "aliases": [
+      "Action Sports",
+      "Skateboarding",
+      "BMX"
+    ]
+  },
+  {
     "slug": "racing/f1",
     "sport": "racing",
     "name": "F1",
@@ -973,9 +1049,9 @@
   {
     "slug": "soccer/arg.1",
     "sport": "soccer",
-    "name": "Argentine Primera División",
+    "name": "Argentine Primera Divisi\u00f3n",
     "aliases": [
-      "Argentine Liga Profesional de Fútbol",
+      "Argentine Liga Profesional de F\u00fatbol",
       "Argentine LPF"
     ]
   },
@@ -990,7 +1066,7 @@
   {
     "slug": "soccer/arg.3",
     "sport": "soccer",
-    "name": "Primera División B de Argentina",
+    "name": "Primera Divisi\u00f3n B de Argentina",
     "aliases": [
       "Argentine Primera B"
     ]
@@ -1241,7 +1317,7 @@
   {
     "slug": "soccer/chi.1",
     "sport": "soccer",
-    "name": "Chilean Primera División",
+    "name": "Chilean Primera Divisi\u00f3n",
     "aliases": [
       "Chilean Primera"
     ]
@@ -1251,7 +1327,7 @@
     "sport": "soccer",
     "name": "Chilean Pro/Rel",
     "aliases": [
-      "Chilean Primera División Promotion/Relegation Playoffs"
+      "Chilean Primera Divisi\u00f3n Promotion/Relegation Playoffs"
     ]
   },
   {
@@ -1289,7 +1365,7 @@
   {
     "slug": "soccer/col.1",
     "sport": "soccer",
-    "name": "Colombian Fútbol Profesional",
+    "name": "Colombian F\u00fatbol Profesional",
     "aliases": [
       "Colombian Primera A"
     ]
@@ -1297,7 +1373,7 @@
   {
     "slug": "soccer/col.copa",
     "sport": "soccer",
-    "name": "Copa Águila",
+    "name": "Copa \u00c1guila",
     "aliases": [
       "Copa Colombia"
     ]
@@ -1406,13 +1482,13 @@
   {
     "slug": "soccer/conmebol.america",
     "sport": "soccer",
-    "name": "Copa América",
+    "name": "Copa Am\u00e9rica",
     "aliases": []
   },
   {
     "slug": "soccer/conmebol.america.femenina",
     "sport": "soccer",
-    "name": "Copa América Femenina",
+    "name": "Copa Am\u00e9rica Femenina",
     "aliases": []
   },
   {
@@ -1438,7 +1514,7 @@
   {
     "slug": "soccer/crc.1",
     "sport": "soccer",
-    "name": "Primera División de Costa Rica",
+    "name": "Primera Divisi\u00f3n de Costa Rica",
     "aliases": [
       "Costa Rican Primera Division",
       "Liga FPD"
@@ -1648,6 +1724,12 @@
     ]
   },
   {
+    "slug": "soccer/fifa.friendly.w",
+    "sport": "soccer",
+    "name": "Women's International Friendly",
+    "aliases": []
+  },
+  {
     "slug": "soccer/fifa.friendly_u21",
     "sport": "soccer",
     "name": "Men's U-21 Friendly",
@@ -1656,10 +1738,12 @@
     ]
   },
   {
-    "slug": "soccer/fifa.friendly.w",
+    "slug": "soccer/fifa.intercontinental.cup",
     "sport": "soccer",
-    "name": "Women's International Friendly",
-    "aliases": []
+    "name": "Intercontinental Cup",
+    "aliases": [
+      "Intercontinental Cup (India)"
+    ]
   },
   {
     "slug": "soccer/fifa.intercontinental_cup",
@@ -1667,14 +1751,6 @@
     "name": "Intercontinental Cup",
     "aliases": [
       "FIFA Intercontinental Cup"
-    ]
-  },
-  {
-    "slug": "soccer/fifa.intercontinental.cup",
-    "sport": "soccer",
-    "name": "Intercontinental Cup",
-    "aliases": [
-      "Intercontinental Cup (India)"
     ]
   },
   {
@@ -1877,10 +1953,10 @@
   {
     "slug": "soccer/fra.w.1",
     "sport": "soccer",
-    "name": "Division 1 Féminine",
+    "name": "Division 1 F\u00e9minine",
     "aliases": [
-      "French Première Ligue",
-      "Première Ligue"
+      "French Premi\u00e8re Ligue",
+      "Premi\u00e8re Ligue"
     ]
   },
   {
@@ -2010,7 +2086,7 @@
   {
     "slug": "soccer/hon.1",
     "sport": "soccer",
-    "name": "Primera División de Honduras",
+    "name": "Primera Divisi\u00f3n de Honduras",
     "aliases": [
       "Honduran Liga Nacional"
     ]
@@ -2100,8 +2176,8 @@
     "sport": "soccer",
     "name": "Mexican Ascenso MX",
     "aliases": [
-      "Mexican Liga de Expansión MX",
-      "Liga de Expansión MX"
+      "Mexican Liga de Expansi\u00f3n MX",
+      "Liga de Expansi\u00f3n MX"
     ]
   },
   {
@@ -2205,9 +2281,9 @@
   {
     "slug": "soccer/par.1",
     "sport": "soccer",
-    "name": "Primera División de Paraguay",
+    "name": "Primera Divisi\u00f3n de Paraguay",
     "aliases": [
-      "Paraguayan Primera División",
+      "Paraguayan Primera Divisi\u00f3n",
       "Paraguayan Primera"
     ]
   },
@@ -2337,7 +2413,7 @@
   {
     "slug": "soccer/slv.1",
     "sport": "soccer",
-    "name": "Primera División de El Salvador",
+    "name": "Primera Divisi\u00f3n de El Salvador",
     "aliases": [
       "Salvadoran Primera Division",
       "Salvadoran Primera"
@@ -2389,6 +2465,15 @@
     ]
   },
   {
+    "slug": "soccer/uefa.euro.u19",
+    "sport": "soccer",
+    "name": "European Under-19 Championship",
+    "aliases": [
+      "UEFA European Under-19 Championship",
+      "EURO Under-19"
+    ]
+  },
+  {
     "slug": "soccer/uefa.euro_u21",
     "sport": "soccer",
     "name": "European Under-21 Championship",
@@ -2406,29 +2491,10 @@
     ]
   },
   {
-    "slug": "soccer/uefa.euro.u19",
-    "sport": "soccer",
-    "name": "European Under-19 Championship",
-    "aliases": [
-      "UEFA European Under-19 Championship",
-      "EURO Under-19"
-    ]
-  },
-  {
     "slug": "soccer/uefa.europa",
     "sport": "soccer",
     "name": "UEFA Europa League",
     "aliases": []
-  },
-  {
-    "slug": "soccer/uefa.europa_qual",
-    "sport": "soccer",
-    "name": "Europa League Qualfiying",
-    "aliases": [
-      "UEFA Europa League Qualifying",
-      "UEFA Europa League Qualfiying",
-      "UEL Qualifying"
-    ]
   },
   {
     "slug": "soccer/uefa.europa.conf",
@@ -2445,6 +2511,16 @@
     "aliases": [
       "UEFA Conference League Qualifying",
       "UECL Qualifying"
+    ]
+  },
+  {
+    "slug": "soccer/uefa.europa_qual",
+    "sport": "soccer",
+    "name": "Europa League Qualfiying",
+    "aliases": [
+      "UEFA Europa League Qualifying",
+      "UEFA Europa League Qualfiying",
+      "UEL Qualifying"
     ]
   },
   {
@@ -2515,7 +2591,7 @@
     "sport": "soccer",
     "name": "URU2",
     "aliases": [
-      "Segunda División de Uruguay",
+      "Segunda Divisi\u00f3n de Uruguay",
       "Seg",
       "Segunda"
     ]
@@ -2589,9 +2665,9 @@
   {
     "slug": "soccer/ven.1",
     "sport": "soccer",
-    "name": "Primera División de Venezuela",
+    "name": "Primera Divisi\u00f3n de Venezuela",
     "aliases": [
-      "Venezuelan Primera División",
+      "Venezuelan Primera Divisi\u00f3n",
       "Liga FUTVE"
     ]
   },

--- a/backend/src/services/SportsNewsService.js
+++ b/backend/src/services/SportsNewsService.js
@@ -7,6 +7,12 @@ const {
 } = require('../config/sportsNews');
 
 const ESPN_BASE_URL = 'https://site.api.espn.com/apis/site/v2/sports';
+// Sports ESPN covers but doesn't expose as site/v2 leagues (MotoGP, cricket,
+// Olympics, boxing…) live behind the oneFeed content API that powers hub
+// pages like espn.com/motogp/. Whitelist slugs use an 'onefeed:' prefix to
+// select this fetcher; everything downstream treats slugs as opaque strings.
+const ONEFEED_BASE_URL = 'https://onefeed.fan.api.espn.com/apis/v3/cached/contentEngine/oneFeed/leagues';
+const ONEFEED_PREFIX = 'onefeed:';
 
 /**
  * Fetches sports news from ESPN's unofficial API and caches it in the
@@ -19,41 +25,11 @@ class SportsNewsService {
     this.logger = logger;
   }
 
-  /**
-   * Fetch one ESPN league news feed and map it to NewsArticle-shaped
-   * objects. Filters out items unusable as news cards: missing url/headline,
-   * ESPN+ premium (paywalled), and video clips.
-   *
-   * Never throws. `status` distinguishes what a failure means:
-   *  - 'ok'      — feed exists (200 + articles array); may still be empty
-   *                for an off-season league
-   *  - 'invalid' — the slug is wrong (HTTP 4xx or shape without an articles
-   *                array): a fact about the slug, safe to cache
-   *  - 'network' — timeout / connection error / 5xx: transient, must not be
-   *                cached as a failure
-   * @param {string} slug - bare league slug, e.g. 'racing/f1'
-   * @returns {Promise<{status: string, articles: Array, error?: string}>}
-   */
-  async fetchFeed(slug) {
-    let response;
-    try {
-      response = await axios.get(`${ESPN_BASE_URL}/${slug}/news`, {
-        timeout: 10000,
-        params: { limit: MAX_ARTICLES_PER_FEED }
-      });
-    } catch (error) {
-      const httpStatus = error.response?.status;
-      if (httpStatus && httpStatus >= 400 && httpStatus < 500) {
-        return { status: 'invalid', articles: [], error: `HTTP ${httpStatus}` };
-      }
-      return { status: 'network', articles: [], error: error.message };
-    }
-
-    if (!Array.isArray(response.data?.articles)) {
-      return { status: 'invalid', articles: [], error: 'malformed response (no articles array)' };
-    }
-
-    const articles = response.data.articles
+  // Both ESPN APIs use the same article field names. Filters out items
+  // unusable as news cards: missing url/headline, ESPN+ premium (paywalled),
+  // and video clips.
+  mapArticles(rawArticles) {
+    return rawArticles
       .map((a) => ({
         articleUrl: a.links?.web?.href,
         headline: a.headline,
@@ -72,6 +48,94 @@ class SportsNewsService {
         return true;
       })
       .map(({ type, premium, ...article }) => article);
+  }
+
+  /**
+   * Fetch one ESPN news feed and map it to NewsArticle-shaped objects.
+   *
+   * Never throws. `status` distinguishes what a failure means:
+   *  - 'ok'      — feed exists (200 + expected shape); may still be empty
+   *                for an off-season league
+   *  - 'invalid' — the slug is wrong (HTTP 4xx or unexpected shape): a fact
+   *                about the slug, safe to cache
+   *  - 'network' — timeout / connection error / 5xx: transient, must not be
+   *                cached as a failure
+   * @param {string} slug - bare league slug ('racing/f1') or oneFeed slug
+   *   ('onefeed:motogp')
+   * @returns {Promise<{status: string, articles: Array, error?: string}>}
+   */
+  async fetchFeed(slug) {
+    if (slug.startsWith(ONEFEED_PREFIX)) {
+      return this.fetchOneFeed(slug.slice(ONEFEED_PREFIX.length));
+    }
+
+    let response;
+    try {
+      response = await axios.get(`${ESPN_BASE_URL}/${slug}/news`, {
+        timeout: 10000,
+        params: { limit: MAX_ARTICLES_PER_FEED }
+      });
+    } catch (error) {
+      const httpStatus = error.response?.status;
+      if (httpStatus && httpStatus >= 400 && httpStatus < 500) {
+        return { status: 'invalid', articles: [], error: `HTTP ${httpStatus}` };
+      }
+      return { status: 'network', articles: [], error: error.message };
+    }
+
+    if (!Array.isArray(response.data?.articles)) {
+      return { status: 'invalid', articles: [], error: 'malformed response (no articles array)' };
+    }
+
+    return { status: 'ok', articles: this.mapArticles(response.data.articles) };
+  }
+
+  /**
+   * Fetch a oneFeed league (articles nested in feed[].data.now[]).
+   *
+   * Caveat: unknown league keys return 200 with an empty feed rather than a
+   * 4xx, so 'ok' here does NOT prove the key exists — whitelist membership
+   * (espnLeagues.json, validated at bootstrap time) is the real gate for
+   * oneFeed slugs, and the resolver only ever fetches whitelisted candidates.
+   */
+  async fetchOneFeed(league) {
+    let response;
+    try {
+      response = await axios.get(`${ONEFEED_BASE_URL}/${league}`, {
+        timeout: 10000,
+        // Feed entries can hold several articles each; over-fetch, then
+        // sort/slice below.
+        params: { limit: MAX_ARTICLES_PER_FEED * 3 },
+        headers: { 'User-Agent': 'Mozilla/5.0' }
+      });
+    } catch (error) {
+      const httpStatus = error.response?.status;
+      if (httpStatus && httpStatus >= 400 && httpStatus < 500) {
+        return { status: 'invalid', articles: [], error: `HTTP ${httpStatus}` };
+      }
+      return { status: 'network', articles: [], error: error.message };
+    }
+
+    const feed = response.data?.feed;
+    if (!Array.isArray(feed)) {
+      return { status: 'invalid', articles: [], error: 'malformed response (no feed array)' };
+    }
+
+    const raw = [];
+    for (const entry of feed) {
+      const now = entry?.data?.now;
+      if (Array.isArray(now)) raw.push(...now);
+    }
+
+    const seen = new Set();
+    const articles = this.mapArticles(raw)
+      .filter((a) => {
+        if (seen.has(a.articleUrl)) return false;
+        seen.add(a.articleUrl);
+        return true;
+      })
+      .sort((a, b) => (b.publishedAt?.getTime() || 0) - (a.publishedAt?.getTime() || 0))
+      .slice(0, MAX_ARTICLES_PER_FEED);
 
     return { status: 'ok', articles };
   }

--- a/backend/src/services/__tests__/sportsNewsServiceOneFeed.test.js
+++ b/backend/src/services/__tests__/sportsNewsServiceOneFeed.test.js
@@ -1,0 +1,124 @@
+const axios = require('axios');
+
+jest.mock('axios');
+
+jest.mock('../../config/sportsNews', () => ({
+  ESPN_LEAGUES: [],
+  isWhitelistedSlug: () => true,
+  getLeagueBySlug: () => null,
+  legacySlugFeeds: () => [],
+  DEFAULT_SUGGESTIONS: [],
+  SPORT_FEEDS: {},
+  GLOBAL_TOP_FEEDS: [],
+  NEWS_TTL_DAYS: 3,
+  MAX_ARTICLES_PER_FEED: 3
+}));
+
+const SportsNewsService = require('../SportsNewsService');
+
+const quietLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+const article = (n, overrides = {}) => ({
+  headline: `Story ${n}`,
+  description: `desc ${n}`,
+  images: [{ url: `https://img/${n}.jpg` }],
+  links: { web: { href: `https://espn.com/story/${n}` } },
+  published: `2026-07-0${n}T10:00:00Z`,
+  type: 'Story',
+  premium: false,
+  ...overrides
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('fetchFeed oneFeed scheme', () => {
+  test('onefeed: slugs hit the oneFeed API and flatten feed[].data.now[]', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        feed: [
+          { data: { now: [article(1), article(2)] } },
+          { data: { now: [article(3)] } },
+          { data: {} } // entry without articles
+        ]
+      }
+    });
+
+    const service = new SportsNewsService(quietLogger);
+    const result = await service.fetchFeed('onefeed:motogp');
+
+    expect(axios.get.mock.calls[0][0]).toBe(
+      'https://onefeed.fan.api.espn.com/apis/v3/cached/contentEngine/oneFeed/leagues/motogp'
+    );
+    expect(result.status).toBe('ok');
+    // Sorted newest-first
+    expect(result.articles.map((a) => a.headline)).toEqual(['Story 3', 'Story 2', 'Story 1']);
+    expect(result.articles[0]).toEqual({
+      articleUrl: 'https://espn.com/story/3',
+      headline: 'Story 3',
+      description: 'desc 3',
+      imageUrl: 'https://img/3.jpg',
+      publishedAt: new Date('2026-07-03T10:00:00Z')
+    });
+  });
+
+  test('dedupes repeated stories, filters premium/video, caps at MAX_ARTICLES_PER_FEED', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        feed: [
+          {
+            data: {
+              now: [
+                article(1),
+                article(1), // duplicate url
+                article(2, { premium: true }),
+                article(3, { type: 'Media' }),
+                article(4),
+                article(5),
+                article(6),
+                article(7)
+              ]
+            }
+          }
+        ]
+      }
+    });
+
+    const service = new SportsNewsService(quietLogger);
+    const { articles } = await service.fetchFeed('onefeed:cricket');
+
+    // MAX_ARTICLES_PER_FEED mocked to 3; premium 2 and Media 3 filtered out
+    expect(articles.map((a) => a.headline)).toEqual(['Story 7', 'Story 6', 'Story 5']);
+  });
+
+  test('malformed body (no feed array) is invalid; 4xx invalid; timeout network', async () => {
+    const service = new SportsNewsService(quietLogger);
+
+    axios.get.mockResolvedValueOnce({ data: { status: 'success' } });
+    expect((await service.fetchFeed('onefeed:x')).status).toBe('invalid');
+
+    const httpErr = new Error('bad'); httpErr.response = { status: 404 };
+    axios.get.mockRejectedValueOnce(httpErr);
+    expect(await service.fetchFeed('onefeed:x')).toEqual({ status: 'invalid', articles: [], error: 'HTTP 404' });
+
+    axios.get.mockRejectedValueOnce(new Error('timeout of 10000ms exceeded'));
+    expect((await service.fetchFeed('onefeed:x')).status).toBe('network');
+  });
+
+  test('empty feed is ok (whitelist is the gate for oneFeed keys)', async () => {
+    axios.get.mockResolvedValueOnce({ data: { feed: [] } });
+    const service = new SportsNewsService(quietLogger);
+    expect(await service.fetchFeed('onefeed:quiet')).toEqual({ status: 'ok', articles: [] });
+  });
+
+  test('plain league slugs still use the site/v2 news endpoint', async () => {
+    axios.get.mockResolvedValueOnce({ data: { articles: [article(1)] } });
+    const service = new SportsNewsService(quietLogger);
+    const result = await service.fetchFeed('racing/f1');
+
+    expect(axios.get.mock.calls[0][0]).toBe(
+      'https://site.api.espn.com/apis/site/v2/sports/racing/f1/news'
+    );
+    expect(result.status).toBe('ok');
+    expect(result.articles).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #125: the user spotted that espn.com *does* have a MotoGP hub. It turns out ESPN serves several sports only through the **oneFeed content API** behind hub pages (`onefeed.fan.api.espn.com/.../oneFeed/leagues/{key}`), invisible to the site/v2 league listing our bootstrap used. Probed ~90 candidate sport keys; 10 have a real corpus and join the whitelist under an `onefeed:` slug scheme (348 leagues total now):

| feed | freshness at probe time |
|---|---|
| cricket, olympics, boxing, wwe, poker | articles from this week |
| horse-racing | ~1 month |
| motogp, x-games, nhra, tgl | seasonal / big-stories-only |

- `fetchFeed` branches on the `onefeed:` prefix; articles flattened from `feed[].data.now[]`, deduped, sorted newest-first, capped. Field shape matches site/v2 so mapping/filtering is shared (`mapArticles()`).
- Unknown oneFeed keys return 200+empty (not 4xx), so **whitelist membership — live-validated at bootstrap — is the gate** for these slugs; documented on `fetchOneFeed`. Resolver only fetches whitelisted candidates regardless.
- `bootstrap-espn-leagues.js` gains a curated `ONEFEED_LEAGUES` section validated on every re-run.
- **Climbing stays unsupported** — ESPN has ~1 climbing article in total; that needs a second provider (NewsData.io note in TOR-93/96) if ever wanted.

Everything downstream (resolver, follows, matching, job, UI) treats slugs as opaque strings — zero changes needed there.

## Verification

- 5 new jest tests (suite 31/31 green): oneFeed URL + flattening + newest-first sort, dedupe/premium/video filter + cap, invalid/network statuses, empty-feed-is-ok, site/v2 path untouched.
- Live fetch of all 10 feeds through the real service: 10 articles each, 100% with images.
- E2E on a scratch stack (dropped after): "MotoGP" → `onefeed:motogp`, "cricket" → `onefeed:cricket`, "olympics" → `onefeed:olympics` + Olympic soccer/basketball site-v2 leagues (nice LLM combo), "WSOP poker" → `onefeed:poker`, "climbing" → honest 422; `GET /news` serves the articles with correct league badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)