### PR TITLE
Sports news: cap top stories at one card per global event

### DIFF
--- a/backend/src/routes/__tests__/newsTopEvents.test.js
+++ b/backend/src/routes/__tests__/newsTopEvents.test.js
@@ -1,0 +1,71 @@
+jest.mock('../../config/sportsNews', () => ({
+  ESPN_LEAGUES: [],
+  isWhitelistedSlug: () => true,
+  getLeagueBySlug: () => null,
+  legacySlugFeeds: () => [],
+  DEFAULT_SUGGESTIONS: [],
+  SPORT_FEEDS: {},
+  GLOBAL_TOP_FEEDS: [
+    { slug: 'soccer/fifa.world', label: 'World Cup', from: '2026-06-01', to: '2026-08-01' },
+    { slug: 'olympics', label: 'Olympics', from: '2026-07-01', to: '2026-09-01' },
+    { slug: 'tennis/wimbledon', label: 'Wimbledon', from: '2026-06-20', to: '2026-07-20' }
+  ],
+  NEWS_TTL_DAYS: 3,
+  MAX_ARTICLES_PER_FEED: 10
+}));
+
+const { pickTopEvents } = require('../news');
+
+const article = (n, feeds) => ({
+  _id: `id-${n}`,
+  headline: `Story ${n}`,
+  feeds,
+  isTopEvent: true,
+  publishedAt: new Date(`2026-07-${String(20 - n).padStart(2, '0')}T10:00:00Z`)
+});
+
+describe('pickTopEvents', () => {
+  test('many articles from one global feed collapse to the newest one', () => {
+    const pool = [1, 2, 3, 4, 5, 6].map((n) => article(n, ['soccer/fifa.world']));
+    const picked = pickTopEvents(pool, 2);
+    expect(picked).toHaveLength(1);
+    expect(picked[0]._id).toBe('id-1');
+  });
+
+  test('two global feeds yield one article each, newest per group', () => {
+    const pool = [
+      article(1, ['soccer/fifa.world']),
+      article(2, ['olympics']),
+      article(3, ['soccer/fifa.world']),
+      article(4, ['olympics'])
+    ];
+    const picked = pickTopEvents(pool, 2);
+    expect(picked.map((a) => a._id)).toEqual(['id-1', 'id-2']);
+  });
+
+  test('three concurrent global feeds respect the cap, keeping newest-first order', () => {
+    const pool = [
+      article(1, ['tennis/wimbledon']),
+      article(2, ['soccer/fifa.world']),
+      article(3, ['olympics'])
+    ];
+    const picked = pickTopEvents(pool, 2);
+    expect(picked.map((a) => a._id)).toEqual(['id-1', 'id-2']);
+  });
+
+  test('articles with stale or missing feed slugs group by fallback key without crashing', () => {
+    const pool = [
+      article(1, ['soccer/uefa.euro']),
+      article(2, ['soccer/uefa.euro']),
+      article(3, undefined),
+      article(4, [])
+    ];
+    const picked = pickTopEvents(pool, 4);
+    // stale slugs group by feeds[0]; missing feeds share the 'unknown' group
+    expect(picked.map((a) => a._id)).toEqual(['id-1', 'id-3']);
+  });
+
+  test('empty pool returns empty', () => {
+    expect(pickTopEvents([], 2)).toEqual([]);
+  });
+});

--- a/backend/src/routes/news.js
+++ b/backend/src/routes/news.js
@@ -4,7 +4,7 @@ const SportResolution = require('../models/SportResolution');
 const User = require('../models/User');
 const SportResolverService = require('../services/SportResolverService');
 const { ResolutionError } = require('../services/SportResolverService');
-const { legacySlugFeeds, DEFAULT_SUGGESTIONS } = require('../config/sportsNews');
+const { legacySlugFeeds, DEFAULT_SUGGESTIONS, GLOBAL_TOP_FEEDS } = require('../config/sportsNews');
 const { auth } = require('../middleware/auth');
 const router = express.Router();
 
@@ -29,6 +29,28 @@ const followedFeeds = (sportsNews) => {
   return [...new Set([...fromFollows, ...fromLegacy])];
 };
 
+const TOP_EVENT_CAP = 2;
+const TOP_EVENT_POOL = 12;
+
+const globalTopSlugs = new Set(GLOBAL_TOP_FEEDS.map((f) => f.slug));
+
+// One article per global top feed, newest first, capped. Articles keep their
+// isTopEvent flag for NEWS_TTL_DAYS after a feed leaves GLOBAL_TOP_FEEDS, so
+// fall back to the article's first feed slug as the group key.
+const pickTopEvents = (articles, cap) => {
+  const seenGroups = new Set();
+  const picked = [];
+  for (const article of articles) {
+    if (picked.length >= cap) break;
+    const feeds = article.feeds || [];
+    const group = feeds.find((slug) => globalTopSlugs.has(slug)) || feeds[0] || 'unknown';
+    if (seenGroups.has(group)) continue;
+    seenGroups.add(group);
+    picked.push(article);
+  }
+  return picked;
+};
+
 // GET /api/v1/news - Sports news feed for the authenticated user:
 // seasonal top-event stories (shown to everyone) interleaved with articles
 // from the league feeds the user follows.
@@ -45,12 +67,14 @@ router.get('/', auth, async (req, res) => {
 
     // Two queries instead of one isTopEvent-first sort: the swipe stack is
     // strictly sequential, so uncapped top events (up to a whole feed's
-    // worth) would bury the user's own sports behind them.
-    const TOP_EVENT_CAP = 4;
-    const topEvents = await NewsArticle.find({ isTopEvent: true })
+    // worth) would bury the user's own sports behind them. Top events are
+    // further deduped to one article per global feed (see pickTopEvents),
+    // so a single event like the World Cup can't flood the stack.
+    const topEventPool = await NewsArticle.find({ isTopEvent: true })
       .sort({ publishedAt: -1 })
-      .limit(TOP_EVENT_CAP)
+      .limit(TOP_EVENT_POOL)
       .lean();
+    const topEvents = pickTopEvents(topEventPool, TOP_EVENT_CAP);
 
     let personal = [];
     if (userFeeds.length > 0) {
@@ -201,3 +225,4 @@ router.get('/suggestions', auth, async (req, res) => {
 });
 
 module.exports = router;
+module.exports.pickTopEvents = pickTopEvents;


### PR DESCRIPTION
## Problem

The dashboard news stack showed too many "Top story" cards, and they were all soccer. Top stories come from `GLOBAL_TOP_FEEDS`, whose only active entry is the FIFA World Cup (through Aug 1), and `GET /api/v1/news` pulled up to 4 `isTopEvent` articles and interleaved them 1 top : 2 personal — so World Cup cards landed at positions 0, 3, 6, 9. Prod currently has 21 World Cup articles flagged `isTopEvent`.

## Change

- New pure helper `pickTopEvents` in `backend/src/routes/news.js`: fetches a pool of 12 top events, keeps only the **newest article per global feed**, capped at **2 overall**.
- Today that means exactly 1 World Cup card per feed load (position 0). If two global events ever run concurrently (e.g. Olympics + World Cup), each contributes one card.
- Interleave ratio and frontend untouched.

## Tests

- `backend/src/routes/__tests__/newsTopEvents.test.js`: single-feed collapse, per-feed diversity, cap enforcement, stale/missing feed-slug fallback. Full backend suite passes (36/36).
- Verified `pickTopEvents` against current prod article shapes: the 4 cards users see today collapse to the newest one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)