### PR TITLE
AI coach: phrase conversation starters in the user's voice

### DIFF
--- a/ai-coach-service/app/api/v1/suggestions.py
+++ b/ai-coach-service/app/api/v1/suggestions.py
@@ -22,19 +22,21 @@ logger = structlog.get_logger()
 
 SUGGESTIONS_PROMPT = """Based on the user's profile, fitness data, and memories provided above, generate exactly 4 personalized conversation starter suggestions.
 
+Each suggestion is a message the USER sends to you (the coach) by tapping it. Write it in the user's voice: first person, addressed to the coach, natural enough to send exactly as written ("Build me...", "Can you...", "What should I...", "I want to..."). Never write a headline or workout title like "Conservative comeback session" or "Easy walk + stretch recovery" — those read as labels, not something a person would type to their coach.
+
 These suggestions should:
 1. Be relevant to the user's current fitness level, goals, and history
 2. Consider any health conditions or limitations from their memories
 3. Reference their available equipment, preferred workout duration, or training style if known
 4. Be actionable and specific to their situation
-5. Be concise (under 40 characters each ideally, max 50)
+5. Be concise (under 50 characters each ideally, max 60)
 
 Generate suggestions that feel personal and helpful for THIS specific user. Examples of good personalization:
-- If user has a shoulder injury: "Shoulder-safe upper body workout"
-- If user does calisthenics: "Progress my pull-up strength"
+- If user has a shoulder injury: "Build me a shoulder-safe upper body workout"
+- If user does calisthenics: "Help me progress my pull-up strength"
 - If user has a weekly plan: "What should I train today?"
-- If user is intermediate: "Help me break through my plateau"
-- If user prefers short workouts: "Quick 20-min full body blast"
+- If user is intermediate: "How do I break through my plateau?"
+- If user prefers short workouts: "Make me a quick 20-min full-body workout"
 
 Return ONLY a JSON array of exactly 4 strings, nothing else. Example format:
 ["suggestion 1", "suggestion 2", "suggestion 3", "suggestion 4"]"""


### PR DESCRIPTION
## Problem
The Sensei empty-state conversation starters read as workout titles ("Conservative comeback session", "Easy walk + stretch recovery") rather than messages the user would send to the coach. Tapping one fills the input box, so the text needs to be sendable as-is.

## Root cause
The `GET /api/v1/suggestions` prompt never stated that a suggestion is a message written in the user's voice, and its own few-shot examples were label-style titles ("Shoulder-safe upper body workout") — the model faithfully mirrored them.

## Fix (prompt-only, `suggestions.py`)
- Explicit instruction: each suggestion is a message the USER sends to the coach — first person, addressed to the coach, natural enough to send exactly as written; label/headline style called out as the anti-pattern.
- Examples rewritten in the user's voice ("Build me a shoulder-safe upper body workout").
- Length budget bumped from 40/50 to 50/60 chars since first-person phrasing runs longer (still fits the suggestion buttons).

## Verification
3 real generations against `openai_model_fast` with a representative profile (Endurance 2 template, back from a break). All 12 outputs were sendable first-person messages under 40 chars, e.g. "Ease me back in after my travel break", "Build me a 60-min side flag session", "What should I do for endurance today?".

Note: the frontend caches suggestions in localStorage for 1h, so old-style starters may linger up to an hour post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)