### PR TITLE
Sport interests 1/4: Training Interests picker + profile write hardening

### DIFF
--- a/backend/src/config/disciplines.js
+++ b/backend/src/config/disciplines.js
@@ -1,0 +1,70 @@
+/**
+ * Canonical discipline vocabulary — backend mirror.
+ *
+ * The canonical source is ai-coach-service/app/core/disciplines.py; keep the
+ * two lists identical (same values, same order). A "discipline" is the SPORT
+ * a session belongs to. ADDITIVE ONLY: values are persisted on user profiles,
+ * exercises, session templates and session logs, so removing or renaming a
+ * value orphans real user data.
+ */
+
+const DISCIPLINES = [
+  'strength',
+  'cardio',
+  'hiit',
+  'hybrid',
+  'recovery',
+  'mobility',
+  'flexibility',
+  'calisthenics',
+  'running',
+  'cycling',
+  'climbing',
+  'swimming',
+  'walking',
+  'yoga',
+  'meditation',
+];
+
+const DISCIPLINE_SET = new Set(DISCIPLINES);
+
+/**
+ * Known legacy synonyms → canonical values. This is the single pinned list;
+ * the discipline-classification script's deterministic pass uses the same
+ * semantics. Legacy values that need per-document judgment (warm_up, core,
+ * corrective, balance, stability, General Fitness) are deliberately absent —
+ * they were resolved one-by-one by the classification migration and are
+ * rejected on new writes.
+ */
+const LEGACY_DISCIPLINE_MAP = {
+  endurance: 'cardio',
+  conditioning: 'cardio',
+  powerlifting: 'strength',
+  power: 'strength',
+  'strength training': 'strength',
+};
+
+/**
+ * Lowercase, map known legacy synonyms, dedupe. Values that are neither
+ * canonical nor mapped are kept as-is (lowercased) so callers can detect and
+ * reject them.
+ */
+const normalizeDisciplines = (values) => {
+  if (!Array.isArray(values)) return [];
+  const out = [];
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const lower = value.trim().toLowerCase();
+    if (!lower) continue;
+    const canonical = LEGACY_DISCIPLINE_MAP[lower] || lower;
+    if (!out.includes(canonical)) out.push(canonical);
+  }
+  return out;
+};
+
+module.exports = {
+  DISCIPLINES,
+  DISCIPLINE_SET,
+  LEGACY_DISCIPLINE_MAP,
+  normalizeDisciplines,
+};

--- a/backend/src/controllers/__tests__/updateProfileProfile.test.js
+++ b/backend/src/controllers/__tests__/updateProfileProfile.test.js
@@ -1,0 +1,92 @@
+jest.mock('../../models/User', () => ({
+  findByIdAndUpdate: jest.fn()
+}));
+jest.mock('../../utils/invalidateTodaysPick', () => ({
+  invalidateTodaysPick: jest.fn()
+}));
+
+const User = require('../../models/User');
+const { updateProfile } = require('../authController');
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const makeReq = (profile) => ({
+  body: { profile },
+  user: { _id: 'user-1', settings: {}, profile: {} }
+});
+
+const savedUser = { _id: 'user-1', settings: {}, profile: {} };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  User.findByIdAndUpdate.mockResolvedValue(savedUser);
+});
+
+describe('updateProfile profile writes', () => {
+  test('plain keys become dot-path sets; omitted keys are not written at all', async () => {
+    await updateProfile(
+      makeReq({ sportPreferences: ['climbing', 'yoga'], goals: ['20 pull-ups'] }),
+      makeRes()
+    );
+
+    const updateData = User.findByIdAndUpdate.mock.calls[0][1];
+    expect(updateData['profile.sportPreferences']).toEqual(['climbing', 'yoga']);
+    expect(updateData['profile.goals']).toEqual(['20 pull-ups']);
+    // no whole-object write, and untouched fields (injuries, weight, ...) absent
+    expect(updateData.profile).toBeUndefined();
+    expect(updateData['profile.injuries']).toBeUndefined();
+    expect(updateData['profile.weight']).toBeUndefined();
+  });
+
+  test('empty-string values are dropped, not written', async () => {
+    await updateProfile(
+      makeReq({ weight: '', gender: '', fitnessLevel: 'advanced' }),
+      makeRes()
+    );
+
+    const updateData = User.findByIdAndUpdate.mock.calls[0][1];
+    expect(updateData['profile.fitnessLevel']).toBe('advanced');
+    expect(updateData['profile.weight']).toBeUndefined();
+    expect(updateData['profile.gender']).toBeUndefined();
+  });
+
+  test('preferences merge one level: each preference key is its own dot-path', async () => {
+    await updateProfile(
+      makeReq({ preferences: { equipment: ['bands'] } }),
+      makeRes()
+    );
+
+    const updateData = User.findByIdAndUpdate.mock.calls[0][1];
+    expect(updateData['profile.preferences.equipment']).toEqual(['bands']);
+    // sibling preferences (sessionDuration, sessionDays) must not be touched
+    expect(updateData['profile.preferences']).toBeUndefined();
+  });
+
+  test('dotted / operator keys cannot smuggle nested paths', async () => {
+    await updateProfile(
+      makeReq({
+        'preferences.equipment': ['evil'],
+        '$set': { role: 'admin' },
+        preferences: { '$rename': { a: 'b' }, 'nested.path': 1 }
+      }),
+      makeRes()
+    );
+
+    const updateData = User.findByIdAndUpdate.mock.calls[0][1];
+    expect(Object.keys(updateData)).toEqual([]); // nothing legitimate in that payload
+  });
+
+  test('injuries change still invalidates the day pick', async () => {
+    const { invalidateTodaysPick } = require('../../utils/invalidateTodaysPick');
+    await updateProfile(
+      makeReq({ injuries: ['right shoulder'] }),
+      makeRes()
+    );
+    expect(invalidateTodaysPick).toHaveBeenCalledWith('user-1');
+  });
+});

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -214,16 +214,28 @@ const updateProfile = async (req, res) => {
       const cleanProfile = Object.fromEntries(
         Object.entries(profile).filter(([, value]) => value !== '')
       );
-      // Deep merge profile preferences
-      const existingProfile = req.user.profile ? (req.user.profile.toObject ? req.user.profile.toObject() : req.user.profile) : {};
-      updateData.profile = {
-        ...existingProfile,
-        ...cleanProfile,
-        preferences: {
-          ...(existingProfile.preferences || {}),
-          ...(cleanProfile.preferences || {})
+      // Dot-path $sets rather than a merged whole-object write (same rationale
+      // as the settings branch below): a partial update touches only the keys
+      // it names, so a stale client snapshot can't clobber fields written
+      // concurrently by other writers (e.g. the AI coach's $addToSet on
+      // profile.sportPreferences).
+      for (const [key, value] of Object.entries(cleanProfile)) {
+        // Client keys become Mongo update paths here — block '.'/'$' so a
+        // crafted key can't write arbitrary nested paths or operators.
+        if (key.includes('.') || key.includes('$')) continue;
+        if (key === 'preferences') {
+          // One merge level: each preference key is set individually so a
+          // partial { preferences: { equipment } } doesn't wipe its siblings.
+          if (value && typeof value === 'object') {
+            for (const [prefKey, prefValue] of Object.entries(value)) {
+              if (prefKey.includes('.') || prefKey.includes('$')) continue;
+              updateData[`profile.preferences.${prefKey}`] = prefValue;
+            }
+          }
+        } else {
+          updateData[`profile.${key}`] = value;
         }
-      };
+      }
     }
     if (settings) {
       // Dot-path $sets rather than a merged whole-object write: a partial

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const { DISCIPLINES } = require('../config/disciplines');
 
 const userSchema = new mongoose.Schema({
   email: {
@@ -74,7 +75,10 @@ const userSchema = new mongoose.Schema({
       default: 'beginner'
     },
     goals: [String],
-    sportPreferences: [String], // e.g., ['running', 'weightlifting', 'yoga', 'cycling']
+    // Sports the user wants in their training (canonical discipline
+    // vocabulary, e.g. ['running', 'climbing', 'yoga']) — feeds AI-coach
+    // context. Distinct from settings.sportsNews.follows (leagues they watch).
+    sportPreferences: { type: [String], enum: DISCIPLINES },
     injuries: [String], // any injuries to be aware of
     preferences: {
       sessionDuration: Number, // preferred minutes

--- a/frontend/src/constants/disciplines.js
+++ b/frontend/src/constants/disciplines.js
@@ -1,0 +1,34 @@
+/**
+ * Canonical discipline vocabulary — frontend mirror.
+ *
+ * The canonical source is ai-coach-service/app/core/disciplines.py; keep the
+ * lists identical (same values, same order). Not derived from designTokens'
+ * discipline color map: that map COVERS the vocabulary, it doesn't define it.
+ * ADDITIVE ONLY — see disciplines.py for why.
+ */
+
+export const DISCIPLINES = [
+  'strength',
+  'cardio',
+  'hiit',
+  'hybrid',
+  'recovery',
+  'mobility',
+  'flexibility',
+  'calisthenics',
+  'running',
+  'cycling',
+  'climbing',
+  'swimming',
+  'walking',
+  'yoga',
+  'meditation',
+];
+
+// Grouping for the Settings "Training Interests" picker — presentation only.
+export const DISCIPLINE_GROUPS = [
+  { label: 'Gym & strength', disciplines: ['strength', 'calisthenics', 'hiit', 'hybrid'] },
+  { label: 'Endurance', disciplines: ['running', 'cycling', 'swimming', 'walking', 'cardio'] },
+  { label: 'Climb & skill', disciplines: ['climbing'] },
+  { label: 'Mind & mobility', disciplines: ['yoga', 'mobility', 'flexibility', 'meditation', 'recovery'] },
+];

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,11 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Camera, Moon, Sun, Loader2, Brain, Link, Unlink, RefreshCw, CheckCircle, AlertCircle, Trash2, Copy, Sparkles, KeyRound, X, Target, HeartPulse, Newspaper } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Camera, Moon, Sun, Loader2, Brain, Link, Unlink, RefreshCw, CheckCircle, AlertCircle, Trash2, Copy, Sparkles, KeyRound, X, Target, HeartPulse, Newspaper, Check, Dumbbell } from 'lucide-react';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Switch } from '@/components/ui/switch';
 import { useTheme } from '@/contexts/ThemeContext';
 import { StravaIntegration } from '@/api/entities';
 import apiService from '@/services/api';
+import { DISCIPLINE_GROUPS } from '@/constants/disciplines';
+import { getDisciplineColor } from '@/styles/designTokens';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -46,6 +48,11 @@ export default function Settings() {
   const [pwForm, setPwForm] = useState({ currentPassword: '', newPassword: '', confirmPassword: '' });
   const [pwSaving, setPwSaving] = useState(false);
   const [pwMessage, setPwMessage] = useState(null);
+
+  // Last profile the server returned — profile PUTs diff against this and send
+  // only changed keys, so a stale snapshot of an untouched field (e.g. a coach
+  // $addToSet on sportPreferences mid-session) is never clobbered.
+  const lastServerProfileRef = useRef(null);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -130,6 +137,7 @@ export default function Settings() {
         const data = await response.json();
         const userData = data.data.user;
         setUser(userData);
+        lastServerProfileRef.current = userData.profile || {};
         setFormData({
           name: userData.name || '',
           email: userData.email || '',
@@ -168,13 +176,27 @@ export default function Settings() {
 
   // Unset weight/height/gender live in form state as '' — the schema wants
   // Number/enum there, so empty values must be omitted, not sent as ''.
-  const buildProfilePayload = () => {
-    const { weight, height, gender, ...rest } = formData.profile;
+  const buildProfilePayload = (profileState = formData.profile) => {
+    const { weight, height, gender, ...rest } = profileState;
     const profile = { ...rest };
     if (weight !== '') profile.weight = Number(weight);
     if (height !== '') profile.height = Number(height);
     if (gender !== '') profile.gender = gender;
     return profile;
+  };
+
+  // Only the keys that differ from the last server-returned profile. The
+  // server applies per-key dot-path sets, so keys we omit are left untouched —
+  // this is what keeps concurrent writers (the AI coach) from being clobbered
+  // by a stale local copy of a field the user didn't edit.
+  const diffProfilePayload = (payload) => {
+    const server = lastServerProfileRef.current;
+    if (!server) return payload;
+    const changed = {};
+    for (const [key, value] of Object.entries(payload)) {
+      if (JSON.stringify(value) !== JSON.stringify(server[key])) changed[key] = value;
+    }
+    return changed;
   };
 
   const handleSave = async () => {
@@ -194,7 +216,7 @@ export default function Settings() {
           dateOfBirth: formData.dateOfBirth || null,
           address: formData.address,
           profilePicture: formData.profilePicture,
-          profile: buildProfilePayload(),
+          profile: diffProfilePayload(buildProfilePayload()),
           settings: formData.settings
         })
       });
@@ -205,6 +227,7 @@ export default function Settings() {
         const authUser = JSON.parse(localStorage.getItem('authUser') || '{}');
         localStorage.setItem('authUser', JSON.stringify({ ...authUser, ...data.data.user }));
         setUser(data.data.user);
+        lastServerProfileRef.current = data.data.user.profile || {};
         setEditingField(null);
       } else {
         const data = await response.json().catch(() => null);
@@ -218,24 +241,26 @@ export default function Settings() {
     }
   };
 
-  // Persist a full profile object (goals/injuries edits save immediately). The
-  // backend deep-merges profile, and we send the whole current profile so no
-  // other field is dropped.
+  // Persist a profile change immediately (goals/injuries/interests edits).
+  // Only the keys that actually changed are sent — see diffProfilePayload.
   const commitProfile = async (nextProfile) => {
     setFormData((prev) => ({ ...prev, profile: nextProfile }));
+    const changed = diffProfilePayload(buildProfilePayload(nextProfile));
+    if (Object.keys(changed).length === 0) return;
     setIsSaving(true);
     try {
       const token = localStorage.getItem('authToken');
       const response = await fetch(`${import.meta.env.VITE_API_URL || 'http://localhost:5001'}/api/v1/auth/profile`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({ profile: nextProfile })
+        body: JSON.stringify({ profile: changed })
       });
       if (response.ok) {
         const data = await response.json();
         const authUser = JSON.parse(localStorage.getItem('authUser') || '{}');
         localStorage.setItem('authUser', JSON.stringify({ ...authUser, ...data.data.user }));
         setUser(data.data.user);
+        lastServerProfileRef.current = data.data.user.profile || {};
       }
     } catch (error) {
       console.error('Error saving profile arrays:', error);
@@ -395,6 +420,60 @@ export default function Settings() {
       </div>
     </div>
   );
+
+  const toggleSportPreference = (discipline) => {
+    const current = formData.profile.sportPreferences || [];
+    const next = current.includes(discipline)
+      ? current.filter((d) => d !== discipline)
+      : [...current, discipline];
+    commitProfile({ ...formData.profile, sportPreferences: next });
+  };
+
+  // Plain render function for the same focus-preservation reason as
+  // renderChipEditor. Fixed-choice toggle chips — the canonical discipline
+  // vocabulary, never free text.
+  const renderDisciplinePicker = () => {
+    const selected = formData.profile.sportPreferences || [];
+    return (
+      <div className="py-4 border-b border-gray-100 dark:border-gray-800">
+        <div className="flex items-center gap-2 mb-3">
+          <Dumbbell className="w-4 h-4 text-primary-400" />
+          <p className="text-sm font-bold text-gray-500 dark:text-gray-400 tracking-wide">Interests</p>
+        </div>
+        <div className="space-y-3">
+          {DISCIPLINE_GROUPS.map((group) => (
+            <div key={group.label}>
+              <p className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1.5">
+                {group.label}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {group.disciplines.map((discipline) => {
+                  const isSelected = selected.includes(discipline);
+                  const color = getDisciplineColor(discipline);
+                  return (
+                    <button
+                      key={discipline}
+                      onClick={() => toggleSportPreference(discipline)}
+                      disabled={isSaving}
+                      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm capitalize border transition-colors ${
+                        isSelected
+                          ? 'font-semibold text-gray-900 dark:text-white'
+                          : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:border-gray-400 dark:hover:border-gray-500'
+                      }`}
+                      style={isSelected ? { borderColor: color, backgroundColor: `${color}22` } : undefined}
+                    >
+                      {isSelected && <Check className="w-3.5 h-3.5" style={{ color }} />}
+                      {discipline}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
 
   // Strava functions
   const fetchStravaStatus = async () => {
@@ -723,6 +802,17 @@ export default function Settings() {
                 )}
               </div>
             ))}
+          </div>
+        </div>
+
+        {/* Training Interests — sports the coach plans around */}
+        <div className="mt-8">
+          <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">Training Interests</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            Sports and disciplines you want in your training — your coach plans around these.
+          </p>
+          <div className="space-y-1">
+            {renderDisciplinePicker()}
           </div>
         </div>
 


### PR DESCRIPTION
## What

Users can now declare which sports they want in their training — a grouped, fixed-choice chip picker in Settings ("Training Interests"), stored in the existing (previously dead) `profile.sportPreferences` field. First of a 4-PR series; PR 2 wires the sensei (awareness + update tool + gentle nudges).

## Changes

- **`backend/src/config/disciplines.js`** (new): backend mirror of the canonical 15-value discipline vocabulary (`ai-coach-service/app/core/disciplines.py` stays the source), plus the pinned `LEGACY_DISCIPLINE_MAP` and `normalizeDisciplines()` for later PRs.
- **`User.js`**: `profile.sportPreferences` gets an element-wise enum. Safe: prod has zero users with the field set.
- **`authController.updateProfile`**: the `profile` branch now writes per-key dot-path `$set`s instead of a merged whole-object write (same rationale + `.`/`$` key guard as the settings branch). A stale client snapshot can no longer clobber fields written concurrently by other writers — specifically the AI coach's upcoming `$addToSet` on `sportPreferences` (PR 2). `preferences` merges one level, like `dashboard`.
- **`Settings.jsx`**: profile PUTs diff against the last server-returned profile and send only changed keys (`commitProfile` + `handleSave`) — without this the client would re-send `sportPreferences` on every unrelated edit and the dot-path conversion alone wouldn't protect it. New "Training Interests" card with grouped toggle chips (Gym & strength / Endurance / Climb & skill / Mind & mobility), tinted via `getDisciplineColor()`. No free text — free text is how `discipline` accumulated 20 variant values.
- **`frontend/src/constants/disciplines.js`** (new): vocabulary + picker groups.

Deliberately untouched: `settings.sportsNews.follows` guard (spectator taxonomy, separate feature); the DB-backed `disciplines` collection/API (parallel dead vocabulary — follow-up: deprecate or fold); `invalidateTodaysPick` is NOT called for interests since the pick prompt doesn't render them.

## Verification

- Scratch-DB check (prod cluster, throwaway user, dropped after): enum rejects `['crossfit']` via dot-path `$set` with ValidationError; valid `$set` and atomic `$addToSet` persist.
- New `updateProfileProfile.test.js` (5 tests): dot-path shape, empty-string dropping, one-level preferences merge, `.`/`$` smuggling guard, injuries pick-invalidation preserved.
- Full backend suite: 65 tests green. Frontend `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)