### PR TITLE
Fix GPT-5.6 chat.completions 400s (temperature + reasoning_effort)

### DIFF
--- a/ai-coach-service/app/config.py
+++ b/ai-coach-service/app/config.py
@@ -38,8 +38,9 @@ class Settings(BaseSettings):
     # reasoning). None = fall back to openai_model; resolve at the call site.
     openai_model_planner: Optional[str] = None
     # Reasoning effort for all OpenAI calls: none | low | medium | high | xhigh.
-    # Default "none": gpt-5.4-mini 400s on function tools + reasoning_effort, so
-    # every orchestrator chat call would fail. Opt in explicitly per environment
+    # Default "none": reasoning burns latency/tokens with no measured plan-quality
+    # gain (A/B eval), and gpt-5.6 chat/completions rejects function tools unless
+    # reasoning_effort is explicitly "none". Opt in per environment
     # (e.g. OPENAI_REASONING_EFFORT=medium on Render once verified).
     openai_reasoning_effort: str = "none"
 
@@ -79,12 +80,12 @@ class Settings(BaseSettings):
     def llm_tuning_params(self, temperature: Optional[float] = None) -> dict:
         """Sampling/reasoning kwargs for chat.completions.create.
 
-        Reasoning models only accept the default temperature while thinking,
-        so temperature is sent only when reasoning is off ("none").
+        gpt-5.6 models accept only the default temperature (custom values 400),
+        so temperature is never sent — the parameter is kept for call-site
+        documentation of intent. reasoning_effort is always sent explicitly:
+        gpt-5.6 rejects function tools on chat/completions unless it is "none".
         """
-        if self.openai_reasoning_effort != "none":
-            return {"reasoning_effort": self.openai_reasoning_effort}
-        return {"temperature": temperature} if temperature is not None else {}
+        return {"reasoning_effort": self.openai_reasoning_effort}
 
     # Security
     jwt_secret_key: str

--- a/ai-coach-service/app/core/agents/skills/generate_plan_skill.py
+++ b/ai-coach-service/app/core/agents/skills/generate_plan_skill.py
@@ -234,7 +234,7 @@ async def generate_plan(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -
     # A full skeleton (up to 26 weeks, per-phase detailed blueprints) can exceed
     # 6000 output tokens and truncate into invalid JSON (observed with the mini
     # model on a 16-week plan) — which fails the whole generation. Give it room.
-    max_tokens = 16000 if "reasoning_effort" in tuning else 12000
+    max_tokens = 16000 if tuning.get("reasoning_effort", "none") != "none" else 12000
     logger.info("generate_plan LLM call", model=model, weeks=weeks,
                 days_per_week=days_per_week, tuning=tuning)
     try:

--- a/ai-coach-service/tests/test_reflection.py
+++ b/ai-coach-service/tests/test_reflection.py
@@ -350,13 +350,11 @@ class TestReflectionExecution:
 
         # Verify the call used config values
         call_kwargs = orchestrator.client.chat.completions.create.call_args.kwargs
-        # Tuning comes from settings: reasoning_effort when enabled, else the
-        # config temperature.
-        if orchestrator.settings.openai_reasoning_effort != "none":
-            assert call_kwargs["reasoning_effort"] == orchestrator.settings.openai_reasoning_effort
-            assert "temperature" not in call_kwargs
-        else:
-            assert call_kwargs["temperature"] == REFLECTION_CONFIG["temperature"]
+        # Tuning comes from settings: reasoning_effort is always sent explicitly
+        # (gpt-5.6 rejects function tools unless it is "none") and temperature
+        # never is (gpt-5.6 only accepts the default).
+        assert call_kwargs["reasoning_effort"] == orchestrator.settings.openai_reasoning_effort
+        assert "temperature" not in call_kwargs
         # GPT-5 models require max_completion_tokens (see commit #69); the value
         # still comes from the config's max_tokens entry.
         assert call_kwargs["max_completion_tokens"] == REFLECTION_CONFIG["max_tokens"]

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -173,8 +173,7 @@ router.post('/chat', authMiddleware, aiRateLimit, async (req, res) => {
         { role: 'system', content: systemPrompt },
         { role: 'user', content: prompt }
       ],
-      temperature: 0.7,
-      max_tokens: 2000,
+      max_completion_tokens: 2000,
       ...(response_json_schema && { response_format: { type: "json_object" } })
     });
 
@@ -272,8 +271,7 @@ router.post('/generate-workout', authMiddleware, aiRateLimit, async (req, res) =
         },
         { role: 'user', content: prompt }
       ],
-      temperature: 0.7,
-      max_tokens: 2000,
+      max_completion_tokens: 2000,
       response_format: { type: "json_object" }
     });
 
@@ -320,8 +318,7 @@ router.post('/analyze-progress', authMiddleware, aiRateLimit, async (req, res) =
         },
         { role: 'user', content: prompt }
       ],
-      temperature: 0.7,
-      max_tokens: 1500
+      max_completion_tokens: 1500
     });
 
     res.json({
@@ -360,8 +357,7 @@ router.post('/check-form', authMiddleware, aiRateLimit, async (req, res) => {
         },
         { role: 'user', content: prompt }
       ],
-      temperature: 0.6,
-      max_tokens: 1000
+      max_completion_tokens: 1000
     });
 
     res.json({

--- a/backend/src/routes/feedback.js
+++ b/backend/src/routes/feedback.js
@@ -656,8 +656,7 @@ Remember to:
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt }
       ],
-      temperature: 0.5, // Lower temperature for more consistent, analytical output
-      max_tokens: 8000  // Increased for longer, more detailed reports
+      max_completion_tokens: 8000  // Increased for longer, more detailed reports
     });
 
     const analysis = completion.choices[0].message.content;


### PR DESCRIPTION
## Problem

After the GPT-5.6 model upgrade (env-var change), prod broke with two distinct 400s from OpenAI:

1. **Every Sensei chat turn**: `Function tools with reasoning_effort are not supported for gpt-5.6-terra in /v1/chat/completions... set reasoning_effort to 'none'` — reasoning defaults **on** for Terra, so tools require an explicit `reasoning_effort: "none"`.
2. **Summarizer / coach question / reflection**: `'temperature' does not support 0.3 with this model. Only the default (1) value is supported.` — 5.6 models reject custom temperature outright (5.4-mini tolerated it).

## Fix

- `Settings.llm_tuning_params` now **always** sends an explicit `reasoning_effort` and **never** sends temperature. The `temperature=` argument is kept at call sites as documentation of intent.
- `generate_plan_skill` token-headroom heuristic keys off the effort **value** (`!= "none"`) instead of key presence, since the key is now always present.
- Backend Node routes ([ai.js](backend/src/routes/ai.js), [feedback.js](backend/src/routes/feedback.js)): dropped `temperature`, renamed `max_tokens` → `max_completion_tokens` (the other documented 5.x breaker; these routes now run gpt-5.6-luna).
- Updated the reflection test to match the new contract.

## Verification

- 48 tests pass (`test_reflection`, `test_league_map`, `test_sensei_calendar_context`).
- Live against the real OpenAI API using the service's own `Settings`: Terra + function tools + streaming (the exact failing orchestrator shape, tool call returned), Luna summarizer call, Luna JSON-mode call, Terra planner JSON call — all succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)