### PR TITLE
Replace exercise for good: persist mid-workout swaps to the template

### DIFF
--- a/backend/src/models/CalendarEvent.js
+++ b/backend/src/models/CalendarEvent.js
@@ -123,7 +123,8 @@ calendarEventSchema.statics.getByDateRange = function(userId, startDate, endDate
   .sort({ date: 1 })
   // blocks included: events don't embed exercises, so range consumers
   // (calendar page, detail modal, MCP list) read them off the template.
-  .populate('workoutTemplateId', 'name goal primary_disciplines estimated_duration blocks');
+  // isCommon included so session launches know a permanent swap will clone.
+  .populate('workoutTemplateId', 'name goal primary_disciplines estimated_duration blocks isCommon');
 };
 
 // Static method to get today's events
@@ -141,7 +142,7 @@ calendarEventSchema.statics.getToday = function(userId) {
       $lte: endOfDay
     },
     status: { $ne: 'cancelled' }
-  }).populate('workoutTemplateId', 'name goal primary_disciplines estimated_duration blocks');
+  }).populate('workoutTemplateId', 'name goal primary_disciplines estimated_duration blocks isCommon');
 };
 
 module.exports = mongoose.model('CalendarEvent', calendarEventSchema);

--- a/backend/src/routes/__tests__/swapExercise.test.js
+++ b/backend/src/routes/__tests__/swapExercise.test.js
@@ -1,0 +1,226 @@
+jest.mock('../../middleware/auth', () => ({
+  auth: (req, res, next) => {
+    req.user = { id: 'aaaaaaaaaaaaaaaaaaaaaaaa', role: 'user' };
+    next();
+  },
+  optionalAuth: (req, res, next) => next()
+}));
+jest.mock('../../services/WorkoutService', () => ({}));
+jest.mock('../../models/CalendarEvent', () => ({
+  updateMany: jest.fn().mockResolvedValue({}),
+  countDocuments: jest.fn().mockResolvedValue(0)
+}));
+jest.mock('../../models/Plan', () => ({
+  updateMany: jest.fn().mockResolvedValue({})
+}));
+jest.mock('../../models/Exercise', () => ({
+  findOne: jest.fn()
+}));
+jest.mock('../../models/UserWorkoutModification', () => ({
+  findOne: jest.fn()
+}));
+jest.mock('../../models/PredefinedWorkout', () => {
+  const ctor = jest.fn();
+  ctor.findById = jest.fn();
+  return ctor;
+});
+
+const express = require('express');
+const request = require('supertest');
+const PredefinedWorkout = require('../../models/PredefinedWorkout');
+const CalendarEvent = require('../../models/CalendarEvent');
+const Plan = require('../../models/Plan');
+const Exercise = require('../../models/Exercise');
+const UserWorkoutModification = require('../../models/UserWorkoutModification');
+const router = require('../predefinedWorkouts');
+
+const app = express();
+app.use(express.json());
+app.use('/', router);
+
+const USER_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const FROM_EX = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+const TO_EX = 'cccccccccccccccccccccccc';
+const WORKOUT_ID = 'dddddddddddddddddddddddd';
+const CLONE_ID = 'eeeeeeeeeeeeeeeeeeeeeeee';
+
+const makeBlocks = () => [
+  {
+    name: 'Warm-up',
+    exercises: [{ exercise_id: FROM_EX, exercise_name: 'Bench Press', volume: '2x10', rest: '60s', notes: 'light' }]
+  },
+  {
+    name: 'Main Work',
+    exercises: [
+      { exercise_id: FROM_EX, exercise_name: 'Bench Press', volume: '3x8', rest: '90s', notes: '' },
+      { exercise_id: 'ffffffffffffffffffffffff', exercise_name: 'Squat', volume: '3x5', rest: '120s', notes: '' }
+    ]
+  }
+];
+
+const makeWorkout = ({ ownedByUser, isCommon, blocks = makeBlocks() }) => {
+  const workout = {
+    _id: WORKOUT_ID,
+    name: 'Push Day',
+    goal: 'strength',
+    estimated_duration: 45,
+    difficulty_level: 'intermediate',
+    isCommon,
+    createdBy: ownedByUser ? USER_ID : 'a1a1a1a1a1a1a1a1a1a1a1a1',
+    popularity: 7,
+    ratings: { average: 4.5, count: 12 },
+    blocks,
+    canUserEdit(userId) {
+      return !this.isCommon && this.createdBy === userId;
+    },
+    save: jest.fn().mockResolvedValue(undefined)
+  };
+  workout.toObject = () => JSON.parse(JSON.stringify({ ...workout, save: undefined, toObject: undefined }));
+  return workout;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Exercise.findOne.mockReturnValue({
+    select: jest.fn().mockResolvedValue({ _id: TO_EX, name: 'Dumbbell Press' })
+  });
+  UserWorkoutModification.findOne.mockResolvedValue(null);
+  PredefinedWorkout.mockImplementation(function (data) {
+    Object.assign(this, JSON.parse(JSON.stringify(data)));
+    this._id = CLONE_ID;
+    this.save = jest.fn().mockResolvedValue(undefined);
+    this.toObject = () => JSON.parse(JSON.stringify({ ...this, save: undefined, toObject: undefined }));
+  });
+});
+
+describe('POST /:id/swap-exercise', () => {
+  test('own template: swaps every occurrence in place, keeps volume/rest/notes', async () => {
+    const workout = makeWorkout({ ownedByUser: true, isCommon: false });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/swap-exercise`)
+      .send({ fromExerciseId: FROM_EX, toExerciseId: TO_EX });
+
+    expect(res.status).toBe(200);
+    expect(res.body.cloned).toBe(false);
+    expect(res.body.replacedCount).toBe(2);
+    expect(workout.save).toHaveBeenCalled();
+    expect(workout.blocks[0].exercises[0]).toMatchObject({
+      exercise_id: TO_EX,
+      exercise_name: 'Dumbbell Press',
+      volume: '2x10',
+      rest: '60s',
+      notes: 'light'
+    });
+    expect(workout.blocks[1].exercises[0].exercise_id).toBe(TO_EX);
+    expect(workout.blocks[1].exercises[1].exercise_id).toBe('ffffffffffffffffffffffff');
+    expect(CalendarEvent.updateMany).not.toHaveBeenCalled();
+    expect(Plan.updateMany).not.toHaveBeenCalled();
+  });
+
+  test('common template: clones privately, swaps, relinks calendar events and plans', async () => {
+    const workout = makeWorkout({ ownedByUser: false, isCommon: true });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/swap-exercise`)
+      .send({ fromExerciseId: FROM_EX, toExerciseId: TO_EX });
+
+    expect(res.status).toBe(200);
+    expect(res.body.cloned).toBe(true);
+    expect(res.body.replacedCount).toBe(2);
+    expect(res.body.workout._id).toBe(CLONE_ID);
+    expect(workout.save).not.toHaveBeenCalled();
+
+    const cloneData = PredefinedWorkout.mock.calls[0][0];
+    expect(cloneData._id).toBeUndefined();
+    expect(cloneData.createdBy).toBe(USER_ID);
+    expect(cloneData.isCommon).toBe(false);
+    expect(cloneData.popularity).toBe(0);
+    expect(cloneData.ratings).toEqual({ average: 0, count: 0 });
+
+    expect(CalendarEvent.updateMany).toHaveBeenCalledWith(
+      {
+        userId: USER_ID,
+        workoutTemplateId: WORKOUT_ID,
+        status: { $in: ['scheduled', 'in_progress'] }
+      },
+      { $set: { workoutTemplateId: CLONE_ID } }
+    );
+    expect(Plan.updateMany).toHaveBeenCalledWith(
+      { userId: USER_ID, 'weeks.workouts.predefinedWorkoutId': WORKOUT_ID },
+      { $set: { 'weeks.$[].workouts.$[w].predefinedWorkoutId': CLONE_ID } },
+      { arrayFilters: [{ 'w.predefinedWorkoutId': WORKOUT_ID }] }
+    );
+  });
+
+  test('common template clone folds the modification overlay and moves the row', async () => {
+    const workout = makeWorkout({ ownedByUser: false, isCommon: true });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+    const modification = {
+      modifications: { title: 'My Push Day', description: 'tweaked', durationMinutes: 60 },
+      metadata: { isFavorite: true },
+      markModified: jest.fn(),
+      save: jest.fn().mockResolvedValue(undefined)
+    };
+    UserWorkoutModification.findOne.mockResolvedValue(modification);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/swap-exercise`)
+      .send({ fromExerciseId: FROM_EX, toExerciseId: TO_EX });
+
+    expect(res.status).toBe(200);
+    const cloneData = PredefinedWorkout.mock.calls[0][0];
+    expect(cloneData.name).toBe('My Push Day');
+    expect(cloneData.goal).toBe('tweaked');
+    expect(cloneData.estimated_duration).toBe(60);
+
+    expect(modification.workoutId).toBe(CLONE_ID);
+    expect(modification.modifications.title).toBeUndefined();
+    expect(modification.modifications.description).toBeUndefined();
+    expect(modification.modifications.durationMinutes).toBeUndefined();
+    expect(modification.markModified).toHaveBeenCalledWith('modifications');
+    expect(modification.save).toHaveBeenCalled();
+  });
+
+  test('400 when the exercise is not in the workout', async () => {
+    const workout = makeWorkout({
+      ownedByUser: true,
+      isCommon: false,
+      blocks: [{ name: 'Main', exercises: [{ exercise_id: 'ffffffffffffffffffffffff', exercise_name: 'Squat' }] }]
+    });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/swap-exercise`)
+      .send({ fromExerciseId: FROM_EX, toExerciseId: TO_EX });
+
+    expect(res.status).toBe(400);
+    expect(workout.save).not.toHaveBeenCalled();
+  });
+
+  test('403 on someone else\'s private workout', async () => {
+    const workout = makeWorkout({ ownedByUser: false, isCommon: false });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/swap-exercise`)
+      .send({ fromExerciseId: FROM_EX, toExerciseId: TO_EX });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('400 when the replacement exercise is not visible to the user', async () => {
+    const workout = makeWorkout({ ownedByUser: true, isCommon: false });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+    Exercise.findOne.mockReturnValue({ select: jest.fn().mockResolvedValue(null) });
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/swap-exercise`)
+      .send({ fromExerciseId: FROM_EX, toExerciseId: TO_EX });
+
+    expect(res.status).toBe(400);
+    expect(workout.save).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/predefinedWorkouts.js
+++ b/backend/src/routes/predefinedWorkouts.js
@@ -300,6 +300,137 @@ router.post('/:id/rate', auth, async (req, res) => {
   }
 });
 
+// POST /api/predefined-workouts/:id/swap-exercise - Replace an exercise in the
+// template "for good". Own template: edited in place. Common template: cloned
+// into a private copy (clone-on-modify) and the user's live references
+// (upcoming calendar events, active plan weeks, modification row) move to the
+// clone. Completed/skipped history intentionally keeps pointing at the
+// original.
+router.post('/:id/swap-exercise', auth, async (req, res) => {
+  try {
+    const { fromExerciseId, toExerciseId } = req.body;
+    if (!fromExerciseId || !toExerciseId) {
+      return res.status(400).json({ error: 'fromExerciseId and toExerciseId are required' });
+    }
+
+    const workout = await PredefinedWorkout.findById(req.params.id);
+    if (!workout) {
+      return res.status(404).json({ error: 'Predefined workout not found' });
+    }
+
+    if (!workout.canUserEdit(req.user.id) && !workout.isCommon) {
+      return res.status(403).json({ error: 'You can only modify your own workouts' });
+    }
+
+    const Exercise = require('../models/Exercise');
+    const replacement = await Exercise.findOne({
+      _id: toExerciseId,
+      $or: [{ isCommon: true }, { createdBy: req.user.id }]
+    }).select('_id name');
+    if (!replacement) {
+      return res.status(400).json({ error: 'Replacement exercise not found' });
+    }
+
+    // The same movement may appear in several blocks (e.g. warm-up + main
+    // work); a "for good" swap means all of them.
+    const applySwap = (doc) => {
+      let replacedCount = 0;
+      for (const block of doc.blocks || []) {
+        for (const ex of block.exercises || []) {
+          if (ex.exercise_id?.toString() === fromExerciseId.toString()) {
+            ex.exercise_id = replacement._id;
+            ex.exercise_name = replacement.name;
+            replacedCount += 1;
+          }
+        }
+      }
+      return replacedCount;
+    };
+
+    if (workout.canUserEdit(req.user.id)) {
+      const replacedCount = applySwap(workout);
+      if (replacedCount === 0) {
+        return res.status(400).json({ error: 'Exercise not found in this workout' });
+      }
+      await workout.save();
+      const workoutObj = workout.toObject();
+      workoutObj.id = workoutObj._id;
+      return res.json({ workout: workoutObj, cloned: false, replacedCount });
+    }
+
+    // Common template: clone-on-modify.
+    const cloneData = workout.toObject();
+    delete cloneData._id;
+    delete cloneData.createdAt;
+    delete cloneData.updatedAt;
+    delete cloneData.__v;
+    cloneData.createdBy = req.user.id;
+    cloneData.isCommon = false;
+    cloneData.popularity = 0;
+    cloneData.ratings = { average: 0, count: 0 };
+
+    // The user's modification overlay (custom title/description/duration +
+    // favorite/PR metadata) is applied on every read — bake the field
+    // overrides into the clone and move the row so the metadata follows.
+    const UserWorkoutModification = require('../models/UserWorkoutModification');
+    const modification = await UserWorkoutModification.findOne({
+      userId: req.user.id,
+      workoutId: workout._id
+    });
+    if (modification?.modifications) {
+      if (modification.modifications.title) cloneData.name = modification.modifications.title;
+      if (modification.modifications.description) cloneData.goal = modification.modifications.description;
+      if (modification.modifications.durationMinutes) {
+        cloneData.estimated_duration = modification.modifications.durationMinutes;
+      }
+    }
+
+    const clone = new PredefinedWorkout(cloneData);
+    const replacedCount = applySwap(clone);
+    if (replacedCount === 0) {
+      return res.status(400).json({ error: 'Exercise not found in this workout' });
+    }
+    await clone.save();
+
+    if (modification) {
+      modification.workoutId = clone._id;
+      // Field overrides are baked into the clone now; keeping them on the row
+      // would double-apply if the user later edits the clone directly.
+      if (modification.modifications) {
+        modification.modifications.title = undefined;
+        modification.modifications.description = undefined;
+        modification.modifications.durationMinutes = undefined;
+        modification.markModified('modifications');
+      }
+      await modification.save();
+    }
+
+    // Move the user's live references to the fork so "for good" holds for
+    // already-scheduled sessions and plan-driven scheduling.
+    await CalendarEvent.updateMany(
+      {
+        userId: req.user.id,
+        workoutTemplateId: workout._id,
+        status: { $in: ['scheduled', 'in_progress'] }
+      },
+      { $set: { workoutTemplateId: clone._id } }
+    );
+
+    const Plan = require('../models/Plan');
+    await Plan.updateMany(
+      { userId: req.user.id, 'weeks.workouts.predefinedWorkoutId': workout._id },
+      { $set: { 'weeks.$[].workouts.$[w].predefinedWorkoutId': clone._id } },
+      { arrayFilters: [{ 'w.predefinedWorkoutId': workout._id }] }
+    );
+
+    const cloneObj = clone.toObject();
+    cloneObj.id = cloneObj._id;
+    return res.json({ workout: cloneObj, cloned: true, replacedCount });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // Modification endpoints
 
 // PUT /api/predefined-workouts/:id/modifications - Create or update workout modification

--- a/frontend/src/components/exercise/ReplaceExerciseModal.jsx
+++ b/frontend/src/components/exercise/ReplaceExerciseModal.jsx
@@ -44,14 +44,22 @@ function ExerciseResultRow({ name, subtitle, badge, onPick, disabled }) {
   );
 }
 
-export default function ReplaceExerciseModal({ exercise, onClose, onReplace }) {
+export default function ReplaceExerciseModal({ exercise, onClose, onReplace, canPersist = false, isCommonTemplate = false }) {
   const [tab, setTab] = useState("similar");
   const [reason, setReason] = useState(null);
   const [error, setError] = useState(null);
   const [materializingId, setMaterializingId] = useState(null);
+  // When the session is linked to a template, a pick pauses on a scope step
+  // ("just this session" vs "from now on") instead of replacing immediately.
+  const [pendingPick, setPendingPick] = useState(null);
 
   const exerciseId = exercise?.exercise_id || null;
   const exerciseName = exercise?.exercise_name || "";
+
+  const handlePick = (ex) => {
+    if (canPersist) setPendingPick(ex);
+    else onReplace(ex, { permanent: false });
+  };
 
   // If there's no real id we can't query "similar" — default to Search.
   useEffect(() => {
@@ -121,7 +129,7 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace }) {
       const existing = (Array.isArray(matches) ? matches : []).find(
         (e) => (e.name || "").toLowerCase() === (opt.name || "").toLowerCase()
       );
-      if (existing) { onReplace(existing); return; }
+      if (existing) { handlePick(existing); return; }
 
       const created = await apiService.exercises.create({
         name: opt.name,
@@ -132,7 +140,7 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace }) {
         difficulty: opt.difficulty || "beginner",
         strain: opt.strain || undefined,
       });
-      onReplace(created);
+      handlePick(created);
     } catch (err) {
       console.error("Failed to create generated exercise:", err);
       setError(`Couldn't add “${opt.name}”. Pick another option or search instead.`);
@@ -143,7 +151,7 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace }) {
 
   const pickOption = (opt) => {
     if (opt.source === "new") return pickGenerated(opt);
-    return onReplace(opt); // catalog pick already has a real id + strain
+    return handlePick(opt); // catalog pick already has a real id + strain
   };
 
   const availableTabs = TABS.filter((t) => t.key !== "similar" || exerciseId);
@@ -226,7 +234,7 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace }) {
                   key={ex._id || ex.id}
                   name={ex.name}
                   subtitle={(ex.muscles || []).join(", ")}
-                  onPick={() => onReplace(ex)}
+                  onPick={() => handlePick(ex)}
                 />
               ))}
               {!similarLoading && similar && similar.length === 0 && (
@@ -308,10 +316,40 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace }) {
               autoFocus
               excludeId={exerciseId}
               placeholder="Search for a replacement…"
-              onSelect={(ex) => onReplace(ex)}
+              onSelect={(ex) => handlePick(ex)}
             />
           )}
         </div>
+
+        {/* Scope step: only reachable when the session is template-linked */}
+        {pendingPick && (
+          <div className="border-t border-gray-100 p-5 space-y-2.5 bg-gray-50 rounded-b-3xl sm:rounded-b-2xl">
+            <p className="text-sm text-gray-700">
+              Swap in <span className="font-semibold text-gray-900">{pendingPick.name}</span> — for how long?
+            </p>
+            <button
+              onClick={() => onReplace(pendingPick, { permanent: false })}
+              className="w-full py-3 bg-primary-600 text-white rounded-xl font-semibold hover:bg-primary-700"
+            >
+              Just this session
+            </button>
+            <button
+              onClick={() => onReplace(pendingPick, { permanent: true })}
+              className="w-full py-3 bg-white border border-gray-300 text-gray-800 rounded-xl font-semibold hover:border-gray-400"
+            >
+              From now on
+              <span className="block text-xs font-normal text-gray-500 mt-0.5">
+                {isCommonTemplate ? "Creates your own copy of this workout" : "Updates this workout"}
+              </span>
+            </button>
+            <button
+              onClick={() => setPendingPick(null)}
+              className="w-full text-sm text-gray-500 py-1.5 hover:text-gray-700"
+            >
+              Choose something else
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/LiveWorkout.jsx
+++ b/frontend/src/pages/LiveWorkout.jsx
@@ -17,6 +17,8 @@ import {
 } from "@/components/ui/drawer";
 import ReplaceExerciseModal from "@/components/exercise/ReplaceExerciseModal";
 import ExerciseSearchInput from "@/components/exercise/ExerciseSearchInput";
+import { apiService } from "@/services/api";
+import { toast } from "@/components/ui/use-toast";
 
 // Format seconds to MM:SS
 const formatTime = (seconds) => {
@@ -661,10 +663,43 @@ export default function LiveWorkout() {
     setUndoState(null);
   };
 
+  // Persist a replacement to the source template ("from now on"). Fired after
+  // the session swap and never rolls it back on failure — the session change
+  // already happened; only the template write is reported.
+  const persistReplaceToTemplate = async (sourceWorkoutId, fromExerciseId, picked) => {
+    try {
+      const result = await apiService.predefinedWorkouts.swapExercise(sourceWorkoutId, {
+        fromExerciseId,
+        toExerciseId: picked._id || picked.id,
+      });
+      if (result?.cloned) {
+        // The common template was forked into a private copy — relink the
+        // session so a second "from now on" edits the copy in place.
+        setWorkout(w => ({ ...w, sourceWorkoutId: result.workout._id, sourceWorkoutIsCommon: false }));
+        toast({
+          title: "Saved to your workouts",
+          description: `Created your own copy of “${result.workout.name}” with the swap.`,
+        });
+      } else {
+        toast({
+          title: "Workout updated",
+          description: `“${picked.name}” is now part of this workout.`,
+        });
+      }
+    } catch (error) {
+      console.error('[LiveWorkout] Failed to persist replacement to template:', error);
+      toast({
+        title: "Session updated, workout not",
+        description: "The swap applies to this session, but saving it to the workout failed. Try again from the Workouts page.",
+        variant: "destructive",
+      });
+    }
+  };
+
   // Replace preserves already-logged work: it swaps identity and keeps the existing
   // sets array (counts + completion). Only when the old exercise had no sets do we
   // regenerate defaults from the new exercise's strain.
-  const handleReplaceExercise = (exIndex, picked) => {
+  const handleReplaceExercise = (exIndex, picked, opts = {}) => {
     const built = buildSessionExercise(picked, exIndex);
     const old = workout.exercises[exIndex];
     // Session exercises ALWAYS have a sets array, so "has sets" is always true.
@@ -683,6 +718,10 @@ export default function LiveWorkout() {
     setWorkout({ ...workout, exercises: withOrder(nextExercises) });
     setReplaceIndex(null);
     if (navigator.vibrate) navigator.vibrate(30);
+
+    if (opts.permanent && workout.sourceWorkoutId && old.exercise_id) {
+      persistReplaceToTemplate(workout.sourceWorkoutId, old.exercise_id, picked);
+    }
   };
 
   const handleAddExercise = (exIndex, position, picked) => {
@@ -926,7 +965,9 @@ export default function LiveWorkout() {
         <ReplaceExerciseModal
           exercise={workout.exercises[replaceIndex]}
           onClose={() => setReplaceIndex(null)}
-          onReplace={(picked) => handleReplaceExercise(replaceIndex, picked)}
+          onReplace={(picked, opts) => handleReplaceExercise(replaceIndex, picked, opts)}
+          canPersist={Boolean(workout.sourceWorkoutId && workout.exercises[replaceIndex]?.exercise_id)}
+          isCommonTemplate={Boolean(workout.sourceWorkoutIsCommon)}
         />
       )}
 

--- a/frontend/src/pages/PredefinedWorkouts.jsx
+++ b/frontend/src/pages/PredefinedWorkouts.jsx
@@ -198,7 +198,10 @@ export default function PredefinedWorkouts() {
 
   const doStartWorkout = (workout) => {
     try {
-      const sessionData = parseWorkoutToSessionData(workout);
+      const sessionData = parseWorkoutToSessionData(workout, {
+        sourceWorkoutId: workout._id || workout.id,
+        sourceWorkoutIsCommon: workout.isCommon
+      });
       startWorkoutSession(sessionData);
       navigate(createPageUrl('LiveWorkout')); // No ID param needed
     } catch (error) {

--- a/frontend/src/pages/TrainNow.jsx
+++ b/frontend/src/pages/TrainNow.jsx
@@ -421,9 +421,8 @@ export default function TrainNow() {
               blocks: templateBlocks,
               exercises: templateBlocks.length > 0 ? [] : convertedExercises,
               calendarEventId: scheduledEvent._id,
-              // getToday's populate projection doesn't include isCommon, so we
-              // only carry the template id; the swap endpoint reports cloning.
-              sourceWorkoutId: scheduledEvent.workoutTemplateId?._id
+              sourceWorkoutId: scheduledEvent.workoutTemplateId?._id,
+              isCommon: scheduledEvent.workoutTemplateId?.isCommon
             });
             setIsFromCalendar(true);
             setSuggestionLoading(false);

--- a/frontend/src/pages/TrainNow.jsx
+++ b/frontend/src/pages/TrainNow.jsx
@@ -420,7 +420,10 @@ export default function TrainNow() {
               // duplicates.
               blocks: templateBlocks,
               exercises: templateBlocks.length > 0 ? [] : convertedExercises,
-              calendarEventId: scheduledEvent._id
+              calendarEventId: scheduledEvent._id,
+              // getToday's populate projection doesn't include isCommon, so we
+              // only carry the template id; the swap endpoint reports cloning.
+              sourceWorkoutId: scheduledEvent.workoutTemplateId?._id
             });
             setIsFromCalendar(true);
             setSuggestionLoading(false);
@@ -493,7 +496,13 @@ export default function TrainNow() {
 
   const doStartWorkout = (workout) => {
     try {
-      const sessionData = parseWorkoutToSessionData(workout);
+      // sourceWorkoutId is set explicitly on the calendar suggestion; library
+      // cards carry _id. AI-generated suggestions have neither (no template).
+      // Never fall back to .id here — on the calendar path it's the event id.
+      const sessionData = parseWorkoutToSessionData(workout, {
+        sourceWorkoutId: workout.sourceWorkoutId || workout._id,
+        sourceWorkoutIsCommon: workout.isCommon
+      });
       startWorkoutSession(sessionData);
       navigate(createPageUrl('LiveWorkout')); // No ID param needed
     } catch (error) {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -260,6 +260,12 @@ class APIService {
       method: 'POST',
       body: JSON.stringify(data)
     }),
+    // Returns { workout, cloned, replacedCount } — the route responds with a
+    // bare object (no data envelope), so no extra unwrap here.
+    swapExercise: (id, data) => this.request(`/predefined-workouts/${id}/swap-exercise`, {
+      method: 'POST',
+      body: JSON.stringify(data)
+    }),
     favorite: (id) => this.request(`/predefined-workouts/${id}/favorite`, {
       method: 'PUT'
     })

--- a/frontend/src/utils/workoutSession.js
+++ b/frontend/src/utils/workoutSession.js
@@ -30,6 +30,8 @@ const ACTIVE_WORKOUT_TTL = 24 * 60 * 60 * 1000; // 24 hours
  * @property {string} title
  * @property {string} type
  * @property {number} duration_minutes
+ * @property {string|null} sourceWorkoutId - PredefinedWorkout template this session started from (null for ad-hoc sessions)
+ * @property {boolean} sourceWorkoutIsCommon - whether that template is shared/common (permanent edits clone it)
  * @property {WorkoutExercise[]} exercises
  */
 
@@ -179,11 +181,19 @@ function parseRest(rest) {
 
 /**
  * Parse workout blocks into exercise format for LiveWorkout
+ *
+ * sourceWorkoutId must be passed explicitly — never derived from workout._id,
+ * because callers hand in shapes where the id is something else entirely
+ * (e.g. TrainNow's calendar path, where .id is the calendar event id).
+ *
  * @param {Object} workout - workout with blocks
+ * @param {Object} [options]
+ * @param {string} [options.sourceWorkoutId] - PredefinedWorkout template id this session was started from
+ * @param {boolean} [options.sourceWorkoutIsCommon] - whether that template is a shared/common one
  * @returns {WorkoutData}
  * @throws {Error} if workout data is invalid
  */
-export function parseWorkoutToSessionData(workout) {
+export function parseWorkoutToSessionData(workout, { sourceWorkoutId, sourceWorkoutIsCommon } = {}) {
   if (!workout) {
     throw new Error('Workout data is required');
   }
@@ -196,6 +206,8 @@ export function parseWorkoutToSessionData(workout) {
     title: workout.name || workout.title,
     type: workout.primary_disciplines?.[0] || workout.type || null,
     duration_minutes: workout.estimated_duration || workout.duration_minutes || null,
+    sourceWorkoutId: isValidObjectId(String(sourceWorkoutId || '')) ? String(sourceWorkoutId) : null,
+    sourceWorkoutIsCommon: sourceWorkoutIsCommon === true,
     exercises: []
   };
 

--- a/frontend/src/utils/workoutSession.js
+++ b/frontend/src/utils/workoutSession.js
@@ -232,7 +232,12 @@ export function parseWorkoutToSessionData(workout, { sourceWorkoutId, sourceWork
       return;
     }
 
-    const rawExerciseId = ex.exercise_id || ex.exerciseId;
+    // exercise_id may arrive populated as an object ({_id, name, ...}) — the
+    // Workouts-page list populates it — or as a plain id string.
+    const rawIdSource = ex.exercise_id ?? ex.exerciseId;
+    const rawExerciseId = rawIdSource && typeof rawIdSource === 'object'
+      ? String(rawIdSource._id || rawIdSource.id || '')
+      : rawIdSource;
     const newExercise = {
       exercise_id: isValidObjectId(rawExerciseId) ? rawExerciseId : null,
       exercise_name: ex.exercise_name || ex.exerciseName || ex.name,


### PR DESCRIPTION
## What

Part 1 of the in-workout replace feature (coach-conversation card lands separately). Mid-workout exercise replacements were session-only — this adds a **"From now on"** path that persists the swap to the workout template.

- **Session ↔ template link**: session data now carries `sourceWorkoutId` / `sourceWorkoutIsCommon`, passed explicitly at launch (Workouts page + TrainNow calendar path; ad-hoc and AI-generated sessions stay unlinked and behave as before). Never derived from `.id` — on the calendar path that's the calendar-event id.
- **Scope step in ReplaceExerciseModal**: after picking a replacement (any tab), a footer asks *Just this session* / *From now on*. Only shown when the session is template-linked and the exercise has a real id.
- **New endpoint** `POST /api/v1/predefined-workouts/:id/swap-exercise` (`{fromExerciseId, toExerciseId}`):
  - replaces **every** occurrence across blocks, keeping `volume`/`rest`/`notes`; returns `replacedCount`
  - own template → edited in place; common template → **clone-on-modify** (private copy, popularity/ratings reset)
  - on clone, the user's references follow the fork: upcoming calendar events (`scheduled`/`in_progress` only — history intentionally keeps pointing at the original), active plan `weeks.workouts.predefinedWorkoutId`, and the `UserWorkoutModification` row (title/description/duration baked into the clone, favorites/PR metadata moved)
- **Failure isolation**: a failed template write never rolls back the session swap (toast explains). On clone the live session relinks, so a second "From now on" edits the copy in place.

## Why safe

- Reuse-first dedup (`templateMaterializer`, consistency job) matches by **exact** content signature and only back-links orphan events — a one-exercise fork can't be matched back to the original.
- `UserWorkoutModification`'s exercise-level overlay (dead stub) is untouched; only the live title/metadata fields are folded.

## Tests

- `backend/src/routes/__tests__/swapExercise.test.js`: in-place swap keeps volume/rest/notes + replaces all occurrences, clone path (ownership reset + calendar/plan relink), modification fold/move, no-match 400, foreign-private 403, invisible replacement 400.
- Full backend suite green (42/42); frontend production build clean.
- Manual click-through (own-template swap, common-template clone, calendar-launched session) pending — will be exercised heavily by the Part 2 coach-card work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)