### PR TITLE
AI coach: remember tool calls across turns (persist + replay tool_rounds)

### DIFF
--- a/ai-coach-service/app/api/v1/chat_stream.py
+++ b/ai-coach-service/app/api/v1/chat_stream.py
@@ -74,13 +74,20 @@ async def generate_sse_stream(
                 # Calculate response time
                 response_time_ms = int((time.time() - start_time) * 1000)
 
-                # Save AI response to conversation (includes tool markers)
-                if full_response.strip():
+                # Structured tool exchange from the orchestrator — persisted so
+                # later turns can replay it (never sent over SSE).
+                tool_rounds = event.get("tool_rounds") or []
+
+                # Save AI response to conversation (includes tool markers).
+                # A tool-only turn with empty final text must still save, or
+                # the human message is orphaned and the tool context lost.
+                if full_response.strip() or tool_rounds:
                     await conversation_service.add_message(
                         conversation_id=conversation_id,
                         role="ai",
                         content=full_response,
-                        response_time_ms=response_time_ms
+                        response_time_ms=response_time_ms,
+                        tool_rounds=tool_rounds
                     )
                     logger.info(f"Saved AI response to conversation {conversation_id}")
 

--- a/ai-coach-service/app/api/v1/conversations.py
+++ b/ai-coach-service/app/api/v1/conversations.py
@@ -118,6 +118,11 @@ async def get_conversation(
         if not conversation:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
+        # tool_rounds is model-replay context only — the chat UI never renders
+        # it, so don't ship potentially large tool payloads to the browser.
+        for msg in conversation.get("messages", []):
+            msg.pop("tool_rounds", None)
+
         return conversation
 
     except HTTPException:

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -99,6 +99,158 @@ def _model_facing_result(result: Any) -> Any:
     return result
 
 
+# --- Tool-call memory across turns ---------------------------------------
+# Assistant messages persist their turn's tool exchange as `tool_rounds`
+# (see conversation_service.add_message). On later turns the recent rounds
+# are replayed into the OpenAI history so the model remembers what it
+# already looked up instead of re-calling the same tools.
+
+# Replay caps: at most the last K tool-bearing assistant messages, and at
+# most this many total chars of tool-result content (~6k tokens). Anything
+# beyond either cap replays as text only.
+REPLAY_TOOL_ROUNDS_LAST_K = 2
+REPLAY_TOOL_CHARS_BUDGET = 24_000
+
+# Write classification, used to decide when forced grounding may relax:
+# after a write, replayed read results may be stale, so re-reads are correct.
+# A dry-run/confirm preview mutates nothing and counts as a read.
+_WRITE_PREVIEW_DEFAULT_TRUE = {  # dry_run defaults true → write only on explicit dry_run=false
+    "schedule_to_calendar", "schedule_plan_to_calendar", "reschedule_session",
+    "update_calendar_workout", "adjust_plan",
+}
+_WRITE_CONFIRM_TOOLS = {"delete_calendar_event", "delete_workout_template"}  # write only on confirm=true
+_WRITE_PREVIEW_DEFAULT_FALSE = {"resolve_week"}  # writes unless dry_run=true
+_WRITE_ALWAYS = {
+    "add_exercise", "add_plan_workout", "create_goal", "create_plan",
+    "create_workout_template", "delete_memory", "generate_plan", "log_workout",
+    "remove_plan_workout", "save_exercise_video", "save_memory",
+    "substitute_exercise", "update_goal", "update_memory", "update_plan",
+}
+
+
+def _call_is_write(name: str, arguments_json: str | None) -> bool:
+    """True when a persisted tool call actually mutated user data."""
+    try:
+        args = json.loads(arguments_json) if arguments_json else {}
+    except (ValueError, TypeError):
+        args = {}
+    if not isinstance(args, dict):
+        args = {}
+    if name in _WRITE_ALWAYS:
+        return True
+    if name in _WRITE_CONFIRM_TOOLS:
+        return args.get("confirm") is True
+    if name in _WRITE_PREVIEW_DEFAULT_TRUE:
+        return args.get("dry_run") is False
+    if name in _WRITE_PREVIEW_DEFAULT_FALSE:
+        return args.get("dry_run") is not True
+    return False
+
+
+# The calendar-preview card tag carries a base64 payload in saved content;
+# replaying the blob to the model is pure token waste (and parrot bait).
+_CALENDAR_PREVIEW_TAG_RE = re.compile(
+    r'<calendar-preview\s+payload="[^"]*">\s*</calendar-preview>'
+)
+
+
+def _sanitize_replayed_content(content: str) -> str:
+    return _CALENDAR_PREVIEW_TAG_RE.sub("<calendar-preview/>", content or "")
+
+
+def _replayable_indexes(conversation_history: List[Dict[str, Any]]) -> set:
+    """Indexes of assistant history messages whose tool_rounds get replayed,
+    chosen newest→oldest under the K and char-budget caps."""
+    chosen = set()
+    budget = REPLAY_TOOL_CHARS_BUDGET
+    remaining = REPLAY_TOOL_ROUNDS_LAST_K
+    for idx in range(len(conversation_history) - 1, -1, -1):
+        msg = conversation_history[idx]
+        if msg.get("role") == "human" or not msg.get("tool_rounds"):
+            continue
+        if remaining <= 0:
+            break
+        cost = sum(
+            len(str(r.get("content") or ""))
+            for rd in msg["tool_rounds"]
+            for r in (rd.get("results") or [])
+        )
+        if cost > budget:
+            break
+        budget -= cost
+        remaining -= 1
+        chosen.add(idx)
+    return chosen
+
+
+def _expand_tool_rounds(tool_rounds: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Expand persisted rounds into OpenAI messages. A round missing any
+    matching result is skipped whole — an assistant tool_calls message
+    without its full set of adjacent tool replies 400s the API."""
+    expanded = []
+    for round_ in tool_rounds:
+        calls = round_.get("tool_calls") or []
+        results = round_.get("results") or []
+        result_by_id = {r.get("tool_call_id"): r for r in results}
+        if not calls or any(c.get("id") not in result_by_id for c in calls):
+            continue
+        expanded.append({
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": c["id"],
+                    "type": "function",
+                    "function": {
+                        "name": c.get("name") or "",
+                        "arguments": c.get("arguments") or "{}",
+                    },
+                }
+                for c in calls
+            ],
+        })
+        for c in calls:
+            expanded.append({
+                "role": "tool",
+                "tool_call_id": c["id"],
+                "content": str(result_by_id[c["id"]].get("content") or ""),
+            })
+    return expanded
+
+
+def _history_to_openai_messages(conversation_history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Rebuild OpenAI messages from stored history. Recent assistant turns
+    replay their structured tool exchange (within caps); older or legacy
+    turns replay as text only. Note this is a collapse, not a byte-faithful
+    reproduction: prose streamed between tool rounds lives only in the final
+    saved content, so it folds into the trailing assistant message."""
+    replay_at = _replayable_indexes(conversation_history)
+    messages = []
+    for idx, hist_msg in enumerate(conversation_history):
+        if hist_msg.get("role") == "human":
+            messages.append({"role": "user", "content": hist_msg.get("content", "")})
+            continue
+        content = _sanitize_replayed_content(hist_msg.get("content", ""))
+        if idx in replay_at:
+            messages.extend(_expand_tool_rounds(hist_msg["tool_rounds"]))
+            if content.strip():
+                messages.append({"role": "assistant", "content": content})
+        else:
+            messages.append({"role": "assistant", "content": content})
+    return messages
+
+
+def _history_write_in_replay_window(conversation_history: List[Dict[str, Any]]) -> bool:
+    """True if any replayed round contains a real write — replayed reads may
+    then be stale, so forced grounding must stay on."""
+    for idx in _replayable_indexes(conversation_history):
+        for round_ in conversation_history[idx].get("tool_rounds") or []:
+            for call in round_.get("tool_calls") or []:
+                if _call_is_write(call.get("name") or "", call.get("arguments")):
+                    return True
+    return False
+
+
 class AgentOrchestrator:
     """Enhanced orchestrator with comprehensive fitness management tools"""
 
@@ -590,12 +742,7 @@ USER DATA:
         # Add conversation history if available
         if conversation_history:
             logger.info(f"[SENSEI DEBUG STREAMING] Has conversation history ({len(conversation_history)} messages)")
-            for hist_msg in conversation_history:
-                role = "user" if hist_msg.get("role") == "human" else "assistant"
-                messages.append({
-                    "role": role,
-                    "content": hist_msg.get("content", "")
-                })
+            messages.extend(_history_to_openai_messages(conversation_history))
             # Add current message (context is already in system prompt)
             messages.append({"role": "user", "content": current_user_message})
         else:
@@ -606,6 +753,9 @@ USER DATA:
         # Track the full response and tools used for reflection
         full_response = []
         tools_used = []
+        # Structured tool exchange for this turn (one entry per LLM round),
+        # persisted with the assistant message so later turns can replay it.
+        turn_tool_rounds: List[Dict[str, Any]] = []
         # Video-embed tags returned by tools this turn. The model sometimes
         # paraphrases a video result instead of emitting the <video-embed> tag,
         # which breaks the player. We ensure the tag(s) end up in the response.
@@ -615,7 +765,19 @@ USER DATA:
             # Create streaming completion with tools. If the user referenced their
             # own plan/calendar/workouts, force at least one tool call so the answer
             # is grounded in their real data instead of generic advice.
-            first_tool_choice = "required" if _needs_grounding(message) else "auto"
+            # Exception: when the replayed history already carries tool results
+            # AND none of those rounds wrote anything (a write makes replayed
+            # reads potentially stale), let the model answer from what it has.
+            history_replays_tools = bool(_replayable_indexes(conversation_history or []))
+            grounding_satisfied_by_history = (
+                history_replays_tools
+                and not _history_write_in_replay_window(conversation_history or [])
+            )
+            first_tool_choice = (
+                "required"
+                if _needs_grounding(message) and not grounding_satisfied_by_history
+                else "auto"
+            )
             logger.info(
                 f"Calling OpenAI API with model: {self.settings.openai_model} and "
                 f"{len(self.get_tools())} tools (tool_choice={first_tool_choice})"
@@ -737,6 +899,31 @@ USER DATA:
                             "tool_call_id": tool_result["tool_call_id"],
                             "content": tool_result["content"]
                         })
+
+                    # Record the round for persistence (content mirrors what the
+                    # model saw; capped later in conversation_service).
+                    _round_names = {
+                        tool_calls_data[i]["id"]: tool_calls_data[i]["function"]["name"]
+                        for i in sorted(tool_calls_data.keys())
+                    }
+                    turn_tool_rounds.append({
+                        "tool_calls": [
+                            {
+                                "id": tool_calls_data[i]["id"],
+                                "name": tool_calls_data[i]["function"]["name"],
+                                "arguments": tool_calls_data[i]["function"]["arguments"],
+                            }
+                            for i in sorted(tool_calls_data.keys())
+                        ],
+                        "results": [
+                            {
+                                "tool_call_id": tr["tool_call_id"],
+                                "name": _round_names.get(tr["tool_call_id"], ""),
+                                "content": tr["content"],
+                            }
+                            for tr in tool_results
+                        ],
+                    })
 
                     # Stream the final response after tool execution - with tools enabled for chaining
                     logger.info("Getting final response after tool execution...")
@@ -864,6 +1051,30 @@ USER DATA:
                                         "content": result["content"]
                                     })
 
+                                # Record the follow-up round for persistence.
+                                _round_names = {
+                                    follow_up_tool_calls[i]["id"]: follow_up_tool_calls[i]["function"]["name"]
+                                    for i in sorted(follow_up_tool_calls.keys())
+                                }
+                                turn_tool_rounds.append({
+                                    "tool_calls": [
+                                        {
+                                            "id": follow_up_tool_calls[i]["id"],
+                                            "name": follow_up_tool_calls[i]["function"]["name"],
+                                            "arguments": follow_up_tool_calls[i]["function"]["arguments"],
+                                        }
+                                        for i in sorted(follow_up_tool_calls.keys())
+                                    ],
+                                    "results": [
+                                        {
+                                            "tool_call_id": fr["tool_call_id"],
+                                            "name": _round_names.get(fr["tool_call_id"], ""),
+                                            "content": fr["content"],
+                                        }
+                                        for fr in follow_up_results
+                                    ],
+                                })
+
                                 # Continue the loop to process more tool calls
                                 break
 
@@ -935,7 +1146,8 @@ USER DATA:
             # Yield completion event with final content
             yield {
                 "type": "complete",
-                "full_response": accumulated_content
+                "full_response": accumulated_content,
+                "tool_rounds": turn_tool_rounds
             }
 
         except Exception as e:

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -57,6 +57,12 @@ These rules govern state-changing turns for workouts, calendar, plans, and goals
 Pure questions and lookups need no checklist — answer with minimal reads. Memory
 tools (save_memory etc.) keep their own rules below and are exempt from
 read-before-write.
+
+## Replayed tool results from earlier turns
+Tool results replayed from earlier turns reflect state AT THE TIME they ran. You may
+answer from them and reuse their ids while nothing has changed — do not repeat a read
+you already have. But after ANY write (yours or a reported change), re-read before
+answering about current state.
 </tool_use_policy>
 
 CONVERSATION STYLE (applies to EVERY answer):

--- a/ai-coach-service/app/models/schemas.py
+++ b/ai-coach-service/app/models/schemas.py
@@ -49,6 +49,9 @@ class ConversationMessage(BaseModel):
     content: str
     timestamp: Optional[str] = None
     response_time_ms: Optional[int] = None  # Only for AI responses
+    # Structured tool exchange for this AI turn (see conversation_service);
+    # replayed into model context on later turns, never rendered by the UI.
+    tool_rounds: Optional[List[Dict[str, Any]]] = None
 
 
 class ModelInfo(BaseModel):

--- a/ai-coach-service/app/services/conversation_service.py
+++ b/ai-coach-service/app/services/conversation_service.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any, List, Optional
 from datetime import datetime
+import json
 import uuid
 import math
 import re
@@ -12,6 +13,41 @@ from app.config import get_settings
 logger = structlog.get_logger()
 
 COLLECTION_NAME = "chatConversations"
+
+# Per-result cap for persisted tool results. Large enough for multi-item
+# calendar/search payloads; bounds Mongo doc growth and replay token cost.
+TOOL_RESULT_PERSIST_MAX_CHARS = 8000
+
+
+def _truncate_tool_result(content: str) -> tuple:
+    """Shrink an oversized tool-result string while keeping it valid JSON.
+
+    Sliced JSON is worse than useless on replay (malformed, and the dropped
+    tail may hold the exact item a follow-up refers to), so for JSON objects
+    we drop trailing elements from the largest array field and annotate the
+    omission instead. Returns (content, truncated).
+    """
+    if len(content) <= TOOL_RESULT_PERSIST_MAX_CHARS:
+        return content, False
+
+    try:
+        parsed = json.loads(content)
+    except (ValueError, TypeError):
+        parsed = None
+
+    if isinstance(parsed, dict):
+        array_keys = [k for k, v in parsed.items() if isinstance(v, list) and v]
+        if array_keys:
+            largest = max(array_keys, key=lambda k: len(json.dumps(parsed[k])))
+            original_len = len(parsed[largest])
+            while parsed[largest] and len(json.dumps(parsed)) > TOOL_RESULT_PERSIST_MAX_CHARS:
+                parsed[largest].pop()
+            parsed["truncated"] = True
+            parsed["omitted_items"] = original_len - len(parsed[largest])
+            return json.dumps(parsed), True
+
+    # Not JSON (or not shrinkable by dropping array items): plain slice.
+    return content[:TOOL_RESULT_PERSIST_MAX_CHARS] + "...[truncated]", True
 
 
 class ConversationService:
@@ -221,13 +257,26 @@ class ConversationService:
                 "total": 0
             }
 
+    @staticmethod
+    def _bound_tool_rounds(tool_rounds: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Copy tool rounds with each result's content capped for storage."""
+        bounded = []
+        for round_ in tool_rounds:
+            results = []
+            for result in round_.get("results", []):
+                content, truncated = _truncate_tool_result(str(result.get("content", "")))
+                results.append({**result, "content": content, "truncated": truncated})
+            bounded.append({"tool_calls": round_.get("tool_calls", []), "results": results})
+        return bounded
+
     async def add_message(
         self,
         conversation_id: str,
         role: str,
         content: str,
         response_time_ms: Optional[int] = None,
-        user_id: Optional[str] = None
+        user_id: Optional[str] = None,
+        tool_rounds: Optional[List[Dict[str, Any]]] = None
     ) -> bool:
         """Add a message to a conversation"""
         try:
@@ -240,6 +289,9 @@ class ConversationService:
 
             if response_time_ms is not None:
                 message["response_time_ms"] = response_time_ms
+
+            if tool_rounds:
+                message["tool_rounds"] = self._bound_tool_rounds(tool_rounds)
 
             query = {"conversation_id": conversation_id}
             if user_id:

--- a/ai-coach-service/evals/harness.py
+++ b/ai-coach-service/evals/harness.py
@@ -42,13 +42,16 @@ def instrument(orchestrator, trace: Trace):
     return orchestrator
 
 
-async def run_turn(orchestrator, message: str, history: list, user_id: str) -> str:
-    """Run one user turn through the streaming path; return the final text.
+async def run_turn(orchestrator, message: str, history: list, user_id: str) -> tuple:
+    """Run one user turn through the streaming path; return
+    (final_text, tool_rounds) — tool_rounds mirrors what chat_stream persists
+    on the assistant message so multi-turn evals replay real history.
     OpenAI rate limits (429) are infrastructure noise, not agent behavior —
     retry the whole turn with backoff instead of failing the scenario."""
     last_error = None
     for attempt in range(4):
         final = None
+        tool_rounds: List[Dict[str, Any]] = []
         tokens: List[str] = []
         error = None
         async for event in orchestrator.process_request_streaming(
@@ -59,10 +62,12 @@ async def run_turn(orchestrator, message: str, history: list, user_id: str) -> s
                 tokens.append(event.get("content", ""))
             elif etype == "complete":
                 final = event.get("full_response")
+                tool_rounds = event.get("tool_rounds") or []
             elif etype == "error":
                 error = event
         if error is None:
-            return final if final is not None else "".join(tokens)
+            text = final if final is not None else "".join(tokens)
+            return text, tool_rounds
         message_text = str(error.get("message", ""))
         if "429" not in message_text and "rate_limit" not in message_text:
             raise AssertionError(f"agent returned error event: {error}")
@@ -195,3 +200,28 @@ def assert_no_writes(trace: Trace) -> List[str]:
         f"call #{i} {c.name} is a write but this scenario allows none"
         for i, c in enumerate(trace.calls) if is_write(c)
     ]
+
+
+def assert_no_repeated_reads(trace: Trace) -> List[str]:
+    """Tool-call memory check: a read already made in an EARLIER turn must not
+    be re-executed with identical args in a later turn — unless a write
+    happened in between (post-write re-reads are correct, not waste; the
+    freshness scenario asserts they DO happen)."""
+    violations = []
+    seen: Dict[Any, int] = {}  # (name, canonical args) -> first turn
+    for i, call in enumerate(trace.calls):
+        if is_write(call) and _succeeded(call):
+            seen.clear()
+            continue
+        if call.name not in READ_TOOLS or not _succeeded(call):
+            continue
+        key = (call.name, json.dumps(call.args or {}, sort_keys=True, default=str))
+        first_turn = seen.get(key)
+        if first_turn is not None and first_turn != call.turn:
+            violations.append(
+                f"call #{i} {call.name} (turn {call.turn}) repeats an identical "
+                f"read from turn {first_turn} with no write in between"
+            )
+        elif first_turn is None:
+            seen[key] = call.turn
+    return violations

--- a/ai-coach-service/evals/scenarios.py
+++ b/ai-coach-service/evals/scenarios.py
@@ -17,8 +17,11 @@ from evals.harness import (
     Trace,
     assert_id_provenance,
     assert_no_false_success,
+    assert_no_repeated_reads,
     assert_no_writes,
     assert_read_before_write,
+    is_write,
+    _succeeded,
 )
 
 
@@ -383,6 +386,80 @@ SCHEDULE_TWICE_ONE_TEMPLATE = Scenario(
 )
 
 
+# --- tool-call memory scenarios (TOR: coach repeats tool calls every turn) ---
+# These two are deliberately in tension: TOOL_MEMORY asserts reads are NOT
+# repeated while nothing was written; FRESHNESS_AFTER_WRITE asserts a read IS
+# repeated after a write. Passing both means memory without staleness.
+
+
+async def _check_memory_endurance2(db, user_id, refs, trace):
+    """Prod repro: exactly 1 event today, linked to Endurance 2, no new template."""
+    problems = []
+    events = await _workout_events_today(db, user_id)
+    endurance2 = refs["template_ids"][1]
+    if len(events) != 1:
+        problems.append(f"expected exactly 1 workout event today, found {len(events)}")
+    elif events[0].get("workoutTemplateId") != endurance2:
+        problems.append(
+            f"event not linked to the existing Endurance 2 template "
+            f"(workoutTemplateId={events[0].get('workoutTemplateId')})"
+        )
+    if await _template_count(db, user_id) != refs["template_count"]:
+        problems.append("a new template was created instead of reusing Endurance 2")
+    return problems
+
+
+TOOL_MEMORY = Scenario(
+    id="tool-memory-no-repeated-reads",
+    turns=["Add a workout for today",
+           "Add Endurance 2",
+           "Yes, add it"],
+    seed=_seed_ambiguous,
+    final_state_check=_check_memory_endurance2,
+    trajectory_checks=[assert_read_before_write, assert_id_provenance,
+                       assert_no_false_success, assert_no_repeated_reads],
+)
+
+
+async def _check_freshness_after_write(db, user_id, refs, trace):
+    """After the confirmed write, the calendar question must trigger a FRESH
+    get_calendar_events (replayed pre-write results are stale) and the reply
+    must reflect the newly added workout."""
+    problems = []
+    writes = [i for i, c in enumerate(trace.calls) if is_write(c) and _succeeded(c)]
+    if not writes:
+        problems.append("no successful write happened — scenario did not exercise staleness")
+        return problems
+    last_write = max(writes)
+    post_write_calendar_reads = [
+        c for c in trace.calls[last_write + 1:]
+        if c.name == "get_calendar_events" and _succeeded(c)
+    ]
+    if not post_write_calendar_reads:
+        problems.append(
+            "no fresh get_calendar_events after the write — the agent answered "
+            "the calendar question from stale replayed results"
+        )
+    final_text = (trace.turn_texts[-1] or "").lower()
+    if "endurance" not in final_text:
+        problems.append(
+            "final answer doesn't mention the just-added Endurance 1 workout — "
+            "stale view of the calendar"
+        )
+    return problems
+
+
+FRESHNESS_AFTER_WRITE = Scenario(
+    id="freshness-reads-repeat-after-write",
+    turns=["What's on my calendar today?",
+           "Add my Endurance 1 workout to my calendar for today",
+           "Yes, go ahead",
+           "What's on my calendar today now?"],
+    seed=_seed_endurance,
+    final_state_check=_check_freshness_after_write,
+)
+
+
 SCENARIOS = [
     SCHEDULE_EXISTING,
     SCHEDULE_NONEXISTENT,
@@ -391,4 +468,6 @@ SCENARIOS = [
     CORRECTION_TURN,
     AMBIGUOUS_NAME,
     SCHEDULE_TWICE_ONE_TEMPLATE,
+    TOOL_MEMORY,
+    FRESHNESS_AFTER_WRITE,
 ]

--- a/ai-coach-service/evals/test_think_then_act.py
+++ b/ai-coach-service/evals/test_think_then_act.py
@@ -10,6 +10,7 @@ import os
 import pytest
 
 from app.core.agents.orchestrator import AgentOrchestrator
+from app.services.conversation_service import ConversationService
 from evals.harness import Trace, instrument, run_turn
 from evals.scenarios import SCENARIOS, seed_user
 
@@ -29,10 +30,15 @@ async def test_scenario(scenario, scratch_db):
         history = []
         for turn_index, message in enumerate(scenario.turns):
             trace.current_turn = turn_index
-            text = await run_turn(orchestrator, message, history, user_id)
+            text, tool_rounds = await run_turn(orchestrator, message, history, user_id)
             trace.turn_texts.append(text)
             history.append({"role": "human", "content": message})
-            history.append({"role": "ai", "content": text})
+            # Mirror chat_stream persistence: the assistant message carries its
+            # (storage-capped) tool_rounds so later turns replay real history.
+            ai_msg = {"role": "ai", "content": text}
+            if tool_rounds:
+                ai_msg["tool_rounds"] = ConversationService._bound_tool_rounds(tool_rounds)
+            history.append(ai_msg)
 
         problems = []
         for check in scenario.trajectory_checks:

--- a/ai-coach-service/tests/test_history_replay.py
+++ b/ai-coach-service/tests/test_history_replay.py
@@ -1,0 +1,258 @@
+"""Tests for tool-call memory across turns: history replay of persisted
+tool_rounds, the write-aware grounding relaxation, and storage truncation."""
+
+import json
+
+from app.core.agents.orchestrator import (
+    REPLAY_TOOL_CHARS_BUDGET,
+    REPLAY_TOOL_ROUNDS_LAST_K,
+    _call_is_write,
+    _expand_tool_rounds,
+    _history_to_openai_messages,
+    _history_write_in_replay_window,
+    _replayable_indexes,
+    _sanitize_replayed_content,
+)
+from app.services.conversation_service import (
+    TOOL_RESULT_PERSIST_MAX_CHARS,
+    ConversationService,
+    _truncate_tool_result,
+)
+
+
+def _round(call_id="call_1", name="get_calendar_events", args='{"start_date":"2026-07-26"}',
+           content='{"success": true, "events": []}'):
+    return {
+        "tool_calls": [{"id": call_id, "name": name, "arguments": args}],
+        "results": [{"tool_call_id": call_id, "name": name, "content": content}],
+    }
+
+
+def _ai(content="ok", tool_rounds=None):
+    msg = {"role": "ai", "content": content}
+    if tool_rounds is not None:
+        msg["tool_rounds"] = tool_rounds
+    return msg
+
+
+def _human(content="hi"):
+    return {"role": "human", "content": content}
+
+
+# --- legacy history -------------------------------------------------------
+
+def test_legacy_text_only_history_unchanged():
+    history = [_human("hello"), _ai("hi there"), _human("more"), _ai("sure")]
+    messages = _history_to_openai_messages(history)
+    assert messages == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+        {"role": "user", "content": "more"},
+        {"role": "assistant", "content": "sure"},
+    ]
+
+
+# --- expansion ------------------------------------------------------------
+
+def test_tool_rounds_expand_with_adjacency():
+    history = [_human("add a workout"), _ai("done", [_round()])]
+    messages = _history_to_openai_messages(history)
+    assert [m["role"] for m in messages] == ["user", "assistant", "tool", "assistant"]
+    assistant_tc = messages[1]
+    assert assistant_tc["content"] is None
+    assert assistant_tc["tool_calls"][0]["id"] == "call_1"
+    assert assistant_tc["tool_calls"][0]["function"]["name"] == "get_calendar_events"
+    assert messages[2] == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": '{"success": true, "events": []}',
+    }
+    assert messages[3] == {"role": "assistant", "content": "done"}
+
+
+def test_multi_call_round_keeps_call_order():
+    round_ = {
+        "tool_calls": [
+            {"id": "a", "name": "get_calendar_events", "arguments": "{}"},
+            {"id": "b", "name": "grep_workouts", "arguments": "{}"},
+        ],
+        "results": [
+            # persisted out of order on purpose
+            {"tool_call_id": "b", "name": "grep_workouts", "content": "B"},
+            {"tool_call_id": "a", "name": "get_calendar_events", "content": "A"},
+        ],
+    }
+    expanded = _expand_tool_rounds([round_])
+    assert [m["role"] for m in expanded] == ["assistant", "tool", "tool"]
+    assert [m["content"] for m in expanded[1:]] == ["A", "B"]  # call order, not stored order
+
+
+def test_tool_only_turn_with_empty_content_is_valid():
+    history = [_human("do it"), _ai("", [_round()])]
+    messages = _history_to_openai_messages(history)
+    # No empty trailing assistant message; sequence still valid.
+    assert [m["role"] for m in messages] == ["user", "assistant", "tool"]
+
+
+# --- orphan guard ----------------------------------------------------------
+
+def test_orphaned_round_is_skipped_whole():
+    orphan = {
+        "tool_calls": [
+            {"id": "a", "name": "get_calendar_events", "arguments": "{}"},
+            {"id": "b", "name": "grep_workouts", "arguments": "{}"},
+        ],
+        "results": [{"tool_call_id": "a", "name": "get_calendar_events", "content": "A"}],
+    }
+    assert _expand_tool_rounds([orphan]) == []
+    # A good round alongside the orphan still expands.
+    assert len(_expand_tool_rounds([orphan, _round()])) == 2
+
+
+def test_empty_calls_round_is_skipped():
+    assert _expand_tool_rounds([{"tool_calls": [], "results": []}]) == []
+
+
+def test_missing_arguments_and_content_are_coerced():
+    round_ = {
+        "tool_calls": [{"id": "a", "name": "list_plans"}],
+        "results": [{"tool_call_id": "a", "name": "list_plans", "content": None}],
+    }
+    expanded = _expand_tool_rounds([round_])
+    assert expanded[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert expanded[1]["content"] == ""
+
+
+# --- replay window ----------------------------------------------------------
+
+def test_only_last_k_tool_bearing_messages_replay():
+    history = []
+    for i in range(REPLAY_TOOL_ROUNDS_LAST_K + 2):
+        history.append(_human(f"q{i}"))
+        history.append(_ai(f"a{i}", [_round(call_id=f"call_{i}")]))
+    messages = _history_to_openai_messages(history)
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert len(tool_msgs) == REPLAY_TOOL_ROUNDS_LAST_K
+    # The replayed ones are the most recent.
+    replayed_ids = {m["tool_call_id"] for m in tool_msgs}
+    assert replayed_ids == {"call_3", "call_2"}
+    # Older turns still present as plain text.
+    assert {"role": "assistant", "content": "a0"} in messages
+
+
+def test_char_budget_collapses_oversized_history():
+    big = "x" * (REPLAY_TOOL_CHARS_BUDGET + 1)
+    history = [_human("q"), _ai("a", [_round(content=big)])]
+    messages = _history_to_openai_messages(history)
+    assert all(m.get("role") != "tool" for m in messages)
+    assert {"role": "assistant", "content": "a"} in messages
+
+
+def test_budget_stops_at_first_unaffordable_message():
+    # Newest fits, the one before it blows the budget -> only newest replays.
+    big = "x" * REPLAY_TOOL_CHARS_BUDGET
+    history = [
+        _human("q1"), _ai("a1", [_round(call_id="old", content=big)]),
+        _human("q2"), _ai("a2", [_round(call_id="new", content="small")]),
+    ]
+    idx = _replayable_indexes(history)
+    assert idx == {3}
+
+
+# --- calendar-preview sanitization ------------------------------------------
+
+def test_calendar_preview_payload_stripped_on_replay():
+    content = 'Preview: <calendar-preview payload="eyJ2IjoxfQ=="></calendar-preview> confirm?'
+    assert _sanitize_replayed_content(content) == "Preview: <calendar-preview/> confirm?"
+    history = [_human("q"), _ai(content)]
+    messages = _history_to_openai_messages(history)
+    assert "payload" not in messages[1]["content"]
+
+
+# --- write classification ----------------------------------------------------
+
+def test_reads_are_not_writes():
+    assert _call_is_write("get_calendar_events", "{}") is False
+    assert _call_is_write("grep_workouts", '{"pattern": "x"}') is False
+
+
+def test_always_write_tools():
+    assert _call_is_write("save_memory", "{}") is True
+    assert _call_is_write("log_workout", None) is True
+
+
+def test_dry_run_preview_is_read_and_confirmed_write_is_write():
+    assert _call_is_write("schedule_to_calendar", "{}") is False  # dry_run defaults true
+    assert _call_is_write("schedule_to_calendar", '{"dry_run": true}') is False
+    assert _call_is_write("schedule_to_calendar", '{"dry_run": false}') is True
+    assert _call_is_write("delete_calendar_event", "{}") is False
+    assert _call_is_write("delete_calendar_event", '{"confirm": true}') is True
+    # resolve_week writes by default (dry_run defaults false)
+    assert _call_is_write("resolve_week", "{}") is True
+    assert _call_is_write("resolve_week", '{"dry_run": true}') is False
+
+
+def test_malformed_arguments_do_not_crash():
+    assert _call_is_write("schedule_to_calendar", "not json") is False
+    assert _call_is_write("save_memory", "not json") is True
+
+
+def test_write_in_replay_window_detection():
+    no_write = [_human("q"), _ai("a", [_round()])]
+    assert _history_write_in_replay_window(no_write) is False
+
+    with_write = [
+        _human("q"),
+        _ai("a", [_round(name="schedule_to_calendar", args='{"dry_run": false}')]),
+    ]
+    assert _history_write_in_replay_window(with_write) is True
+
+    # A write outside the replay window (older than K affordable turns) is invisible.
+    history = [_human("q0"), _ai("a0", [_round(name="save_memory")])]
+    for i in range(1, REPLAY_TOOL_ROUNDS_LAST_K + 1):
+        history.append(_human(f"q{i}"))
+        history.append(_ai(f"a{i}", [_round(call_id=f"c{i}")]))
+    assert _history_write_in_replay_window(history) is False
+
+
+# --- storage truncation -------------------------------------------------------
+
+def test_small_result_untouched():
+    content = '{"success": true}'
+    out, truncated = _truncate_tool_result(content)
+    assert out == content and truncated is False
+
+
+def test_json_truncation_stays_valid_and_annotates():
+    events = [{"title": f"event {i}", "notes": "n" * 200} for i in range(100)]
+    content = json.dumps({"success": True, "events": events})
+    assert len(content) > TOOL_RESULT_PERSIST_MAX_CHARS
+    out, truncated = _truncate_tool_result(content)
+    assert truncated is True
+    parsed = json.loads(out)  # must remain valid JSON
+    assert parsed["truncated"] is True
+    assert parsed["omitted_items"] == 100 - len(parsed["events"])
+    assert len(parsed["events"]) > 0  # kept items intact
+    assert parsed["events"][0] == events[0]
+    assert len(out) <= TOOL_RESULT_PERSIST_MAX_CHARS
+
+
+def test_non_json_truncation_slices():
+    out, truncated = _truncate_tool_result("y" * (TOOL_RESULT_PERSIST_MAX_CHARS + 500))
+    assert truncated is True
+    assert out.endswith("...[truncated]")
+
+
+def test_bound_tool_rounds_caps_results():
+    big = json.dumps({"success": True, "items": [{"n": i, "pad": "p" * 300} for i in range(200)]})
+    rounds = [{
+        "tool_calls": [{"id": "a", "name": "grep_workouts", "arguments": "{}"}],
+        "results": [{"tool_call_id": "a", "name": "grep_workouts", "content": big}],
+    }]
+    bounded = ConversationService._bound_tool_rounds(rounds)
+    result = bounded[0]["results"][0]
+    assert result["truncated"] is True
+    assert len(result["content"]) <= TOOL_RESULT_PERSIST_MAX_CHARS
+    json.loads(result["content"])
+    # Original input not mutated.
+    assert rounds[0]["results"][0]["content"] == big


### PR DESCRIPTION
## Problem

The coach re-ran the same tool calls after every message in a conversation (confirmed in prod: "check calendar" + "search workouts" repeated on all 3 turns of the latest conversation, ~5.6s each turn). Root cause: the structured tool exchange was discarded at end of turn — `chatConversations` messages stored only prose with cosmetic `<tool-complete>` markers, history was rebuilt text-only, and `_needs_grounding` forced `tool_choice="required"` on top.

## Fix

**Persist** — the assistant message gains an optional `tool_rounds` field (calls + results per LLM round). Embedded on the existing `"ai"` message, *not* as separate messages: the messages array's indexes/counts are load-bearing (chat UI mapping, feedback `message_index`, sidebar counts, summarizer windows). Oversized results are truncated JSON-safely: whole array items dropped + `{truncated, omitted_items}` annotation, 8KB/result cap.

**Replay** — `_history_to_openai_messages` expands recent rounds back into proper `assistant(tool_calls)` → `tool` sequences. Bounded: last 2 tool-bearing turns AND a 24k-char budget (~6k tokens worst case). Orphan guard skips any round missing a matching result, so legacy/partial docs can never 400 the OpenAI API. Calendar-preview base64 payloads are stripped on replay (coordination with the in-flight preview-card branch).

**Grounding (write-aware, narrow)** — `required` relaxes to `auto` only when replayed history has tool context **and no real write in the window**. Writes are classified per tool convention (`dry_run` default-true tools, `confirm` tools, `resolve_week` default-false, always-write set) — dry-run previews count as reads. So "Yes, add it" mid-confirm-flow stops re-reading, but the turn after a calendar mutation still re-reads fresh. Plus one `<tool_use_policy>` line telling the model replayed results reflect past state.

**Save path** — tool-only turns with empty final text now save (previously the human message was orphaned). `tool_rounds` never goes over SSE; the user conversation GET strips it from the payload.

## Verification

- 481 unit tests green, incl. 20 new in `tests/test_history_replay.py` (expansion adjacency/order, orphan guard, K-window + char budget, write classification, JSON-safe truncation).
- Real-LLM evals (scratch DB): two new scenarios deliberately in tension —
  - `tool-memory-no-repeated-reads` (the prod 3-turn repro): no identical read repeated before any write ✅
  - `freshness-reads-repeat-after-write`: after a confirmed write, a *fresh* calendar read must happen and the reply must reflect the new event ✅
  - `schedule-twice-one-template` regression ✅
- Backward compatible: legacy text-only messages replay exactly as before (unit-tested).

## Out of scope (pre-existing, flagged)
- Non-streaming `process_request` ignores history entirely.
- Mid-stream exception can still orphan a human message (error path).
- Saved content is pre-revision text; `tool_rounds` stay accurate regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)