### PR TITLE
Fix substitute chat always falling back in prod (non-JSON replies)

### DIFF
--- a/ai-coach-service/app/api/v1/exercises.py
+++ b/ai-coach-service/app/api/v1/exercises.py
@@ -677,9 +677,18 @@ async def substitute_chat(
         original_muscles=", ".join((original or {}).get("muscles", []) or []) or "n/a",
         candidates_block=candidates_block,
     )
+    # Replay assistant turns in the SAME JSON shape the contract demands.
+    # The client stores them as plain text (the rendered reply); echoing that
+    # verbatim teaches the model to answer in prose, which breaks parsing —
+    # and each failed turn adds more prose to history, so it never recovers.
+    def _history_message(m: SubstituteChatMessage) -> Dict[str, str]:
+        if m.role == "assistant":
+            return {"role": "assistant", "content": json.dumps({"reply": m.content, "options": []})}
+        return {"role": m.role, "content": m.content}
+
     messages = (
         [{"role": "system", "content": system_prompt}]
-        + [{"role": m.role, "content": m.content} for m in history]
+        + [_history_message(m) for m in history]
         + [{"role": "user", "content": request.message}]
     )
 
@@ -689,11 +698,22 @@ async def substitute_chat(
         response = await client.chat.completions.create(
             model=settings.openai_model_fast,
             messages=messages,
-            max_completion_tokens=700,
+            # Roomy cap: in environments with reasoning_effort != "none",
+            # reasoning tokens draw from this same budget before any output.
+            max_completion_tokens=2000,
             **settings.llm_tuning_params(temperature=0.4),
         )
-        content = _strip_json_fences(response.choices[0].message.content)
-        data = json.loads(content)
+        content = _strip_json_fences(response.choices[0].message.content or "")
+        if not content:
+            raise ValueError("LLM returned empty content")
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            # The model answered in prose despite the contract. That text IS a
+            # usable coaching reply — surface it (options only ever come from
+            # validated JSON, so none here) instead of the fallback message.
+            logger.warning("substitute_chat got non-JSON reply, using as plain text")
+            return SubstituteChatResponse(reply=content)
         reply = (data.get("reply") or "").strip()
         if not reply:
             raise ValueError("LLM returned no reply text")

--- a/ai-coach-service/tests/test_substitute_chat.py
+++ b/ai-coach-service/tests/test_substitute_chat.py
@@ -178,6 +178,61 @@ class TestSubstituteChat:
         assert res.options == []
         assert res.fallback is True
 
+    async def test_non_json_reply_is_used_as_plain_text(self, monkeypatch):
+        _mock_db(monkeypatch)
+        captured = {}
+
+        async def create(**kwargs):
+            captured.update(kwargs)
+            response = MagicMock()
+            response.choices[0].message.content = "Try chin-ups instead, they keep the same pull pattern."
+            return response
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(side_effect=create)
+        monkeypatch.setattr(ex, "AsyncOpenAI", MagicMock(return_value=client))
+
+        req = ex.SubstituteChatRequest(message="I want variety", exercise_id=str(ORIGINAL_ID))
+        res = await ex.substitute_chat(req, CURRENT_USER)
+        assert res.reply.startswith("Try chin-ups")
+        assert res.options == []
+        assert res.fallback is False
+
+    async def test_assistant_history_replayed_as_json(self, monkeypatch):
+        _mock_db(monkeypatch)
+        captured, _ = _mock_openai(monkeypatch, payload={"reply": "ok", "options": []})
+        req = ex.SubstituteChatRequest(
+            message="so what instead?",
+            history=[{"role": "user", "content": "I want variety"},
+                     {"role": "assistant", "content": "What equipment do you have?"}],
+            exercise_id=str(ORIGINAL_ID),
+        )
+        await ex.substitute_chat(req, CURRENT_USER)
+        assistant_turn = captured["messages"][2]
+        assert assistant_turn["role"] == "assistant"
+        assert json.loads(assistant_turn["content"]) == {"reply": "What equipment do you have?", "options": []}
+        # User turns stay verbatim.
+        assert captured["messages"][1]["content"] == "I want variety"
+
+    async def test_empty_llm_content_falls_back(self, monkeypatch):
+        _mock_db(monkeypatch)
+        captured = {}
+
+        async def create(**kwargs):
+            captured.update(kwargs)
+            response = MagicMock()
+            response.choices[0].message.content = ""
+            return response
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(side_effect=create)
+        monkeypatch.setattr(ex, "AsyncOpenAI", MagicMock(return_value=client))
+
+        req = ex.SubstituteChatRequest(message="I want variety", exercise_id=str(ORIGINAL_ID))
+        res = await ex.substitute_chat(req, CURRENT_USER)
+        assert res.fallback is True
+        assert [o.name for o in res.options] == ["Chin-up"]
+
     async def test_unresolvable_exercise_still_chats_without_pool(self, monkeypatch):
         _mock_db(monkeypatch, original=None)
         captured, _ = _mock_openai(monkeypatch, payload={"reply": "Try weighted dips.", "options": []})


### PR DESCRIPTION
## Summary
In the deployed app, every "Ask the Sensei" chat turn showed "I couldn't think that through just now — here are the closest matches from your catalog." Render logs pinpointed it: `substitute_chat LLM failure, degrading: Expecting value: line 1 column 1 (char 0)` — the model's reply wasn't parseable JSON.

Root causes and fixes:
1. **Assistant history replayed as prose.** The client stores assistant turns as rendered text (safety caution, previous replies); echoing that verbatim taught the model to answer in prose instead of the JSON contract — and every failed turn added more prose to history, so the failure was self-reinforcing. Assistant turns are now replayed as `{"reply": …, "options": []}` JSON.
2. **Usable prose was discarded.** A non-JSON reply is a perfectly good coaching reply — it's now surfaced as the reply text (with no options, since options only ever come from validated JSON). Only genuinely empty content falls back to catalog matches.
3. **Token headroom.** `max_completion_tokens` 700 → 2000: prod runs with `reasoning_effort != "none"`, where reasoning tokens draw from the same budget before any visible output.

Explains why the one-shot rank endpoint (Sensei picks) was unaffected in prod: it has no conversational history to poison the format.

## Tests
- `pytest`: 551 passed, incl. new cases: non-JSON reply used as plain text, assistant history serialized as JSON, empty content → fallback.
- Will verify against the deployed app after auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)