### PR TITLE
Upgrade OpenAI model tiers to GPT-5.6

### DIFF
--- a/ai-coach-service/.env.example
+++ b/ai-coach-service/.env.example
@@ -4,15 +4,15 @@ MONGODB_DATABASE=ripped-potato
 
 # AI Models (required)
 OPENAI_API_KEY=your-openai-api-key-here
-OPENAI_MODEL=gpt-5.4-mini
-OPENAI_MODEL_FAST=gpt-5.4-mini
+OPENAI_MODEL=gpt-5.6-terra
+OPENAI_MODEL_FAST=gpt-5.6-luna
 # Reasoning effort for all OpenAI calls: none | low | medium | high | xhigh.
 # "none" disables thinking (fastest/cheapest); temperature only applies at "none".
 # Kept at "none": A/B eval showed no plan-quality gain at 2.5-4x latency, and
 # gpt-5.4-mini 400s on function tools + reasoning_effort. Opt in per-env if needed.
 OPENAI_REASONING_EFFORT=none
 # Optional: stronger model for plan generation only (falls back to OPENAI_MODEL)
-# OPENAI_MODEL_PLANNER=gpt-5.4
+# OPENAI_MODEL_PLANNER=gpt-5.6-terra
 
 # Security (must match Node.js backend)
 JWT_SECRET_KEY=your-jwt-secret-key-here

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,7 +21,9 @@ RATE_LIMIT_MAX=100
 # AI Configuration
 # Get your API key from https://platform.openai.com/api-keys
 OPENAI_API_KEY=your-openai-api-key-here
-OPENAI_MODEL=gpt-4o-mini
+OPENAI_MODEL=gpt-5.6-luna
+# Feedback → Linear classification (falls back to gpt-5.4 in code if unset)
+OPENAI_FEEDBACK_MODEL=gpt-5.6-luna
 AI_MAX_TOKENS=2000
 AI_TEMPERATURE=0.7
 

--- a/backend/.env.production.template
+++ b/backend/.env.production.template
@@ -55,6 +55,8 @@ APP_VERSION=1.0.0
 # AI Configuration
 # Get your API key from https://platform.openai.com/api-keys
 OPENAI_API_KEY=
-OPENAI_MODEL=gpt-4o-mini
+OPENAI_MODEL=gpt-5.6-luna
+# Feedback → Linear classification (falls back to gpt-5.4 in code if unset)
+OPENAI_FEEDBACK_MODEL=gpt-5.6-luna
 AI_MAX_TOKENS=2000
 AI_TEMPERATURE=0.7


### PR DESCRIPTION
## What

Updates the documented model defaults across env examples/templates to the GPT-5.6 family (released 2026-07-09):

| Slot | Before | After |
|---|---|---|
| Sensei chat (`OPENAI_MODEL`, ai-coach) | gpt-5.4-mini | **gpt-5.6-terra** |
| Fast/background paths (`OPENAI_MODEL_FAST`) | gpt-5.4-mini | **gpt-5.6-luna** |
| Planner (`OPENAI_MODEL_PLANNER`) | gpt-5.4 | **gpt-5.6-terra** |
| Backend routes (`OPENAI_MODEL`) | gpt-4o-mini | **gpt-5.6-luna** |
| Feedback classification (`OPENAI_FEEDBACK_MODEL`, new) | gpt-5.4 code fallback | **gpt-5.6-luna** |

## Why

- Terra is price-identical to gpt-5.4 ($2.50/$15 per 1M) but stronger — free upgrade for chat + planner.
- Luna ($1/$6) nearly matches the previous flagship at mini-tier economics for summarizer/daily-pick/check-in calls.
- `OPENAI_FEEDBACK_MODEL` is now set explicitly so feedback classification stops silently falling back to full-price gpt-5.4.
- Sol deliberately skipped: 2× Terra's price, and plan-generation quality was bottlenecked by validation/return-path issues, not model strength.

## Deployment

Render prod env vars for `ai-coach` and `synergyfit-api` were already updated to these values (env-var save auto-redeployed both). This PR only aligns the tracked examples/templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)