### PR TITLE
Coach question: ground the dashboard check-in in the calendar

### DIFF
--- a/ai-coach-service/app/api/v1/coach_question.py
+++ b/ai-coach-service/app/api/v1/coach_question.py
@@ -11,7 +11,7 @@ based on (and correct the coach if a memory is wrong).
 
 from fastapi import APIRouter, Depends, Body
 from typing import Dict, Any
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 import json
 import structlog
@@ -21,7 +21,7 @@ from app.config import get_settings
 from app.middleware.auth import get_current_user
 from app.core.agents.data_reader import DataReaderAgent
 from app.core.agents.prompts import SYSTEM_PROMPT
-from app.core.agents.services import MemoryService
+from app.core.agents.services import CalendarService, MemoryService
 from app.services.coach_question_service import CoachQuestionService
 from app.services.conversation_service import ConversationService
 from app.services.recommendation_service import RecommendationService
@@ -39,20 +39,25 @@ Rules:
 1. Ground the question in something specific you actually know - a recent workout,
    a recent dated check-in or note, a standing injury memory, a schedule
    constraint, or today's plan. Do NOT invent facts that aren't in the context.
-2. Keep it to one or two sentences, warm and concise. Offer to adapt if relevant
+2. TODAY'S CALENDAR is the source of truth for what is planned today. If a
+   workout is scheduled there, treat it as today's session and refer to it by
+   its title - do NOT ask about or suggest a different workout instead. Only
+   when nothing is scheduled today may you mention other ideas (e.g. the
+   Today's Pick suggestion).
+3. Keep it to one or two sentences, warm and concise. Offer to adapt if relevant
    (e.g. "I can ease the intervals if you need it").
-3. Provide 2-4 short quick-reply chips (each <= 14 chars) the athlete can tap to
+4. Provide 2-4 short quick-reply chips (each <= 14 chars) the athlete can tap to
    answer. Order them best-state to worst-state where that makes sense
    (e.g. "Fresh", "A bit heavy", "Cooked"). Do NOT pre-select one.
-4. Provide a short provenance label (<= 32 chars) naming what the question is based
+5. Provide a short provenance label (<= 32 chars) naming what the question is based
    on, e.g. "run log - Jul 10", "knee note - Jul 12", "your Tuesday plan".
-5. Recency: memories and notes above are dated. Prefer signals from the last few
+6. Recency: memories and notes above are dated. Prefer signals from the last few
    days. NEVER ask about transient state (sleep, fatigue, soreness, mood,
    illness, stress) based on a note older than 3 days - treat it as expired.
    Standing facts (injuries, goals, schedule, preferences) may be referenced at
    any age, but if a newer check-in or note contradicts an older one, the newer
    one wins - ignore the older note entirely.
-6. When the question is based on a dated note or check-in, include its date in
+7. When the question is based on a dated note or check-in, include its date in
    the provenance label, e.g. "check-in - Jul 24".
 
 Return ONLY a JSON object, nothing else, in exactly this shape:
@@ -155,6 +160,77 @@ RECENT WORKOUTS:{workouts_str or ' none logged recently'}
 USER DATA:
 - {len(data_context.get('goals', []))} active goals
 - {len(data_context.get('plans', []))} training plans"""
+
+        # Calendar anchors: today's scheduled session(s) plus the nearest
+        # neighbours (last completed session, next upcoming event) so the
+        # question is grounded in what's actually planned, not just the
+        # Today's Pick suggestion. Best-effort — a calendar failure must not
+        # block the question.
+        events = []
+        try:
+            window_start = (local_now - timedelta(days=14)).strftime("%Y-%m-%d")
+            window_end = (local_now + timedelta(days=14)).strftime("%Y-%m-%d")
+            cal = await CalendarService(db).get_calendar_events(
+                user_id, {"startDate": window_start, "endDate": window_end}
+            )
+            if cal.get("success"):
+                events = cal.get("events", [])
+        except Exception:
+            logger.warning(
+                f"Failed to load calendar context for coach question (user {user_id})",
+                exc_info=True,
+            )
+
+        def fmt_event(ev):
+            line = (
+                f"\n- {ev.get('date')} ({ev.get('dayOfWeek')}) "
+                f"{ev.get('type', 'workout')} \"{ev.get('title')}\" "
+                f"[{ev.get('status', 'scheduled')}]"
+            )
+            if ev.get("duration"):
+                line += f", ~{ev['duration']} min"
+            if ev.get("notes"):
+                line += f" (note: {ev['notes']})"
+            return line
+
+        def fmt_external(act):
+            line = (
+                f"\n- {act.get('date')} {act.get('sport_type') or 'activity'} "
+                f"\"{act.get('name') or 'external activity'}\" "
+                f"[completed, via {act.get('source') or 'external'}]"
+            )
+            if act.get("duration_mins"):
+                line += f", {act['duration_mins']} min"
+            if act.get("distance_km"):
+                line += f", {act['distance_km']} km"
+            return line
+
+        todays = [e for e in events if e.get("date") == today_date]
+        last_done = next(
+            (e for e in reversed(events)
+             if e.get("date") < today_date and e.get("status") == "completed"),
+            None,
+        )
+        next_up = next((e for e in events if e.get("date") > today_date), None)
+
+        # The last completed session may live on the calendar or come from a
+        # synced tracker (e.g. Strava) — pick whichever is more recent.
+        ext_activities = data_context.get("external_activities") or []
+        latest_ext = next((a for a in ext_activities if a.get("date")), None)
+        last_done_line = fmt_event(last_done) if last_done else None
+        if latest_ext and (not last_done or latest_ext["date"] >= last_done.get("date", "")):
+            last_done_line = fmt_external(latest_ext)
+
+        calendar_str = "TODAY'S CALENDAR:"
+        calendar_str += (
+            "".join(fmt_event(e) for e in todays) or " nothing scheduled today"
+        )
+        calendar_str += "\nLAST COMPLETED SESSION:"
+        calendar_str += last_done_line or " none recently"
+        calendar_str += "\nNEXT UPCOMING EVENT:"
+        calendar_str += fmt_event(next_up) if next_up else " nothing scheduled in the next 14 days"
+
+        context_str += f"\n\n{calendar_str}"
 
         memory_block = MemoryService.format_for_prompt(user_memories, limit=15)
         if memory_block:

--- a/ai-coach-service/tests/test_coach_question_context.py
+++ b/ai-coach-service/tests/test_coach_question_context.py
@@ -1,0 +1,156 @@
+"""Tests for the coach-question context assembly — the Today dashboard
+check-in must be grounded in the calendar (today's scheduled session, last
+completed session incl. Strava, next upcoming event), not just Today's Pick."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bson import ObjectId
+
+import app.api.v1.coach_question as cq
+
+USER_ID = str(ObjectId())
+
+CURRENT_USER = {"user_id": USER_ID, "email": "t@t.co", "username": "t"}
+
+LLM_ANSWER = {"question": "Ready for Endurance 2?", "chips": ["Yes", "Ease it"], "source": "your calendar"}
+
+
+def _mock_openai(monkeypatch):
+    """Patch AsyncOpenAI and capture the messages sent to the LLM."""
+    captured = {}
+
+    async def create(**kwargs):
+        captured["messages"] = kwargs["messages"]
+        response = MagicMock()
+        response.choices[0].message.content = json.dumps(LLM_ANSWER)
+        return response
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=create)
+    monkeypatch.setattr(cq, "AsyncOpenAI", MagicMock(return_value=client))
+    return captured
+
+
+def _patch_flow(monkeypatch, data_context, calendar_result, today="2026-07-26"):
+    monkeypatch.setattr("app.main.db", MagicMock())
+    monkeypatch.setattr(cq.CoachQuestionService, "get_fresh", AsyncMock(return_value=None))
+    monkeypatch.setattr(cq.CoachQuestionService, "save", AsyncMock(return_value=True))
+    monkeypatch.setattr(cq.DataReaderAgent, "process", AsyncMock(return_value=data_context))
+    monkeypatch.setattr(cq.MemoryService, "get_user_memories", AsyncMock(return_value=[]))
+    monkeypatch.setattr(cq.ShortTermContextService, "get_recent", AsyncMock(return_value=[]))
+    monkeypatch.setattr(cq.RecommendationService, "get_recent", AsyncMock(return_value=[]))
+    monkeypatch.setattr(cq, "spawn_background", lambda coro: coro.close())
+    if isinstance(calendar_result, Exception):
+        monkeypatch.setattr(
+            cq.CalendarService, "get_calendar_events", AsyncMock(side_effect=calendar_result)
+        )
+    else:
+        monkeypatch.setattr(
+            cq.CalendarService, "get_calendar_events", AsyncMock(return_value=calendar_result)
+        )
+
+
+def _event(date, title, status="scheduled", **extra):
+    return {
+        "date": date,
+        "dayOfWeek": "Sunday",
+        "type": "workout",
+        "title": title,
+        "status": status,
+        **extra,
+    }
+
+
+def _prompt(captured):
+    return captured["messages"][1]["content"]
+
+
+DATA_CONTEXT = {
+    "user_profile": {"name": "Elior", "timezone": "UTC"},
+    "workouts": [],
+    "goals": [],
+    "plans": [],
+    "external_activities": [],
+}
+
+
+class TestCalendarContext:
+    @pytest.mark.asyncio
+    async def test_todays_scheduled_event_is_in_prompt(self, monkeypatch):
+        captured = _mock_openai(monkeypatch)
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        _patch_flow(monkeypatch, DATA_CONTEXT, {
+            "success": True,
+            "events": [
+                _event("2000-01-01", "Old run", status="completed"),
+                _event(today, "Endurance 2", duration=60),
+                _event("2999-01-01", "Long ride"),
+            ],
+        })
+
+        result = await cq.get_coach_question(current_user=CURRENT_USER)
+
+        assert result["success"] is True
+        prompt = _prompt(captured)
+        assert "TODAY'S CALENDAR:" in prompt
+        assert '"Endurance 2"' in prompt
+        assert "LAST COMPLETED SESSION:" in prompt
+        assert '"Old run"' in prompt
+        assert "NEXT UPCOMING EVENT:" in prompt
+        assert '"Long ride"' in prompt
+
+    @pytest.mark.asyncio
+    async def test_empty_calendar_says_nothing_scheduled(self, monkeypatch):
+        captured = _mock_openai(monkeypatch)
+        _patch_flow(monkeypatch, DATA_CONTEXT, {"success": True, "events": []})
+
+        await cq.get_coach_question(current_user=CURRENT_USER)
+
+        prompt = _prompt(captured)
+        assert "nothing scheduled today" in prompt
+        assert "none recently" in prompt
+        assert "nothing scheduled in the next 14 days" in prompt
+
+    @pytest.mark.asyncio
+    async def test_strava_activity_wins_as_last_completed_when_newer(self, monkeypatch):
+        captured = _mock_openai(monkeypatch)
+        data_context = {
+            **DATA_CONTEXT,
+            "external_activities": [
+                {"date": "2000-01-02", "name": "Morning Run", "sport_type": "Run",
+                 "source": "strava", "duration_mins": 42, "distance_km": 8.1},
+            ],
+        }
+        _patch_flow(monkeypatch, data_context, {
+            "success": True,
+            "events": [_event("2000-01-01", "Old gym session", status="completed")],
+        })
+
+        await cq.get_coach_question(current_user=CURRENT_USER)
+
+        prompt = _prompt(captured)
+        assert '"Morning Run"' in prompt
+        assert "via strava" in prompt
+        assert '"Old gym session"' not in prompt
+
+    @pytest.mark.asyncio
+    async def test_calendar_failure_does_not_block_question(self, monkeypatch):
+        captured = _mock_openai(monkeypatch)
+        data_context = {
+            **DATA_CONTEXT,
+            "external_activities": [
+                {"date": "2000-01-02", "name": "Morning Run", "sport_type": "Run",
+                 "source": "strava", "duration_mins": 42},
+            ],
+        }
+        _patch_flow(monkeypatch, data_context, RuntimeError("mongo down"))
+
+        result = await cq.get_coach_question(current_user=CURRENT_USER)
+
+        assert result["success"] is True
+        assert result.get("fallback") is None
+        # Strava-sourced last-completed still surfaces without the calendar
+        assert '"Morning Run"' in _prompt(captured)


### PR DESCRIPTION
## Problem
The Today-dashboard coach question was generated with no calendar context — it only saw the cached Today's Pick, so it asked about a suggested workout ("full-body reset") while a different session ("Endurance 2") was actually scheduled for today.

## Fix
`ai-coach-service/app/api/v1/coach_question.py`:
- Add a calendar block to the LLM context via the existing `CalendarService.get_calendar_events` (single ±14-day window call):
  - **TODAY'S CALENDAR** — all events scheduled today (title, type, status, duration, notes)
  - **LAST COMPLETED SESSION** — most recent completed calendar event **or** latest Strava/external activity, whichever is newer (external activities were already loaded by `DataReaderAgent`)
  - **NEXT UPCOMING EVENT** — next scheduled event after today
- New prompt rule: today's calendar is the source of truth — if a workout is scheduled, ask about that session by title; only mention the Today's Pick when nothing is scheduled.
- Calendar fetch is best-effort: on failure the question still generates, and the Strava-based last-completed line still surfaces.

## Tests
- New `tests/test_coach_question_context.py` drives the real endpoint with mocked DB/LLM and asserts the calendar block reaches the prompt (today's event, empty calendar, Strava-wins-when-newer, calendar-failure resilience).
- Full ai-coach-service suite: 524 passed.

## Note
The 45-min coach-question cache is unchanged — a question cached before a workout is scheduled can persist until TTL/day-rollover/answer. Busting the cache on calendar writes is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)