### PR TITLE
Open replace modal phone-sized like other cards

### DIFF
--- a/frontend/src/components/exercise/ReplaceExerciseModal.jsx
+++ b/frontend/src/components/exercise/ReplaceExerciseModal.jsx
@@ -62,7 +62,7 @@ export default function ReplaceExerciseModal({ exercise, onClose, onReplace, can
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[55] flex items-end sm:items-center justify-center sm:p-4">
-      <div className="bg-white rounded-t-3xl sm:rounded-2xl shadow-2xl w-full sm:max-w-lg max-h-[92vh] flex flex-col">
+      <div className="bg-white rounded-t-3xl sm:rounded-2xl shadow-2xl w-full sm:max-w-lg max-h-[85vh] flex flex-col">
         {/* Header */}
         <div className="p-5 border-b border-gray-100">
           <div className="flex items-start justify-between gap-3">

--- a/frontend/src/components/exercise/replace/SenseiChatTab.jsx
+++ b/frontend/src/components/exercise/replace/SenseiChatTab.jsx
@@ -73,8 +73,10 @@ export default function SenseiChatTab({ exerciseId, exerciseName, onPickOption, 
   };
 
   return (
-    <div className="flex flex-col min-h-[40vh]">
-      <div className="flex-1 space-y-4">
+    // Content-sized: the panel hugs the conversation so the sheet opens small
+    // (like the app's other cards) and only grows as messages accumulate.
+    <div className="flex flex-col">
+      <div className="space-y-4">
         {messages.length === 0 && !sending && (
           <div className="text-center py-6">
             <Sparkles className="w-10 h-10 text-primary-500 mx-auto mb-3" />


### PR DESCRIPTION
## Summary
Fixes the replace modal opening nearly full-screen on phones (user report with screenshot). The chat tab forced a `min-h-[40vh]` panel with a flex spacer pushing the input to the bottom — one message produced a huge empty gap, and with the iOS keyboard up the sheet covered the whole screen. The panel is now content-sized (grows with the conversation, scrolls at the cap) and the sheet max height drops 92vh → 85vh to match the app's other modal cards.

Verified with Playwright at 390×844: the sheet now opens as a compact bottom card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)