### PR TITLE
Fix undismissable success toasts (X dead, no auto-dismiss)

### DIFF
--- a/frontend/src/components/ui/toast.jsx
+++ b/frontend/src/components/ui/toast.jsx
@@ -63,8 +63,9 @@ ToastAction.displayName = "ToastAction";
 const ToastClose = React.forwardRef(({ className, ...props }, ref) => (
   <button
     ref={ref}
+    aria-label="Dismiss"
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-70 transition-opacity hover:text-foreground hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
     toast-close=""

--- a/frontend/src/components/ui/toaster.jsx
+++ b/frontend/src/components/ui/toaster.jsx
@@ -9,13 +9,13 @@ import {
 } from "@/components/ui/toast";
 
 export function Toaster() {
-  const { toasts } = useToast();
+  const { toasts, dismiss } = useToast();
 
   return (
     <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, ...props }) {
+      {toasts.map(function ({ id, title, description, action, open, onOpenChange, ...props }) {
         return (
-          <Toast key={id} {...props}>
+          <Toast key={id} data-state={open ? "open" : "closed"} {...props}>
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && (
@@ -23,11 +23,11 @@ export function Toaster() {
               )}
             </div>
             {action}
-            <ToastClose />
+            <ToastClose onClick={() => dismiss(id)} />
           </Toast>
         );
       })}
       <ToastViewport />
     </ToastProvider>
   );
-} 
+}

--- a/frontend/src/components/ui/use-toast.jsx
+++ b/frontend/src/components/ui/use-toast.jsx
@@ -2,7 +2,10 @@
 import { useState, useEffect, createContext, useContext } from "react";
 
 const TOAST_LIMIT = 20;
-const TOAST_REMOVE_DELAY = 1000000;
+// Time a dismissed (open:false) toast stays mounted so the exit animation can play.
+const TOAST_REMOVE_DELAY = 300;
+// Toasts auto-dismiss; pass { duration } to toast() to override.
+const TOAST_AUTO_DISMISS_MS = 5000;
 
 const actionTypes = {
   ADD_TOAST: "ADD_TOAST",
@@ -110,7 +113,7 @@ function dispatch(action) {
   });
 }
 
-function toast({ ...props }) {
+function toast({ duration = TOAST_AUTO_DISMISS_MS, ...props }) {
   const id = genId();
 
   const update = (props) =>
@@ -133,6 +136,10 @@ function toast({ ...props }) {
       },
     },
   });
+
+  if (duration !== Infinity) {
+    setTimeout(dismiss, duration);
+  }
 
   return {
     id,


### PR DESCRIPTION
## Summary
Fixes the report that the "Workout updated" box after a permanent exercise swap could not be closed — the X did nothing and it couldn't be swiped away.

Root causes (all in the hand-rolled `components/ui/toast` system, so this affected every `toast()` call site, not just the swap flow):
1. `ToastClose` was a plain `<button>` with **no onClick** — it's shadcn-styled markup without Radix, so nothing wires the close automatically. Now calls `dismiss(id)`.
2. `TOAST_REMOVE_DELAY` was `1,000,000` ms and nothing ever dismissed a toast, so it sat on screen for ~17 minutes. Toasts now auto-dismiss after 5s (`toast({ duration })` to override, `Infinity` to pin) and unmount 300ms after dismissal so the exit animation plays.
3. The X was `opacity-0` until mouse hover — invisible on touch devices. Now always visible.
4. `Toaster` spread `open`/`onOpenChange` onto a plain div (React unknown-prop noise); it now maps `open` → `data-state` so the existing animate-in/out classes engage. (The swipe-to-dismiss classes reference Radix data-attrs that don't exist here; swipe remains unsupported.)

## Verification
Playwright against the local stack: performed a "From now on" swap → toast appears → **clicking the X removes it immediately**; repeated swap → toast **auto-dismisses after 5s** and is fully removed from the DOM (verified twice). `npm run build` passes. The pm-test template used for verification was swapped back to its original state (confirmed in DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)