### PR TITLE
Swap card: both scopes + stay in conversation; delete-for-good

### DIFF
--- a/backend/src/routes/__tests__/removeExercise.test.js
+++ b/backend/src/routes/__tests__/removeExercise.test.js
@@ -1,0 +1,169 @@
+jest.mock('../../middleware/auth', () => ({
+  auth: (req, res, next) => {
+    req.user = { id: 'aaaaaaaaaaaaaaaaaaaaaaaa', role: 'user' };
+    next();
+  },
+  optionalAuth: (req, res, next) => next()
+}));
+jest.mock('../../services/WorkoutService', () => ({}));
+jest.mock('../../models/CalendarEvent', () => ({
+  updateMany: jest.fn().mockResolvedValue({}),
+  countDocuments: jest.fn().mockResolvedValue(0)
+}));
+jest.mock('../../models/Plan', () => ({
+  updateMany: jest.fn().mockResolvedValue({})
+}));
+jest.mock('../../models/Exercise', () => ({
+  findOne: jest.fn()
+}));
+jest.mock('../../models/UserWorkoutModification', () => ({
+  findOne: jest.fn()
+}));
+jest.mock('../../models/PredefinedWorkout', () => {
+  const ctor = jest.fn();
+  ctor.findById = jest.fn();
+  return ctor;
+});
+
+const express = require('express');
+const request = require('supertest');
+const PredefinedWorkout = require('../../models/PredefinedWorkout');
+const CalendarEvent = require('../../models/CalendarEvent');
+const Plan = require('../../models/Plan');
+const UserWorkoutModification = require('../../models/UserWorkoutModification');
+const router = require('../predefinedWorkouts');
+
+const app = express();
+app.use(express.json());
+app.use('/', router);
+
+const USER_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const TARGET_EX = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+const OTHER_EX = 'ffffffffffffffffffffffff';
+const WORKOUT_ID = 'dddddddddddddddddddddddd';
+const CLONE_ID = 'eeeeeeeeeeeeeeeeeeeeeeee';
+
+const makeBlocks = () => [
+  {
+    name: 'Warm-up',
+    exercises: [{ exercise_id: TARGET_EX, exercise_name: 'Plank', volume: '2x30s', rest: '30s', notes: '' }]
+  },
+  {
+    name: 'Main Work',
+    exercises: [
+      { exercise_id: TARGET_EX, exercise_name: 'Plank', volume: '3x60s', rest: '60s', notes: '' },
+      { exercise_id: OTHER_EX, exercise_name: 'Squat', volume: '3x5', rest: '120s', notes: '' }
+    ]
+  }
+];
+
+const makeWorkout = ({ ownedByUser, isCommon, blocks = makeBlocks() }) => {
+  const workout = {
+    _id: WORKOUT_ID,
+    name: 'Core Day',
+    isCommon,
+    createdBy: ownedByUser ? USER_ID : 'a1a1a1a1a1a1a1a1a1a1a1a1',
+    blocks,
+    canUserEdit(userId) {
+      return !this.isCommon && this.createdBy === userId;
+    },
+    save: jest.fn().mockResolvedValue(undefined)
+  };
+  workout.toObject = () => JSON.parse(JSON.stringify({ ...workout, save: undefined, toObject: undefined }));
+  return workout;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  UserWorkoutModification.findOne.mockResolvedValue(null);
+  PredefinedWorkout.mockImplementation(function (data) {
+    Object.assign(this, JSON.parse(JSON.stringify(data)));
+    this._id = CLONE_ID;
+    this.save = jest.fn().mockResolvedValue(undefined);
+    this.toObject = () => JSON.parse(JSON.stringify({ ...this, save: undefined, toObject: undefined }));
+  });
+});
+
+describe('POST /:id/remove-exercise', () => {
+  it('400s without exerciseId', async () => {
+    const res = await request(app).post(`/${WORKOUT_ID}/remove-exercise`).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('removes all occurrences in-place on an own template and drops emptied blocks', async () => {
+    const workout = makeWorkout({ ownedByUser: true, isCommon: false });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/remove-exercise`)
+      .send({ exerciseId: TARGET_EX });
+
+    expect(res.status).toBe(200);
+    expect(res.body.cloned).toBe(false);
+    expect(res.body.removedCount).toBe(2);
+    // Warm-up block became empty and was dropped; Main Work keeps the squat.
+    expect(workout.blocks).toHaveLength(1);
+    expect(workout.blocks[0].exercises.map(e => e.exercise_name)).toEqual(['Squat']);
+    expect(workout.save).toHaveBeenCalled();
+  });
+
+  it('clones a common template and relinks calendar + plan references', async () => {
+    const workout = makeWorkout({ ownedByUser: false, isCommon: true });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/remove-exercise`)
+      .send({ exerciseId: TARGET_EX });
+
+    expect(res.status).toBe(200);
+    expect(res.body.cloned).toBe(true);
+    expect(res.body.workout.isCommon).toBe(false);
+    expect(res.body.workout.createdBy).toBe(USER_ID);
+    expect(workout.save).not.toHaveBeenCalled(); // original untouched
+    expect(CalendarEvent.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ workoutTemplateId: WORKOUT_ID }),
+      { $set: { workoutTemplateId: CLONE_ID } }
+    );
+    expect(Plan.updateMany).toHaveBeenCalled();
+  });
+
+  it('400s when the exercise is not in the workout', async () => {
+    const workout = makeWorkout({ ownedByUser: true, isCommon: false });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/remove-exercise`)
+      .send({ exerciseId: 'cccccccccccccccccccccccc' });
+
+    expect(res.status).toBe(400);
+    expect(workout.save).not.toHaveBeenCalled();
+  });
+
+  it('refuses to remove the last remaining exercise', async () => {
+    const workout = makeWorkout({
+      ownedByUser: true,
+      isCommon: false,
+      blocks: [{ name: 'Only', exercises: [{ exercise_id: TARGET_EX, exercise_name: 'Plank', volume: '3x60s', rest: '', notes: '' }] }]
+    });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/remove-exercise`)
+      .send({ exerciseId: TARGET_EX });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/empty/i);
+    expect(workout.save).not.toHaveBeenCalled();
+  });
+
+  it('403s on someone else\'s private workout', async () => {
+    const workout = makeWorkout({ ownedByUser: false, isCommon: false });
+    PredefinedWorkout.findById.mockResolvedValue(workout);
+
+    const res = await request(app)
+      .post(`/${WORKOUT_ID}/remove-exercise`)
+      .send({ exerciseId: TARGET_EX });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/src/routes/predefinedWorkouts.js
+++ b/backend/src/routes/predefinedWorkouts.js
@@ -300,12 +300,78 @@ router.post('/:id/rate', auth, async (req, res) => {
   }
 });
 
-// POST /api/predefined-workouts/:id/swap-exercise - Replace an exercise in the
-// template "for good". Own template: edited in place. Common template: cloned
-// into a private copy (clone-on-modify) and the user's live references
-// (upcoming calendar events, active plan weeks, modification row) move to the
+// --- Clone-on-modify machinery, shared by swap-exercise and remove-exercise ---
+// A common template can't be edited in place: it's forked into a private copy,
+// the user's field-override modification row is baked in and moved, and their
+// live references (upcoming calendar events, active plan weeks) relink to the
 // clone. Completed/skipped history intentionally keeps pointing at the
 // original.
+
+async function buildUserClone(workout, userId) {
+  const cloneData = workout.toObject();
+  delete cloneData._id;
+  delete cloneData.createdAt;
+  delete cloneData.updatedAt;
+  delete cloneData.__v;
+  cloneData.createdBy = userId;
+  cloneData.isCommon = false;
+  cloneData.popularity = 0;
+  cloneData.ratings = { average: 0, count: 0 };
+
+  // The user's modification overlay (custom title/description/duration +
+  // favorite/PR metadata) is applied on every read — bake the field
+  // overrides into the clone and move the row so the metadata follows.
+  const UserWorkoutModification = require('../models/UserWorkoutModification');
+  const modification = await UserWorkoutModification.findOne({
+    userId,
+    workoutId: workout._id
+  });
+  if (modification?.modifications) {
+    if (modification.modifications.title) cloneData.name = modification.modifications.title;
+    if (modification.modifications.description) cloneData.goal = modification.modifications.description;
+    if (modification.modifications.durationMinutes) {
+      cloneData.estimated_duration = modification.modifications.durationMinutes;
+    }
+  }
+  return { cloneData, modification };
+}
+
+async function relinkUserReferences(workout, clone, modification, userId) {
+  if (modification) {
+    modification.workoutId = clone._id;
+    // Field overrides are baked into the clone now; keeping them on the row
+    // would double-apply if the user later edits the clone directly.
+    if (modification.modifications) {
+      modification.modifications.title = undefined;
+      modification.modifications.description = undefined;
+      modification.modifications.durationMinutes = undefined;
+      modification.markModified('modifications');
+    }
+    await modification.save();
+  }
+
+  // Move the user's live references to the fork so "for good" holds for
+  // already-scheduled sessions and plan-driven scheduling.
+  await CalendarEvent.updateMany(
+    {
+      userId,
+      workoutTemplateId: workout._id,
+      status: { $in: ['scheduled', 'in_progress'] }
+    },
+    { $set: { workoutTemplateId: clone._id } }
+  );
+
+  const Plan = require('../models/Plan');
+  await Plan.updateMany(
+    { userId, 'weeks.workouts.predefinedWorkoutId': workout._id },
+    { $set: { 'weeks.$[].workouts.$[w].predefinedWorkoutId': clone._id } },
+    { arrayFilters: [{ 'w.predefinedWorkoutId': workout._id }] }
+  );
+}
+
+// POST /api/predefined-workouts/:id/swap-exercise - Replace an exercise in the
+// template "for good". Own template: edited in place. Common template:
+// clone-on-modify (see above).
 router.post('/:id/swap-exercise', auth, async (req, res) => {
   try {
     const { fromExerciseId, toExerciseId } = req.body;
@@ -359,73 +425,88 @@ router.post('/:id/swap-exercise', auth, async (req, res) => {
     }
 
     // Common template: clone-on-modify.
-    const cloneData = workout.toObject();
-    delete cloneData._id;
-    delete cloneData.createdAt;
-    delete cloneData.updatedAt;
-    delete cloneData.__v;
-    cloneData.createdBy = req.user.id;
-    cloneData.isCommon = false;
-    cloneData.popularity = 0;
-    cloneData.ratings = { average: 0, count: 0 };
-
-    // The user's modification overlay (custom title/description/duration +
-    // favorite/PR metadata) is applied on every read — bake the field
-    // overrides into the clone and move the row so the metadata follows.
-    const UserWorkoutModification = require('../models/UserWorkoutModification');
-    const modification = await UserWorkoutModification.findOne({
-      userId: req.user.id,
-      workoutId: workout._id
-    });
-    if (modification?.modifications) {
-      if (modification.modifications.title) cloneData.name = modification.modifications.title;
-      if (modification.modifications.description) cloneData.goal = modification.modifications.description;
-      if (modification.modifications.durationMinutes) {
-        cloneData.estimated_duration = modification.modifications.durationMinutes;
-      }
-    }
-
+    const { cloneData, modification } = await buildUserClone(workout, req.user.id);
     const clone = new PredefinedWorkout(cloneData);
     const replacedCount = applySwap(clone);
     if (replacedCount === 0) {
       return res.status(400).json({ error: 'Exercise not found in this workout' });
     }
     await clone.save();
-
-    if (modification) {
-      modification.workoutId = clone._id;
-      // Field overrides are baked into the clone now; keeping them on the row
-      // would double-apply if the user later edits the clone directly.
-      if (modification.modifications) {
-        modification.modifications.title = undefined;
-        modification.modifications.description = undefined;
-        modification.modifications.durationMinutes = undefined;
-        modification.markModified('modifications');
-      }
-      await modification.save();
-    }
-
-    // Move the user's live references to the fork so "for good" holds for
-    // already-scheduled sessions and plan-driven scheduling.
-    await CalendarEvent.updateMany(
-      {
-        userId: req.user.id,
-        workoutTemplateId: workout._id,
-        status: { $in: ['scheduled', 'in_progress'] }
-      },
-      { $set: { workoutTemplateId: clone._id } }
-    );
-
-    const Plan = require('../models/Plan');
-    await Plan.updateMany(
-      { userId: req.user.id, 'weeks.workouts.predefinedWorkoutId': workout._id },
-      { $set: { 'weeks.$[].workouts.$[w].predefinedWorkoutId': clone._id } },
-      { arrayFilters: [{ 'w.predefinedWorkoutId': workout._id }] }
-    );
+    await relinkUserReferences(workout, clone, modification, req.user.id);
 
     const cloneObj = clone.toObject();
     cloneObj.id = cloneObj._id;
     return res.json({ workout: cloneObj, cloned: true, replacedCount });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// POST /api/predefined-workouts/:id/remove-exercise - Delete an exercise from
+// the template "for good" (all occurrences). Own template: edited in place.
+// Common template: clone-on-modify. Refuses to leave the workout empty.
+router.post('/:id/remove-exercise', auth, async (req, res) => {
+  try {
+    const { exerciseId } = req.body;
+    if (!exerciseId) {
+      return res.status(400).json({ error: 'exerciseId is required' });
+    }
+
+    const workout = await PredefinedWorkout.findById(req.params.id);
+    if (!workout) {
+      return res.status(404).json({ error: 'Predefined workout not found' });
+    }
+
+    if (!workout.canUserEdit(req.user.id) && !workout.isCommon) {
+      return res.status(403).json({ error: 'You can only modify your own workouts' });
+    }
+
+    // Remove every occurrence; drop any block the removal leaves empty.
+    const applyRemove = (doc) => {
+      let removedCount = 0;
+      for (const block of doc.blocks || []) {
+        const before = (block.exercises || []).length;
+        block.exercises = (block.exercises || []).filter(
+          ex => ex.exercise_id?.toString() !== exerciseId.toString()
+        );
+        removedCount += before - block.exercises.length;
+      }
+      doc.blocks = (doc.blocks || []).filter(b => (b.exercises || []).length > 0);
+      return removedCount;
+    };
+
+    const wouldEmpty = (doc) => (doc.blocks || []).length === 0;
+
+    if (workout.canUserEdit(req.user.id)) {
+      const removedCount = applyRemove(workout);
+      if (removedCount === 0) {
+        return res.status(400).json({ error: 'Exercise not found in this workout' });
+      }
+      if (wouldEmpty(workout)) {
+        return res.status(400).json({ error: 'Removing this would leave the workout empty' });
+      }
+      await workout.save();
+      const workoutObj = workout.toObject();
+      workoutObj.id = workoutObj._id;
+      return res.json({ workout: workoutObj, cloned: false, removedCount });
+    }
+
+    // Common template: clone-on-modify.
+    const { cloneData, modification } = await buildUserClone(workout, req.user.id);
+    const clone = new PredefinedWorkout(cloneData);
+    const removedCount = applyRemove(clone);
+    if (removedCount === 0) {
+      return res.status(400).json({ error: 'Exercise not found in this workout' });
+    }
+    if (wouldEmpty(clone)) {
+      return res.status(400).json({ error: 'Removing this would leave the workout empty' });
+    }
+    await clone.save();
+    await relinkUserReferences(workout, clone, modification, req.user.id);
+
+    const cloneObj = clone.toObject();
+    cloneObj.id = cloneObj._id;
+    return res.json({ workout: cloneObj, cloned: true, removedCount });
   } catch (error) {
     res.status(500).json({ error: error.message });
   }

--- a/frontend/src/components/chat/ExerciseSwapCard.jsx
+++ b/frontend/src/components/chat/ExerciseSwapCard.jsx
@@ -43,7 +43,10 @@ export default function ExerciseSwapCard({ payload }) {
     }
   };
 
-  const offerPermanent = Boolean(card.offerPermanent && old.id && swap?.canPersist);
+  // Both scopes are always offered when the session is template-linked; the
+  // skill's offerPermanent flag is advisory only (the user asked for the
+  // permanent option to be available regardless).
+  const offerPermanent = Boolean(old.id && swap?.canPersist);
 
   return (
     <span className="not-prose block my-2 max-w-sm">

--- a/frontend/src/pages/LiveWorkout.jsx
+++ b/frontend/src/pages/LiveWorkout.jsx
@@ -639,16 +639,53 @@ export default function LiveWorkout() {
     setConfirmDelete({ index: exIndex, exercise: workout.exercises[exIndex] });
   };
 
-  const performDeleteExercise = (exIndex) => {
+  const performDeleteExercise = (exIndex, opts = {}) => {
     const removed = workout.exercises[exIndex];
     const nextExercises = withOrder(workout.exercises.filter((_, i) => i !== exIndex));
     setWorkout({ ...workout, exercises: nextExercises });
     setConfirmDelete(null);
+    if (navigator.vibrate) navigator.vibrate(40);
+
+    if (opts.permanent && workout.sourceWorkoutId && removed.exercise_id) {
+      // Template changed too — an undo would silently diverge from it, so the
+      // permanent path reports via toast instead of offering undo.
+      persistRemoveFromTemplate(workout.sourceWorkoutId, removed);
+      return;
+    }
+
     // Offer an undo for a few seconds (restores the exercise with its logged sets).
     if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
     setUndoState({ exercise: removed, index: exIndex });
     undoTimerRef.current = setTimeout(() => setUndoState(null), 6000);
-    if (navigator.vibrate) navigator.vibrate(40);
+  };
+
+  // Persist a deletion to the source template ("from now on"). Mirrors
+  // persistReplaceToTemplate: the session change already happened and is never
+  // rolled back; only the template write is reported.
+  const persistRemoveFromTemplate = async (sourceWorkoutId, removed) => {
+    try {
+      const result = await apiService.predefinedWorkouts.removeExercise(sourceWorkoutId, {
+        exerciseId: removed.exercise_id,
+      });
+      if (result?.cloned) {
+        setWorkout(w => ({ ...w, sourceWorkoutId: result.workout._id, sourceWorkoutIsCommon: false }));
+        toast({
+          title: "Saved to your workouts",
+          description: `Created your own copy of “${result.workout.name}” without “${removed.exercise_name}”.`,
+        });
+      } else {
+        toast({
+          title: "Workout updated",
+          description: `“${removed.exercise_name}” is no longer part of this workout.`,
+        });
+      }
+    } catch (error) {
+      console.error('[LiveWorkout] Failed to persist removal to template:', error);
+      const description = /empty/i.test(error?.message || '')
+        ? "It was removed from this session, but a workout can't be left empty — it wasn't changed."
+        : "It was removed from this session, but saving that to the workout failed. Try again from the Workouts page.";
+      toast({ title: "Session updated, workout not", description, variant: "destructive" });
+    }
   };
 
   const handleUndoDelete = () => {
@@ -718,7 +755,8 @@ export default function LiveWorkout() {
     };
     const nextExercises = workout.exercises.map((e, i) => (i === exIndex ? nextExercise : e));
     setWorkout({ ...workout, exercises: withOrder(nextExercises) });
-    setReplaceIndex(null);
+    // Card applies keep the modal (and the coach conversation) open.
+    if (!opts.keepOpen) setReplaceIndex(null);
     if (navigator.vibrate) navigator.vibrate(30);
 
     if (opts.permanent && workout.sourceWorkoutId && old.exercise_id) {
@@ -759,7 +797,7 @@ export default function LiveWorkout() {
         equipment: payload.new?.equipment || [],
       });
     }
-    handleReplaceExercise(idx, picked, { permanent: Boolean(permanent) });
+    handleReplaceExercise(idx, picked, { permanent: Boolean(permanent), keepOpen: true });
   };
 
   const handleAddExercise = (exIndex, position, picked) => {
@@ -956,29 +994,63 @@ export default function LiveWorkout() {
         </DrawerContent>
       </Drawer>
 
-      {/* Delete confirmation */}
+      {/* Delete confirmation — offers the same scope choice as replace when
+          the session is template-linked. */}
       {confirmDelete && (
         <div className="fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4">
           <div className="bg-white rounded-2xl p-6 w-full max-w-sm shadow-2xl">
             <h3 className="text-lg font-bold text-gray-900 mb-2">Delete exercise?</h3>
-            <p className="text-sm text-gray-600 mb-5">
-              Remove <span className="font-semibold">{confirmDelete.exercise?.exercise_name}</span> from
-              this workout? You can undo right after.
-            </p>
-            <div className="flex gap-3">
-              <button
-                onClick={() => setConfirmDelete(null)}
-                className="flex-1 py-3 rounded-xl font-semibold bg-gray-100 text-gray-700"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => performDeleteExercise(confirmDelete.index)}
-                className="flex-1 py-3 rounded-xl font-semibold bg-red-600 text-white"
-              >
-                Delete
-              </button>
-            </div>
+            {Boolean(workout.sourceWorkoutId && confirmDelete.exercise?.exercise_id) ? (
+              <>
+                <p className="text-sm text-gray-600 mb-5">
+                  Remove <span className="font-semibold">{confirmDelete.exercise?.exercise_name}</span> — for how long?
+                </p>
+                <div className="space-y-2.5">
+                  <button
+                    onClick={() => performDeleteExercise(confirmDelete.index)}
+                    className="w-full py-3 rounded-xl font-semibold bg-red-600 text-white"
+                  >
+                    Just this session
+                  </button>
+                  <button
+                    onClick={() => performDeleteExercise(confirmDelete.index, { permanent: true })}
+                    className="w-full py-3 rounded-xl font-semibold bg-white border border-red-300 text-red-700"
+                  >
+                    From now on
+                    <span className="block text-xs font-normal text-red-400 mt-0.5">
+                      {workout.sourceWorkoutIsCommon ? "Creates your own copy of this workout" : "Updates this workout"}
+                    </span>
+                  </button>
+                  <button
+                    onClick={() => setConfirmDelete(null)}
+                    className="w-full text-sm text-gray-500 py-1.5 hover:text-gray-700"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-gray-600 mb-5">
+                  Remove <span className="font-semibold">{confirmDelete.exercise?.exercise_name}</span> from
+                  this workout? You can undo right after.
+                </p>
+                <div className="flex gap-3">
+                  <button
+                    onClick={() => setConfirmDelete(null)}
+                    className="flex-1 py-3 rounded-xl font-semibold bg-gray-100 text-gray-700"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() => performDeleteExercise(confirmDelete.index)}
+                    className="flex-1 py-3 rounded-xl font-semibold bg-red-600 text-white"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -266,6 +266,11 @@ class APIService {
       method: 'POST',
       body: JSON.stringify(data)
     }),
+    // Returns { workout, cloned, removedCount } — same bare-object convention.
+    removeExercise: (id, data) => this.request(`/predefined-workouts/${id}/remove-exercise`, {
+      method: 'POST',
+      body: JSON.stringify(data)
+    }),
     favorite: (id) => this.request(`/predefined-workouts/${id}/favorite`, {
       method: 'PUT'
     })


### PR DESCRIPTION
## Summary
Three follow-ups on the coach swap card and in-workout delete (user requests):

1. **"Apply + update workout" is always available** when the session is template-linked — previously it only appeared when the model flagged the reason as recurring or pain was involved.
2. **Applying from the card keeps the conversation open** — the card flips to "Swapped in ✓" and you can keep chatting; previously it kicked you out of the modal.
3. **Delete gets a "From now on" scope**, mirroring replace: new `POST /predefined-workouts/:id/remove-exercise` (removes all occurrences, drops blocks left empty, refuses to leave the workout empty, clone-on-modify for common templates with calendar/plan/modification-row relinking). The clone machinery is extracted into shared `buildUserClone`/`relinkUserReferences` helpers used by both swap and remove. Session-only delete keeps its undo; the permanent path reports via toast (undo would silently diverge from the updated template).

## Tests
- Backend: 54 jest (6 new: in-place removal + emptied-block drop, common-template clone + relink, not-found 400, empty-workout guard, 403). Swap tests stay green after the helper extraction.
- Playwright: delete dialog shows the scope step on a template-linked session (session path + undo verified); a plain variety request produced a card with both buttons; Apply swapped the exercise, showed "Swapped in ✓", and left the conversation open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)