### PR TITLE
Conversational Ask the Sensei + full autofill for on-the-fly exercises

### DIFF
--- a/ai-coach-service/app/api/v1/exercises.py
+++ b/ai-coach-service/app/api/v1/exercises.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from openai import AsyncOpenAI
-from pydantic import BaseModel
-from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+from typing import Any, Dict, List, Literal, Optional
 from bson import ObjectId
 import json
 import re
@@ -401,7 +401,88 @@ def _candidate_to_option(doc: Dict[str, Any], note: Optional[str] = None) -> Dic
     }
 
 
-async def _load_original(db, user_oid: ObjectId, req: SubstituteRankRequest) -> Optional[Dict[str, Any]]:
+def _strip_json_fences(content: str) -> str:
+    content = content.strip()
+    if content.startswith("```"):
+        content = content.split("```")[1]
+        if content.startswith("json"):
+            content = content[4:]
+        content = content.strip()
+    return content
+
+
+async def _build_candidate_pool(db, user_oid: ObjectId, original: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Equipment-aware candidate pool sharing >=1 primary muscle, deterministically ranked, top 8."""
+    user = await db.users.find_one({"_id": user_oid}, {"profile.preferences.equipment": 1})
+    equipment_list = (((user or {}).get("profile") or {}).get("preferences") or {}).get("equipment") or []
+    available = {(e or "").lower() for e in equipment_list} | _ALWAYS_AVAILABLE
+
+    ownership = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
+    query = {"muscles": {"$in": original.get("muscles", [])}, "_id": {"$ne": original["_id"]}, **ownership}
+    candidates = await db.exercises.find(query).to_list(100)
+    scored = [
+        (score_substitute(original, c), c)
+        for c in candidates
+        if equipment_ok(c.get("equipment", []), available)
+    ]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [c for s, c in scored[:8] if s > 0]
+
+
+def _format_candidates(pool: List[Dict[str, Any]]) -> str:
+    return "\n".join(
+        f'- id={str(c["_id"])} | {c.get("name")} | muscles={c.get("muscles", [])} | equipment={c.get("equipment", [])}'
+        for c in pool
+    )
+
+
+def _parse_llm_options(
+    data: Dict[str, Any],
+    pool_by_id: Dict[str, Dict[str, Any]],
+    original: Dict[str, Any],
+    count: int,
+) -> List[Dict[str, Any]]:
+    """Validate LLM-returned options: catalog ids must exist in the pool, "new" fields
+    must pass the VALID_* vocabularies (muscles inherit from the original when invalid)."""
+    options: List[Dict[str, Any]] = []
+    for raw in data.get("options", [])[:count]:
+        source = raw.get("source")
+        note = raw.get("note")
+        if source == "catalog":
+            doc = pool_by_id.get(raw.get("id"))
+            if doc is not None:  # drop hallucinated ids
+                options.append(_candidate_to_option(doc, note))
+        elif source == "new" and raw.get("name"):
+            strain = raw.get("strain") or {}
+            new_muscles = [m for m in raw.get("muscles", []) if m in VALID_MUSCLES]
+            if not new_muscles:
+                # LLM returned no valid muscles — inherit the original's so the
+                # option is materializable (muscles is required by the Exercise
+                # model) and embeds/searches sensibly. Skip if still empty.
+                new_muscles = [m for m in (original.get("muscles") or []) if m in VALID_MUSCLES]
+            if not new_muscles:
+                continue
+            options.append({
+                "source": "new",
+                "id": None,
+                "name": raw["name"],
+                "muscles": new_muscles,
+                "secondaryMuscles": [],
+                "discipline": [d for d in raw.get("discipline", []) if d in VALID_DISCIPLINES] or ["strength"],
+                "equipment": raw.get("equipment", []) or [],
+                "difficulty": raw.get("difficulty") if raw.get("difficulty") in VALID_DIFFICULTIES else "beginner",
+                "strain": {
+                    "intensity": strain.get("intensity") if strain.get("intensity") in VALID_INTENSITIES else "moderate",
+                    "load": strain.get("load") if strain.get("load") in VALID_LOADS else "moderate",
+                    "durationType": strain.get("duration_type") if strain.get("duration_type") in VALID_DURATION_TYPES else "reps",
+                    "typicalVolume": strain.get("typical_volume", "3x10"),
+                },
+                "note": note,
+            })
+    return options
+
+
+async def _load_original(db, user_oid: ObjectId, req) -> Optional[Dict[str, Any]]:
     ownership = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
     if req.exercise_id:
         try:
@@ -438,24 +519,7 @@ async def substitute_rank(
         return SubstituteRankResponse(options=[], fallback=True,
                                       message="Couldn't find that exercise to build alternatives from.")
 
-    # Available equipment: user profile.
-    user = await db.users.find_one({"_id": user_oid}, {"profile.preferences.equipment": 1})
-    equipment_list = (((user or {}).get("profile") or {}).get("preferences") or {}).get("equipment") or []
-    available = {(e or "").lower() for e in equipment_list} | _ALWAYS_AVAILABLE
-
-    # Candidate pool: shares >=1 primary muscle, equipment-ok, ranked deterministically.
-    ownership = {"$or": [{"isCommon": True}, {"createdBy": user_oid}]}
-    query = {"muscles": {"$in": original.get("muscles", [])}, "_id": {"$ne": original["_id"]}, **ownership}
-    candidates = await db.exercises.find(query).to_list(100)
-    scored = [
-        (score_substitute(original, c), c)
-        for c in candidates
-        if equipment_ok(c.get("equipment", []), available)
-    ]
-    scored.sort(key=lambda x: x[0], reverse=True)
-    scored = [s for s in scored if s[0] > 0]
-
-    pool = [c for _, c in scored[:8]]
+    pool = await _build_candidate_pool(db, user_oid, original)
     pool_by_id = {str(c["_id"]): c for c in pool}
 
     # Deterministic fallback options (used if the LLM call fails or returns nothing usable).
@@ -466,15 +530,11 @@ async def substitute_rank(
 
     settings = get_settings()
     client = AsyncOpenAI(api_key=settings.openai_api_key)
-    candidates_text = "\n".join(
-        f'- id={str(c["_id"])} | {c.get("name")} | muscles={c.get("muscles", [])} | equipment={c.get("equipment", [])}'
-        for c in pool
-    )
     prompt = SUBSTITUTE_RANK_PROMPT.format(
         original_name=original.get("name", ""),
         original_muscles=", ".join(original.get("muscles", []) or []) or "n/a",
         reason=request.reason or "wants a change",
-        candidates=candidates_text,
+        candidates=_format_candidates(pool),
         count=request.count,
     )
 
@@ -488,49 +548,10 @@ async def substitute_rank(
             max_completion_tokens=900,
             **settings.llm_tuning_params(temperature=0.4),
         )
-        content = response.choices[0].message.content.strip()
-        if content.startswith("```"):
-            content = content.split("```")[1]
-            if content.startswith("json"):
-                content = content[4:]
-            content = content.strip()
+        content = _strip_json_fences(response.choices[0].message.content)
         data = json.loads(content)
 
-        options: List[Dict[str, Any]] = []
-        for raw in data.get("options", [])[: request.count]:
-            source = raw.get("source")
-            note = raw.get("note")
-            if source == "catalog":
-                doc = pool_by_id.get(raw.get("id"))
-                if doc is not None:  # drop hallucinated ids
-                    options.append(_candidate_to_option(doc, note))
-            elif source == "new" and raw.get("name"):
-                strain = raw.get("strain") or {}
-                new_muscles = [m for m in raw.get("muscles", []) if m in VALID_MUSCLES]
-                if not new_muscles:
-                    # LLM returned no valid muscles — inherit the original's so the
-                    # option is materializable (muscles is required by the Exercise
-                    # model) and embeds/searches sensibly. Skip if still empty.
-                    new_muscles = [m for m in (original.get("muscles") or []) if m in VALID_MUSCLES]
-                if not new_muscles:
-                    continue
-                options.append({
-                    "source": "new",
-                    "id": None,
-                    "name": raw["name"],
-                    "muscles": new_muscles,
-                    "secondaryMuscles": [],
-                    "discipline": [d for d in raw.get("discipline", []) if d in VALID_DISCIPLINES] or ["strength"],
-                    "equipment": raw.get("equipment", []) or [],
-                    "difficulty": raw.get("difficulty") if raw.get("difficulty") in VALID_DIFFICULTIES else "beginner",
-                    "strain": {
-                        "intensity": strain.get("intensity") if strain.get("intensity") in VALID_INTENSITIES else "moderate",
-                        "load": strain.get("load") if strain.get("load") in VALID_LOADS else "moderate",
-                        "durationType": strain.get("duration_type") if strain.get("duration_type") in VALID_DURATION_TYPES else "reps",
-                        "typicalVolume": strain.get("typical_volume", "3x10"),
-                    },
-                    "note": note,
-                })
+        options = _parse_llm_options(data, pool_by_id, original, request.count)
 
         if not options:
             return SubstituteRankResponse(options=deterministic, fallback=True)
@@ -539,3 +560,147 @@ async def substitute_rank(
     except Exception as e:
         logger.error(f"substitute_rank LLM failure, returning deterministic pool: {e}")
         return SubstituteRankResponse(options=deterministic, fallback=True)
+
+
+# ---------------------------------------------------------------------------
+# Substitute chat ("Ask the Sensei" conversation)
+# ---------------------------------------------------------------------------
+# Stateless multi-turn variant of substitute_rank: the client holds the message
+# history and sends it each turn; every turn is re-grounded on the same
+# catalog candidate pool, and any options the LLM proposes pass through the
+# same validation as the one-shot ranker.
+
+
+class SubstituteChatMessage(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str = Field(max_length=1000)
+
+
+class SubstituteChatRequest(BaseModel):
+    exercise_id: Optional[str] = None
+    exercise_name: Optional[str] = None
+    history: List[SubstituteChatMessage] = []  # client-held, prior turns only
+    message: str = Field(min_length=1, max_length=1000)
+
+
+class SubstituteChatResponse(BaseModel):
+    reply: str
+    options: List[SubstituteOption] = []
+    routed: Optional[str] = None  # "safety" on hard pain-gate turns
+    fallback: bool = False
+
+
+CHAT_SAFETY_MESSAGE = (
+    "Since this is about pain or an injury, I won't just swap in another loaded "
+    "movement. If a clinician has cleared you to train around it, tell me which "
+    "area to avoid and I'll suggest options that work around it. Otherwise please "
+    "rest it or check with a professional — I can't prescribe rehab."
+)
+
+SUBSTITUTE_CHAT_PROMPT = """You are the Sensei, a pragmatic strength coach chatting with an athlete who wants to swap the exercise "{original_name}" mid-workout.
+Primary muscles: {original_muscles}
+
+{candidates_block}
+
+Safety rules:
+- Never prescribe rehab or diagnose. If the athlete mentions pain or injury anywhere in the conversation, include a one-line caution, never load the painful area, and keep suggestions conservative.
+- Ask a short clarifying question when the request is ambiguous instead of guessing.
+
+Respond ONLY with a JSON object:
+{{"reply": "<2-3 conversational sentences answering the athlete>",
+  "options": [
+    {{"source": "catalog", "id": "<exact id from the list>", "note": "<=12 words on why it fits"}},
+    {{"source": "new", "name": "<exercise name>", "muscles": [...], "discipline": [...],
+      "equipment": [...], "difficulty": "beginner|intermediate|advanced",
+      "strain": {{"intensity": "...", "load": "...", "duration_type": "reps", "typical_volume": "3x10"}},
+      "note": "<=12 words on why it fits"}}
+  ]}}
+- "options" is optional: use [] when you are asking a question rather than suggesting.
+- Suggest 0-4 options, at most 2 with source "new". Prefer catalog options (they map to real logged exercises).
+- For "catalog" options include ONLY source, id, note. Use ids EXACTLY as given; never invent an id."""
+
+CHAT_CANDIDATES_BLOCK = """Here are REAL exercises from their catalog that share muscles and fit their equipment,
+already ranked by stimulus match (best first):
+{candidates}"""
+
+CHAT_NO_CANDIDATES_BLOCK = (
+    'Their catalog has no matching exercises to ground on. Suggest well-known '
+    'exercises as source "new" only.'
+)
+
+_CHAT_HISTORY_LIMIT = 8
+
+
+@router.post("/substitute/chat", response_model=SubstituteChatResponse)
+async def substitute_chat(
+    request: SubstituteChatRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+) -> SubstituteChatResponse:
+    """One conversational turn of exercise-substitution coaching."""
+    from app.main import db
+
+    try:
+        user_oid = ObjectId(current_user["user_id"])
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid user.")
+
+    history = request.history[-_CHAT_HISTORY_LIMIT:]
+    pain_anywhere = _is_pain_reason(request.message) or any(
+        _is_pain_reason(m.content) for m in history if m.role == "user"
+    )
+
+    # First pain mention with no prior context gets the deterministic caution —
+    # but unlike the one-shot ranker the conversation continues from here.
+    if not history and _is_pain_reason(request.message):
+        return SubstituteChatResponse(reply=CHAT_SAFETY_MESSAGE, routed="safety")
+
+    original = await _load_original(db, user_oid, request)
+    pool = await _build_candidate_pool(db, user_oid, original) if original else []
+    pool_by_id = {str(c["_id"]): c for c in pool}
+
+    candidates_block = (
+        CHAT_CANDIDATES_BLOCK.format(candidates=_format_candidates(pool))
+        if pool else CHAT_NO_CANDIDATES_BLOCK
+    )
+    system_prompt = SUBSTITUTE_CHAT_PROMPT.format(
+        original_name=(original or {}).get("name") or request.exercise_name or "their exercise",
+        original_muscles=", ".join((original or {}).get("muscles", []) or []) or "n/a",
+        candidates_block=candidates_block,
+    )
+    messages = (
+        [{"role": "system", "content": system_prompt}]
+        + [{"role": m.role, "content": m.content} for m in history]
+        + [{"role": "user", "content": request.message}]
+    )
+
+    settings = get_settings()
+    client = AsyncOpenAI(api_key=settings.openai_api_key)
+    try:
+        response = await client.chat.completions.create(
+            model=settings.openai_model_fast,
+            messages=messages,
+            max_completion_tokens=700,
+            **settings.llm_tuning_params(temperature=0.4),
+        )
+        content = _strip_json_fences(response.choices[0].message.content)
+        data = json.loads(content)
+        reply = (data.get("reply") or "").strip()
+        if not reply:
+            raise ValueError("LLM returned no reply text")
+        options = _parse_llm_options(data, pool_by_id, original or {}, 4)
+        return SubstituteChatResponse(reply=reply, options=options)
+    except Exception as e:
+        logger.error(f"substitute_chat LLM failure, degrading: {e}")
+        # Never 500 for LLM issues mid-workout.
+        if pain_anywhere:
+            return SubstituteChatResponse(reply=CHAT_SAFETY_MESSAGE, routed="safety", fallback=True)
+        if pool:
+            return SubstituteChatResponse(
+                reply="I couldn't think that through just now — here are the closest matches from your catalog:",
+                options=[_candidate_to_option(c) for c in pool[:4]],
+                fallback=True,
+            )
+        return SubstituteChatResponse(
+            reply="I couldn't come up with suggestions right now — try the Browse tab.",
+            fallback=True,
+        )

--- a/ai-coach-service/app/api/v1/exercises.py
+++ b/ai-coach-service/app/api/v1/exercises.py
@@ -158,8 +158,9 @@ Respond with a JSON object. Output the fields IN THIS EXACT ORDER so they can be
 3. "discipline": Training disciplines (array). Valid: {disciplines}
 4. "muscles": Primary muscle groups (array). Valid: {muscles}
 5. "equipment": Equipment needed (array of strings)
-6. "similar_exercises": 2-4 similar exercise names (array)
-7. "strain": Object with intensity ({intensities}), load ({loads}), duration_type ({duration_types}), typical_volume (string like "3x8")
+6. "difficulty": Skill level required. Valid: {difficulties}
+7. "similar_exercises": 2-4 similar exercise names (array)
+8. "strain": Object with intensity ({intensities}), load ({loads}), duration_type ({duration_types}), typical_volume (string like "3x8")
 
 Be accurate. Only use valid options. Output ONLY the JSON object."""
 
@@ -173,6 +174,7 @@ async def stream_exercise_suggestions(exercise_name: str):
         exercise_name=exercise_name,
         muscles=", ".join(VALID_MUSCLES),
         disciplines=", ".join(VALID_DISCIPLINES),
+        difficulties=", ".join(VALID_DIFFICULTIES),
         intensities=", ".join(VALID_INTENSITIES),
         loads=", ".join(VALID_LOADS),
         duration_types=", ".join(VALID_DURATION_TYPES)
@@ -194,7 +196,7 @@ async def stream_exercise_suggestions(exercise_name: str):
         sent_fields = set()
 
         # Field detection patterns (in order of expected appearance)
-        field_order = ["suggested_name", "description", "discipline", "muscles", "equipment", "similar_exercises", "strain"]
+        field_order = ["suggested_name", "description", "discipline", "muscles", "equipment", "difficulty", "similar_exercises", "strain"]
 
         async for chunk in stream:
             if chunk.choices[0].delta.content:
@@ -235,6 +237,11 @@ def extract_field_if_complete(content: str, field: str):
         elif field == "description":
             # Match "description": "..." pattern
             match = re.search(r'"description"\s*:\s*"([^"]*)"', content)
+            if match:
+                return match.group(1)
+
+        elif field == "difficulty":
+            match = re.search(r'"difficulty"\s*:\s*"([^"]*)"', content)
             if match:
                 return match.group(1)
 
@@ -283,6 +290,9 @@ def validate_field(field: str, value):
 
     elif field == "equipment":
         return value if value else None
+
+    elif field == "difficulty":
+        return value if value in VALID_DIFFICULTIES else None
 
     elif field == "similar_exercises":
         return value[:5] if value else None

--- a/ai-coach-service/tests/test_substitute_chat.py
+++ b/ai-coach-service/tests/test_substitute_chat.py
@@ -1,0 +1,208 @@
+"""Tests for the substitute chat endpoint and the shared option-validation helpers."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bson import ObjectId
+from pydantic import ValidationError
+
+import app.api.v1.exercises as ex
+
+USER_ID = str(ObjectId())
+CURRENT_USER = {"user_id": USER_ID, "email": "t@t.co", "username": "t"}
+
+ORIGINAL_ID = ObjectId()
+CAND_ID = ObjectId()
+
+ORIGINAL = {"_id": ORIGINAL_ID, "name": "Pull-up", "muscles": ["back", "biceps"], "equipment": []}
+CANDIDATE = {
+    "_id": CAND_ID,
+    "name": "Chin-up",
+    "muscles": ["back", "biceps"],
+    "equipment": [],
+    "strain": {"intensity": "high", "load": "bodyweight"},
+}
+POOL_BY_ID = {str(CAND_ID): CANDIDATE}
+
+
+# ---------------------------- _parse_llm_options ----------------------------
+
+class TestParseLlmOptions:
+    def test_catalog_option_projected_from_pool(self):
+        data = {"options": [{"source": "catalog", "id": str(CAND_ID), "note": "close match"}]}
+        out = ex._parse_llm_options(data, POOL_BY_ID, ORIGINAL, 4)
+        assert len(out) == 1
+        assert out[0]["source"] == "catalog"
+        assert out[0]["id"] == str(CAND_ID)
+        assert out[0]["name"] == "Chin-up"
+        assert out[0]["note"] == "close match"
+
+    def test_hallucinated_catalog_id_dropped(self):
+        data = {"options": [{"source": "catalog", "id": str(ObjectId()), "note": "fake"}]}
+        assert ex._parse_llm_options(data, POOL_BY_ID, ORIGINAL, 4) == []
+
+    def test_new_option_inherits_muscles_when_invalid(self):
+        data = {"options": [{"source": "new", "name": "Archer Row", "muscles": ["nonsense"]}]}
+        out = ex._parse_llm_options(data, POOL_BY_ID, ORIGINAL, 4)
+        assert out[0]["muscles"] == ["back", "biceps"]
+
+    def test_new_option_skipped_when_muscles_uninheritable(self):
+        data = {"options": [{"source": "new", "name": "Archer Row", "muscles": []}]}
+        assert ex._parse_llm_options(data, POOL_BY_ID, {}, 4) == []
+
+    def test_new_option_strain_mapped_to_camel_case(self):
+        data = {"options": [{
+            "source": "new", "name": "Ring Row", "muscles": ["back"],
+            "strain": {"intensity": "high", "load": "bodyweight",
+                       "duration_type": "reps", "typical_volume": "3x8"},
+        }]}
+        out = ex._parse_llm_options(data, POOL_BY_ID, ORIGINAL, 4)
+        assert out[0]["strain"] == {
+            "intensity": "high", "load": "bodyweight",
+            "durationType": "reps", "typicalVolume": "3x8",
+        }
+
+    def test_count_capped(self):
+        data = {"options": [{"source": "catalog", "id": str(CAND_ID)}] * 6}
+        assert len(ex._parse_llm_options(data, POOL_BY_ID, ORIGINAL, 4)) == 4
+
+
+# ---------------------------- request schema ----------------------------
+
+class TestChatRequestSchema:
+    def test_oversized_message_rejected(self):
+        with pytest.raises(ValidationError):
+            ex.SubstituteChatRequest(message="x" * 1001)
+
+    def test_empty_message_rejected(self):
+        with pytest.raises(ValidationError):
+            ex.SubstituteChatRequest(message="")
+
+    def test_bad_history_role_rejected(self):
+        with pytest.raises(ValidationError):
+            ex.SubstituteChatRequest(message="hi", history=[{"role": "system", "content": "x"}])
+
+
+# ---------------------------- endpoint ----------------------------
+
+def _mock_db(monkeypatch, original=ORIGINAL, candidates=None):
+    db = MagicMock()
+    db.exercises.find_one = AsyncMock(return_value=original)
+    cursor = MagicMock()
+    cursor.to_list = AsyncMock(return_value=candidates if candidates is not None else [CANDIDATE])
+    db.exercises.find = MagicMock(return_value=cursor)
+    db.users.find_one = AsyncMock(return_value={"profile": {"preferences": {"equipment": []}}})
+    monkeypatch.setattr("app.main.db", db)
+    return db
+
+
+def _mock_openai(monkeypatch, payload=None, fail=False):
+    captured = {}
+
+    async def create(**kwargs):
+        captured.update(kwargs)
+        if fail:
+            raise RuntimeError("llm boom")
+        response = MagicMock()
+        response.choices[0].message.content = json.dumps(payload)
+        return response
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=create)
+    factory = MagicMock(return_value=client)
+    monkeypatch.setattr(ex, "AsyncOpenAI", factory)
+    return captured, factory
+
+
+class TestSubstituteChat:
+    async def test_first_turn_pain_routes_to_safety_without_llm(self, monkeypatch):
+        _mock_db(monkeypatch)
+        _, factory = _mock_openai(monkeypatch, payload={"reply": "nope"})
+        req = ex.SubstituteChatRequest(message="sharp pain in my shoulder", exercise_id=str(ORIGINAL_ID))
+        res = await ex.substitute_chat(req, CURRENT_USER)
+        assert res.routed == "safety"
+        assert res.options == []
+        assert res.reply
+        factory.assert_not_called()
+
+    async def test_happy_path_returns_reply_and_validated_options(self, monkeypatch):
+        _mock_db(monkeypatch)
+        payload = {
+            "reply": "Chin-ups keep the pull pattern.",
+            "options": [
+                {"source": "catalog", "id": str(CAND_ID), "note": "same muscles"},
+                {"source": "catalog", "id": str(ObjectId()), "note": "hallucinated"},
+            ],
+        }
+        captured, _ = _mock_openai(monkeypatch, payload=payload)
+        req = ex.SubstituteChatRequest(message="I want variety", exercise_id=str(ORIGINAL_ID))
+        res = await ex.substitute_chat(req, CURRENT_USER)
+        assert res.reply == "Chin-ups keep the pull pattern."
+        assert [o.name for o in res.options] == ["Chin-up"]
+        assert res.fallback is False
+        # System prompt grounds on the real candidate pool.
+        assert str(CAND_ID) in captured["messages"][0]["content"]
+        assert "temperature" not in captured
+
+    async def test_history_truncated_to_last_8(self, monkeypatch):
+        _mock_db(monkeypatch)
+        captured, _ = _mock_openai(monkeypatch, payload={"reply": "ok", "options": []})
+        history = [{"role": "user", "content": f"msg {i}"} for i in range(12)]
+        req = ex.SubstituteChatRequest(message="so what do you think?", history=history)
+        await ex.substitute_chat(req, CURRENT_USER)
+        # system + 8 history + current user message
+        assert len(captured["messages"]) == 10
+        assert captured["messages"][1]["content"] == "msg 4"
+
+    async def test_llm_failure_falls_back_to_pool(self, monkeypatch):
+        _mock_db(monkeypatch)
+        _mock_openai(monkeypatch, fail=True)
+        req = ex.SubstituteChatRequest(message="I want variety", exercise_id=str(ORIGINAL_ID))
+        res = await ex.substitute_chat(req, CURRENT_USER)
+        assert res.fallback is True
+        assert [o.name for o in res.options] == ["Chin-up"]
+        assert res.reply
+
+    async def test_llm_failure_with_pain_in_history_returns_safety(self, monkeypatch):
+        _mock_db(monkeypatch)
+        _mock_openai(monkeypatch, fail=True)
+        req = ex.SubstituteChatRequest(
+            message="ok so what instead?",
+            history=[{"role": "user", "content": "I get elbow pain on these"},
+                     {"role": "assistant", "content": "tell me more"}],
+            exercise_id=str(ORIGINAL_ID),
+        )
+        res = await ex.substitute_chat(req, CURRENT_USER)
+        assert res.routed == "safety"
+        assert res.options == []
+        assert res.fallback is True
+
+    async def test_unresolvable_exercise_still_chats_without_pool(self, monkeypatch):
+        _mock_db(monkeypatch, original=None)
+        captured, _ = _mock_openai(monkeypatch, payload={"reply": "Try weighted dips.", "options": []})
+        req = ex.SubstituteChatRequest(message="I want something harder", exercise_name="Mystery Move")
+        res = await ex.substitute_chat(req, CURRENT_USER)
+        assert res.reply == "Try weighted dips."
+        assert "no matching exercises" in captured["messages"][0]["content"]
+
+
+# ---------------------------- rank regression after helper extraction ----------------------------
+
+class TestRankStillWorks:
+    async def test_rank_uses_shared_pool_and_parser(self, monkeypatch):
+        _mock_db(monkeypatch)
+        payload = {"options": [{"source": "catalog", "id": str(CAND_ID), "note": "fits"}]}
+        _mock_openai(monkeypatch, payload=payload)
+        req = ex.SubstituteRankRequest(exercise_id=str(ORIGINAL_ID), count=5)
+        res = await ex.substitute_rank(req, CURRENT_USER)
+        assert res.fallback is False
+        assert [o.name for o in res.options] == ["Chin-up"]
+
+    async def test_rank_pain_reason_still_gated(self, monkeypatch):
+        _mock_db(monkeypatch)
+        _, factory = _mock_openai(monkeypatch, payload={})
+        req = ex.SubstituteRankRequest(exercise_id=str(ORIGINAL_ID), reason="pain or injury")
+        res = await ex.substitute_rank(req, CURRENT_USER)
+        assert res.routed == "safety"
+        factory.assert_not_called()

--- a/backend/src/routes/__tests__/substituteChat.test.js
+++ b/backend/src/routes/__tests__/substituteChat.test.js
@@ -1,0 +1,113 @@
+jest.mock('../../middleware/auth', () => ({
+  auth: (req, res, next) => {
+    req.user = { id: 'aaaaaaaaaaaaaaaaaaaaaaaa', role: 'user' };
+    next();
+  },
+  optionalAuth: (req, res, next) => next()
+}));
+jest.mock('openai', () => jest.fn().mockImplementation(() => ({})));
+
+const express = require('express');
+const request = require('supertest');
+const http = require('http');
+
+// A real local HTTP server standing in for the AI coach service — the proxy
+// reads AI_SERVICE_URL at module load, so the router is required only after
+// the fake server has a port.
+let app;
+let fakeAi;
+const aiCalls = [];
+let aiResponder = null; // () => ({ status, payload })
+
+beforeAll((done) => {
+  fakeAi = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      aiCalls.push({ path: req.url, headers: req.headers, body: body ? JSON.parse(body) : null });
+      const { status = 200, payload = { reply: 'ok', options: [] } } = aiResponder ? aiResponder() : {};
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(payload));
+    });
+  });
+  fakeAi.listen(0, '127.0.0.1', () => {
+    process.env.AI_SERVICE_URL = `http://127.0.0.1:${fakeAi.address().port}`;
+    const router = require('../ai');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+    done();
+  });
+});
+
+afterAll((done) => {
+  // Drop kept-alive proxy connections so close() can finish.
+  fakeAi.closeAllConnections?.();
+  fakeAi.close(() => done());
+});
+
+beforeEach(() => {
+  aiCalls.length = 0;
+  aiResponder = null;
+});
+
+describe('POST /exercises/substitute/chat', () => {
+  it('400s when message is missing', async () => {
+    const res = await request(app).post('/exercises/substitute/chat').send({ history: [] });
+    expect(res.status).toBe(400);
+    expect(aiCalls).toHaveLength(0);
+  });
+
+  it('400s when message is blank', async () => {
+    const res = await request(app).post('/exercises/substitute/chat').send({ message: '   ' });
+    expect(res.status).toBe(400);
+    expect(aiCalls).toHaveLength(0);
+  });
+
+  it('forwards the request and returns the AI service response verbatim', async () => {
+    const payload = { reply: 'Try chin-ups.', options: [], fallback: false };
+    aiResponder = () => ({ payload });
+
+    const res = await request(app)
+      .post('/exercises/substitute/chat')
+      .set('Authorization', 'Bearer token-123')
+      .send({ exercise_id: 'bbbbbbbbbbbbbbbbbbbbbbbb', message: 'I want variety', history: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(payload);
+    expect(aiCalls).toHaveLength(1);
+    expect(aiCalls[0].path).toBe('/api/v1/exercises/substitute/chat');
+    expect(aiCalls[0].headers.authorization).toBe('Bearer token-123');
+    expect(aiCalls[0].body.message).toBe('I want variety');
+  });
+
+  it('slices history to the last 8 messages before forwarding', async () => {
+    const history = Array.from({ length: 12 }, (_, i) => ({ role: 'user', content: `msg ${i}` }));
+
+    await request(app)
+      .post('/exercises/substitute/chat')
+      .send({ message: 'and now?', history });
+
+    expect(aiCalls[0].body.history).toHaveLength(8);
+    expect(aiCalls[0].body.history[0].content).toBe('msg 4');
+  });
+
+  it('drops a non-array history instead of forwarding it', async () => {
+    await request(app)
+      .post('/exercises/substitute/chat')
+      .send({ message: 'hello', history: 'not-an-array' });
+
+    expect(aiCalls[0].body.history).toEqual([]);
+  });
+
+  it('500s with the error envelope when the AI service fails', async () => {
+    aiResponder = () => ({ status: 500, payload: { detail: 'boom' } });
+
+    const res = await request(app)
+      .post('/exercises/substitute/chat')
+      .send({ message: 'hello' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -784,6 +784,82 @@ router.post('/exercises/substitute/rank', authMiddleware, aiRateLimit, async (re
   }
 });
 
+// Exercise substitute chat - conversational "Ask the Sensei" replace (proxies to AI Coach)
+// Stateless: the client holds the message history and sends it each turn.
+// Forwards the Authorization header because the AI endpoint is user-scoped.
+router.post('/exercises/substitute/chat', authMiddleware, aiRateLimit, async (req, res) => {
+  try {
+    const { exercise_id, exercise_name, message } = req.body;
+
+    if (!message || typeof message !== 'string' || !message.trim()) {
+      return res.status(400).json({
+        success: false,
+        message: 'message is required'
+      });
+    }
+
+    // Bound the forwarded body: the AI service re-grounds every turn, so only
+    // the most recent turns matter.
+    const history = Array.isArray(req.body.history) ? req.body.history.slice(-8) : [];
+
+    const urlParts = new URL(`${AI_SERVICE_URL}/api/v1/exercises/substitute/chat`);
+    const isHttps = urlParts.protocol === 'https:';
+    const http = require(isHttps ? 'https' : 'http');
+
+    const body = JSON.stringify({ exercise_id, exercise_name, history, message });
+
+    const response = await new Promise((resolve, reject) => {
+      const options = {
+        hostname: urlParts.hostname,
+        port: urlParts.port || (isHttps ? 443 : 80),
+        path: urlParts.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          ...(req.headers.authorization && { Authorization: req.headers.authorization })
+        }
+      };
+
+      const request = http.request(options, (response) => {
+        let data = '';
+        response.on('data', (chunk) => { data += chunk; });
+        response.on('end', () => {
+          if (response.statusCode === 200) {
+            try {
+              resolve(JSON.parse(data));
+            } catch (e) {
+              reject(new Error('Invalid JSON response from AI service'));
+            }
+          } else {
+            reject(new Error(`AI service returned status ${response.statusCode}: ${data}`));
+          }
+        });
+      });
+
+      // The downstream call waits on an LLM completion — cap it so a hung
+      // upstream can't hold the client connection open indefinitely.
+      request.setTimeout(30000, () => {
+        request.destroy(new Error('AI service timed out'));
+      });
+
+      request.on('error', reject);
+      request.write(body);
+      request.end();
+    });
+
+    res.json(response);
+
+  } catch (error) {
+    console.error('Substitute chat error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to get a Sensei reply',
+      error: error.message
+    });
+  }
+});
+
 // Progression suggestion streaming endpoint - proxies to Python AI Coach service
 router.post('/progressions/suggest/stream', authMiddleware, aiRateLimit, async (req, res) => {
   try {

--- a/frontend/src/components/exercise/ReplaceExerciseModal.jsx
+++ b/frontend/src/components/exercise/ReplaceExerciseModal.jsx
@@ -1,9 +1,8 @@
-import { useState, useEffect, useRef } from "react";
-import { X, Sparkles, Search, AlertTriangle, Plus, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { X, Sparkles, Search, AlertTriangle } from "lucide-react";
 import { apiService } from "@/services/api";
-import { aiService } from "@/services/aiService";
-import ExerciseResultRow from "./replace/ExerciseResultRow";
 import BrowseTab from "./replace/BrowseTab";
+import SenseiChatTab from "./replace/SenseiChatTab";
 
 const TABS = [
   { key: "browse", label: "Browse", icon: Search },
@@ -25,40 +24,6 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace, can
     if (canPersist) setPendingPick(ex);
     else onReplace(ex, { permanent: false });
   };
-
-  // --- Sensei tab (one-shot) ---
-  const [sensei, setSensei] = useState(null);       // { options?, routed?, message? }
-  const [senseiLoading, setSenseiLoading] = useState(false);
-  const senseiAbortRef = useRef(null);
-
-  const runSensei = () => {
-    if (senseiAbortRef.current) senseiAbortRef.current.abort();
-    const controller = new AbortController();
-    senseiAbortRef.current = controller;
-    setSenseiLoading(true);
-    setSensei(null);
-    setError(null);
-    aiService
-      .rankSubstitutes({ exercise_id: exerciseId, exercise_name: exerciseName }, controller.signal)
-      .then((res) => setSensei(res || { options: [] }))
-      .catch((err) => {
-        if (err?.name === "AbortError") return;
-        setError("The Sensei couldn't fetch options. Try again.");
-        setSensei({ options: [] });
-      })
-      .finally(() => {
-        if (senseiAbortRef.current === controller) senseiAbortRef.current = null;
-        setSenseiLoading(false);
-      });
-  };
-
-  const cancelSensei = () => {
-    if (senseiAbortRef.current) senseiAbortRef.current.abort();
-    senseiAbortRef.current = null;
-    setSenseiLoading(false);
-  };
-
-  useEffect(() => () => { if (senseiAbortRef.current) senseiAbortRef.current.abort(); }, []);
 
   // Materialize a generated (source:"new") exercise into the catalog before swapping,
   // so it carries a real id. Dedup by name first to avoid polluting the catalog.
@@ -132,7 +97,8 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace, can
           })}
         </div>
 
-        {/* Body — panels stay mounted so state survives tab switches */}
+        {/* Body — panels stay mounted so search text / picks / chat history
+            survive tab switches; `hidden` avoids re-firing mount effects. */}
         <div className="flex-1 overflow-y-auto p-5">
           {error && (
             <div className="mb-4 flex items-start gap-2 text-sm text-red-700 bg-red-50 rounded-xl p-3">
@@ -152,63 +118,12 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace, can
           </div>
 
           <div className={tab === "sensei" ? "" : "hidden"}>
-            {!sensei && !senseiLoading && (
-              <div className="text-center py-8">
-                <Sparkles className="w-10 h-10 text-primary-500 mx-auto mb-3" />
-                <p className="text-gray-600 mb-4 text-sm">Get AI-picked alternatives.</p>
-                <button
-                  onClick={runSensei}
-                  className="px-5 py-2.5 bg-primary-600 text-white rounded-xl font-semibold hover:bg-primary-700"
-                >
-                  Get options
-                </button>
-              </div>
-            )}
-
-            {senseiLoading && (
-              <div className="text-center py-8">
-                <Loader2 className="w-8 h-8 text-primary-500 mx-auto mb-3 animate-spin" />
-                <p className="text-gray-500 text-sm mb-4">The Sensei is thinking…</p>
-                <button onClick={cancelSensei} className="text-sm text-gray-500 underline">Cancel</button>
-              </div>
-            )}
-
-            {sensei?.routed === "safety" && (
-              <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-800">
-                <AlertTriangle className="w-5 h-5 mb-2" />
-                {sensei.message}
-              </div>
-            )}
-
-            {sensei && !sensei.routed && (sensei.options?.length > 0) && (
-              <div className="space-y-3">
-                {sensei.options.map((opt, i) => (
-                  <ExerciseResultRow
-                    key={opt.id || `${opt.name}-${i}`}
-                    name={opt.name}
-                    subtitle={opt.note || (opt.muscles || []).join(", ")}
-                    disabled={materializingId === opt.name}
-                    badge={
-                      opt.source === "new" ? (
-                        <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 text-[11px] font-medium">
-                          <Plus className="w-3 h-3" /> New
-                        </span>
-                      ) : null
-                    }
-                    onPick={() => pickOption(opt)}
-                  />
-                ))}
-                <button onClick={runSensei} className="w-full text-sm text-gray-500 py-2 hover:text-gray-700">
-                  Regenerate options
-                </button>
-              </div>
-            )}
-
-            {sensei && !sensei.routed && sensei.options?.length === 0 && !senseiLoading && (
-              <p className="text-center text-gray-500 py-8 text-sm">
-                No options came back. Try the Browse tab instead.
-              </p>
-            )}
+            <SenseiChatTab
+              exerciseId={exerciseId}
+              exerciseName={exerciseName}
+              onPickOption={pickOption}
+              materializingId={materializingId}
+            />
           </div>
         </div>
 

--- a/frontend/src/components/exercise/replace/InlineCreateExercise.jsx
+++ b/frontend/src/components/exercise/replace/InlineCreateExercise.jsx
@@ -24,7 +24,7 @@ export default function InlineCreateExercise({ initialName, onCreated, onCancel 
   const [error, setError] = useState(null);
   // Fields we apply silently on save; strain arrives snake_case from the
   // stream but the Exercise model stores camelCase — mapped in save().
-  const autoRef = useRef({ description: "", discipline: null, strain: null });
+  const autoRef = useRef({ description: "", discipline: null, strain: null, difficulty: null });
   const touchedRef = useRef({ muscles: false, equipment: false });
   const abortRef = useRef(null);
 
@@ -44,6 +44,8 @@ export default function InlineCreateExercise({ initialName, onCreated, onCancel 
           autoRef.current.description = value;
         } else if (field === "discipline") {
           autoRef.current.discipline = value;
+        } else if (field === "difficulty") {
+          autoRef.current.difficulty = value;
         } else if (field === "strain") {
           autoRef.current.strain = value;
         }
@@ -81,7 +83,7 @@ export default function InlineCreateExercise({ initialName, onCreated, onCancel 
         secondaryMuscles: [],
         discipline: autoRef.current.discipline?.length ? autoRef.current.discipline : ["strength"],
         equipment: equipment.split(",").map((x) => x.trim()).filter(Boolean),
-        difficulty: "beginner",
+        difficulty: autoRef.current.difficulty || "beginner",
         description: autoRef.current.description || undefined,
         strain: s
           ? { intensity: s.intensity, load: s.load, durationType: s.duration_type, typicalVolume: s.typical_volume }

--- a/frontend/src/components/exercise/replace/SenseiChatTab.jsx
+++ b/frontend/src/components/exercise/replace/SenseiChatTab.jsx
@@ -1,0 +1,179 @@
+import { useState, useEffect, useRef } from "react";
+import { Sparkles, AlertTriangle, Plus, Send, Loader2 } from "lucide-react";
+import { aiService } from "@/services/aiService";
+import ExerciseResultRow from "./ExerciseResultRow";
+
+// Conversation starters for the empty state — this is where "why do you want
+// to swap" lives now that the modal has no reason-chip row.
+const STARTERS = [
+  "My shoulder hurts on these",
+  "I don't have the equipment",
+  "Want something harder",
+  "Want some variety",
+];
+
+/**
+ * Conversational "Ask the Sensei" tab. History is client-held and
+ * session-scoped (discarded when the modal closes); each turn sends the last
+ * few {role, content} messages and the server re-grounds on the catalog.
+ * Assistant suggestions render as tappable cards that flow through the same
+ * pick pipeline as the Browse tab.
+ */
+export default function SenseiChatTab({ exerciseId, exerciseName, onPickOption, materializingId }) {
+  const [messages, setMessages] = useState([]); // {role, content, options?, routed?}
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [failedMessage, setFailedMessage] = useState(null);
+  const abortRef = useRef(null);
+  const bottomRef = useRef(null);
+
+  useEffect(() => () => { if (abortRef.current) abortRef.current.abort(); }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [messages, sending]);
+
+  const send = async (text) => {
+    const message = (text || "").trim();
+    if (!message || sending) return;
+
+    const history = messages.map((m) => ({ role: m.role, content: m.content }));
+    setMessages((prev) => [...prev, { role: "user", content: message }]);
+    setInput("");
+    setFailedMessage(null);
+    setSending(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      const res = await aiService.substituteChat(
+        { exercise_id: exerciseId, exercise_name: exerciseName, history, message },
+        controller.signal
+      );
+      setMessages((prev) => [...prev, {
+        role: "assistant",
+        content: res?.reply || "…",
+        options: res?.options || [],
+        routed: res?.routed,
+      }]);
+    } catch (err) {
+      if (err?.name === "AbortError") return;
+      // Roll the user message back into the input so nothing typed is lost.
+      setMessages((prev) => prev.slice(0, -1));
+      setInput(message);
+      setFailedMessage(
+        /rate|429|busy/i.test(err?.message || "")
+          ? "The Sensei is busy — try again in a bit, or use the Browse tab."
+          : "Couldn't reach the Sensei. Check your connection and try again."
+      );
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-[40vh]">
+      <div className="flex-1 space-y-4">
+        {messages.length === 0 && !sending && (
+          <div className="text-center py-6">
+            <Sparkles className="w-10 h-10 text-primary-500 mx-auto mb-3" />
+            <p className="text-gray-600 text-sm mb-1">
+              Tell the Sensei why you want to swap “{exerciseName}”.
+            </p>
+            <p className="text-gray-400 text-xs mb-4">e.g. “my knee acts up”, “no bar today”</p>
+            <div className="flex flex-wrap justify-center gap-2">
+              {STARTERS.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => send(s)}
+                  className="px-3 py-1.5 rounded-full text-sm font-medium border bg-white text-gray-600 border-gray-200 hover:border-primary-400 hover:text-primary-600 transition-colors"
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((m, i) => (
+          <div key={i}>
+            {m.role === "user" ? (
+              <div className="flex justify-end">
+                <div className="bg-primary-600 text-white rounded-2xl rounded-br-md px-4 py-2.5 text-sm max-w-[85%]">
+                  {m.content}
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2.5">
+                <div
+                  className={`rounded-2xl rounded-bl-md px-4 py-2.5 text-sm max-w-[92%] ${
+                    m.routed === "safety"
+                      ? "bg-amber-50 border border-amber-200 text-amber-800"
+                      : "bg-gray-100 text-gray-800"
+                  }`}
+                >
+                  {m.routed === "safety" && <AlertTriangle className="w-4 h-4 mb-1.5" />}
+                  {m.content}
+                </div>
+                {m.options?.length > 0 && (
+                  <div className="space-y-2 pl-1">
+                    {m.options.map((opt, j) => (
+                      <ExerciseResultRow
+                        key={opt.id || `${opt.name}-${i}-${j}`}
+                        name={opt.name}
+                        subtitle={opt.note || (opt.muscles || []).join(", ")}
+                        disabled={materializingId === opt.name}
+                        badge={
+                          opt.source === "new" ? (
+                            <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 text-[11px] font-medium">
+                              <Plus className="w-3 h-3" /> New
+                            </span>
+                          ) : null
+                        }
+                        onPick={() => onPickOption(opt)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+
+        {sending && (
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin text-primary-500" />
+            The Sensei is thinking…
+          </div>
+        )}
+
+        {failedMessage && <p className="text-sm text-red-600">{failedMessage}</p>}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input row stays at the bottom of the tab panel */}
+      <form
+        className="flex items-center gap-2 pt-3 mt-2 border-t border-gray-100 sticky bottom-0 bg-white"
+        onSubmit={(e) => { e.preventDefault(); send(input); }}
+      >
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Why do you want to swap?"
+          maxLength={1000}
+          className="flex-1 px-3.5 py-2.5 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
+        />
+        <button
+          type="submit"
+          disabled={!input.trim() || sending}
+          className="p-2.5 bg-primary-600 text-white rounded-xl hover:bg-primary-700 disabled:opacity-40 shrink-0"
+          aria-label="Send"
+        >
+          <Send className="w-4 h-4" />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/services/aiService.js
+++ b/frontend/src/services/aiService.js
@@ -444,6 +444,21 @@ class AIService {
   }
 
   /**
+   * One conversational turn of "Ask the Sensei" exercise substitution.
+   * Stateless: the caller holds the message history ({role, content} only)
+   * and sends it each turn; the server re-grounds on the catalog every time.
+   * @param {{ exercise_id?: string, exercise_name?: string, history?: Array<{role: string, content: string}>, message: string }} params
+   * @returns {Promise<{ reply: string, options?: Array, routed?: string, fallback?: boolean }>}
+   */
+  async substituteChat({ exercise_id, exercise_name, history = [], message }, signal) {
+    return this.request('/api/v1/ai/exercises/substitute/chat', {
+      method: 'POST',
+      body: JSON.stringify({ exercise_id, exercise_name, history: history.slice(-8), message }),
+      ...(signal ? { signal } : {})
+    });
+  }
+
+  /**
    * Clear all cached data (call on logout)
    */
   clearAllCache() {


### PR DESCRIPTION
## Summary
Second PR of the replace-modal redesign (stacked on #140).

- **Conversational "Ask the Sensei" tab** replaces the one-shot ranker: say why you want to swap ("my shoulder hurts", "no bar today"), get free-text coaching plus tappable exercise cards that flow through the same pick/scope pipeline.
  - New stateless `POST /api/v1/exercises/substitute/chat` in ai-coach: client-held history (capped at 8 both sides), re-grounded on the catalog candidate pool every turn; all LLM-proposed options pass the same validation as the ranker (hallucinated ids dropped, "new" fields vocabulary-checked, muscles inherited).
  - Built by extracting `_build_candidate_pool` / `_parse_llm_options` / `_format_candidates` / `_strip_json_fences` from `substitute_rank` (pure refactor — rank behavior unchanged, regression-tested).
  - Safety: first-turn pain/injury gets a deterministic caution that invites a follow-up (conversation continues, unlike rank's dead end); pain anywhere in history keeps fallbacks conservative. LLM failures degrade to catalog-pool options, never 500.
  - GPT-5.6-safe: `llm_tuning_params()` only, `max_completion_tokens`.
- **Backend proxy** following the substitute/rank pattern (auth + shared AI rate limit + 30s timeout), history sliced server-side.
- **Full autofill for on-the-fly exercises**: the suggest/stream module now also emits `difficulty` (was silently missing, so inline-created exercises defaulted to "beginner"); `InlineCreateExercise` consumes it. Benefits the CreateExercise page consumers too.

## Tests
- `pytest`: 548 passed (incl. new `test_substitute_chat.py` — parser validation, pain gates, history truncation, fallbacks, rank regression).
- `jest`: 48 passed (incl. new `substituteChat.test.js` proxying against a real local fake AI server).
- **Playwright end-to-end on the local stack** (pm-test): Browse tab auto-loads Similar + Sensei picks; searching "muscle ups" → Add row → inline form auto-filled by the Sensei (name suggestion, muscles, equipment, description, discipline, strain) → created + swapped via scope step; chat tab: pain first-turn → safety caution → follow-up clarifying question → grounded option cards ("arms low" constraint respected) → card tap → scope step → swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)