### PR TITLE
Stop iOS zoom-in on replace-modal inputs

### DIFF
--- a/frontend/src/components/chat/MiniCoachChat.jsx
+++ b/frontend/src/components/chat/MiniCoachChat.jsx
@@ -247,7 +247,7 @@ export default function MiniCoachChat({
           onChange={(e) => setInput(e.target.value)}
           placeholder="Why do you want to swap?"
           maxLength={1000}
-          className="flex-1 px-3.5 py-2.5 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
+          className="flex-1 px-3.5 py-2.5 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-base sm:text-sm"
         />
         <button
           type="submit"

--- a/frontend/src/components/exercise/replace/InlineCreateExercise.jsx
+++ b/frontend/src/components/exercise/replace/InlineCreateExercise.jsx
@@ -160,7 +160,7 @@ export default function InlineCreateExercise({ initialName, onCreated, onCancel 
           value={equipment}
           onChange={(e) => { touchedRef.current.equipment = true; setEquipment(e.target.value); }}
           placeholder="e.g. pull-up bar, rings (leave empty for none)"
-          className="w-full px-3 py-2.5 border border-gray-300 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
+          className="w-full px-3 py-2.5 border border-gray-300 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-base sm:text-sm"
         />
       </div>
 


### PR DESCRIPTION
## Summary
Typing in the replace modal on iPhone zoomed the page in and left it zoomed (user report). iOS Safari auto-zooms any focused input with a font size below 16px. Two inputs were `text-sm` (14px): the Sensei chat input and the inline-create equipment field — the app's other forms (e.g. CreateExercise) use the 16px default, which is why they don't zoom. Both are now `text-base sm:text-sm`: 16px on phones (no zoom), unchanged compact size on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)