### PR TITLE
Sport interests 2/4: sensei awareness, update skill, gentle mix nudge

### DIFF
--- a/ai-coach-service/app/api/v1/coach_question.py
+++ b/ai-coach-service/app/api/v1/coach_question.py
@@ -151,6 +151,9 @@ async def get_coach_question(
                 line += f" (note: {note})"
             workouts_str += line
 
+        # Deliberately NO sportPreferences here: training interests are set in
+        # the profile card or volunteered in chat — the dashboard check-in
+        # question must never start asking about them.
         context_str = f"""CURRENT TIME:
 - User's local time: {local_time_str}
 - Today's date: {today_date}
@@ -159,7 +162,6 @@ USER PROFILE:
 - Name: {user_name or 'not set'}
 - Fitness Level: {user_profile.get('fitnessLevel', 'not set')}
 - Goals: {', '.join(user_profile.get('goals', [])) or 'not specified'}
-- Sport Preferences: {', '.join(user_profile.get('sportPreferences', [])) or 'not specified'}
 
 RECENT WORKOUTS:{workouts_str or ' none logged recently'}
 

--- a/ai-coach-service/app/core/agents/data_reader.py
+++ b/ai-coach-service/app/core/agents/data_reader.py
@@ -171,7 +171,8 @@ class DataReaderAgent(BaseAgent):
                 "sessionDuration": profile.get("preferences", {}).get("sessionDuration"),
                 "sessionDays": profile.get("preferences", {}).get("sessionDays", []),
                 "injuries": profile.get("injuries", []),
-                "goals": profile.get("goals", [])
+                "goals": profile.get("goals", []),
+                "sportPreferences": profile.get("sportPreferences", [])
             }
         except Exception as e:
             logger.error(f"Error loading user profile: {e}")

--- a/ai-coach-service/app/core/agents/interest_mix.py
+++ b/ai-coach-service/app/core/agents/interest_mix.py
@@ -1,0 +1,115 @@
+"""
+Training-interest vs recent-activity mix for the chat context.
+
+Computes what the athlete actually did in the last N days (logged sessions +
+synced tracker activity) against the sports they declared in
+profile.sportPreferences, so the sensei can gently suggest revisiting a quiet
+interest. Chat-only by design: this is built exclusively from
+Orchestrator._build_extra_context.
+
+Data sources (union, deduped):
+- completed calendarevents, by sessionDetails.discipline — covers Strava and
+  other synced activity, which is mapped to canonical disciplines at sync time
+  (backend StravaIntegrationService.mapStravaTypeToDiscipline) and never hits
+  sessionlogs
+- sessionlogs, by discipline — SKIPPING logs with a calendarEventId, which are
+  already represented by their (completed) calendar event
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+
+logger = logging.getLogger(__name__)
+
+MIX_WINDOW_DAYS = 21
+# Below this much recorded activity in the window we say nothing about mix —
+# inactive or brand-new athletes have bigger problems than interest balance.
+MIN_ACTIVITIES_FOR_MIX = 3
+
+# Off-vocabulary values that live in old activity data. `endurance` counts
+# toward BOTH cardio and running for neglect purposes (either interest is
+# served by an endurance session); `other` carries no discipline signal.
+ACTIVITY_DISCIPLINE_ALIASES: Dict[str, tuple] = {
+    "endurance": ("cardio", "running"),
+    "other": (),
+}
+
+NUDGE_RULES = (
+    "Nudging rules: goals, active plans, injuries and recovery ALWAYS take "
+    "priority over interest balance. At most ONE light suggestion to revisit "
+    "a quiet interest per conversation, only when it fits naturally (planning "
+    "a week, picking today's session). Recorded activity may be incomplete — "
+    "ask, don't assert (\"still getting on the wall these days?\" not \"you "
+    "haven't climbed\"). Never open with it, never repeat it if the "
+    "recent-context summaries show you already mentioned it, never phrase it "
+    "as a failure."
+)
+
+
+async def load_recent_discipline_counts(
+    db, user_id: str, local_now: datetime, days: int = MIX_WINDOW_DAYS
+) -> Dict[str, int]:
+    """Raw discipline -> activity count over the window, from both sources."""
+    user_oid = ObjectId(user_id)
+    # Stored dates are naive UTC; a tz-aware cutoff can't compare against them.
+    cutoff = (local_now.replace(tzinfo=None) if local_now.tzinfo else local_now) - timedelta(days=days)
+    counts: Dict[str, int] = {}
+
+    cal_rows = await db.calendarevents.aggregate([
+        {"$match": {"userId": user_oid, "status": "completed", "date": {"$gte": cutoff}}},
+        {"$group": {"_id": "$sessionDetails.discipline", "count": {"$sum": 1}}},
+    ]).to_list(length=None)
+    log_rows = await db.sessionlogs.aggregate([
+        {"$match": {
+            "userId": user_oid,
+            "startedAt": {"$gte": cutoff},
+            # Logs linked to a calendar event are already counted above.
+            "calendarEventId": None,
+        }},
+        {"$group": {"_id": "$discipline", "count": {"$sum": 1}}},
+    ]).to_list(length=None)
+
+    for row in cal_rows + log_rows:
+        discipline = row.get("_id")
+        if not discipline:
+            continue
+        key = str(discipline).lower()
+        counts[key] = counts.get(key, 0) + int(row.get("count", 0))
+    return counts
+
+
+def build_interest_mix_block(
+    interests: List[str], counts: Dict[str, int], days: int = MIX_WINDOW_DAYS
+) -> Optional[str]:
+    """Pure: the prompt block, or None when there's nothing worth saying
+    (no declared interests, or too little recorded activity to judge mix)."""
+    interests = [i for i in (interests or []) if i]
+    if not interests:
+        return None
+    total = sum(counts.values())
+    if total < MIN_ACTIVITIES_FOR_MIX:
+        return None
+
+    # Which interests got any volume, counting aliased off-vocab activity
+    # (an 'endurance' ride serves both a cardio and a running interest).
+    covered = set()
+    for raw, count in counts.items():
+        if count <= 0:
+            continue
+        for target in ACTIVITY_DISCIPLINE_ALIASES.get(raw, (raw,)):
+            covered.add(target)
+    neglected = [i for i in interests if i not in covered]
+
+    mix = ", ".join(f"{d} {c}" for d, c in sorted(counts.items(), key=lambda x: -x[1]))
+    lines = [
+        f"TRAINING INTERESTS & RECENT MIX (last {days} days, logged + synced activity):",
+        f"- Declared interests: {', '.join(interests)}",
+        f"- Activity by discipline: {mix}",
+    ]
+    if neglected:
+        lines.append(f"- Interests with little/no recorded volume: {', '.join(neglected)}")
+    lines.append(NUDGE_RULES)
+    return "\n".join(lines)

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -31,6 +31,7 @@ from app.core.agents.services import (
     MemoryService,
 )
 from app.core.agents.services.calendar_service import format_calendar_anchors
+from app.core.agents.interest_mix import build_interest_mix_block, load_recent_discipline_counts
 from app.services.coach_question_service import CoachQuestionService
 from app.services.recommendation_service import RecommendationService
 from app.services.short_term_context_service import ShortTermContextService
@@ -143,6 +144,7 @@ _WRITE_ALWAYS = {
     "create_session_template", "delete_memory", "generate_plan", "log_session",
     "remove_plan_session", "save_exercise_video", "save_memory",
     "substitute_exercise", "update_goal", "update_memory", "update_plan",
+    "update_sport_preferences",
 }
 
 
@@ -394,6 +396,8 @@ class AgentOrchestrator:
            stays consistent with what the coach just asked on the Today screen.
         4. Short-term context entries (dashboard check-ins, conversation
            summaries, 14-day TTL) — working memory across conversations.
+        5. Training-interest vs recent-activity mix (chat-only nudge signal;
+           see interest_mix.py).
         Best-effort: returns '' on any failure."""
         blocks = []
         try:
@@ -456,6 +460,15 @@ class AgentOrchestrator:
                 blocks.append(stc_block)
         except Exception as e:
             logger.error(f"Failed building extra context for {user_id}: {e}")
+        try:
+            interests = (data_context or {}).get("user_profile", {}).get("sportPreferences", [])
+            if interests:
+                counts = await load_recent_discipline_counts(self.db, user_id, local_now)
+                mix_block = build_interest_mix_block(interests, counts)
+                if mix_block:
+                    blocks.append(mix_block)
+        except Exception as e:
+            logger.error(f"Failed building interest mix for {user_id}: {e}")
         return ("\n\n" + "\n\n".join(blocks)) if blocks else ""
 
     async def process_request(
@@ -520,6 +533,7 @@ USER PROFILE:
 - Training Days per Week: {len(user_profile.get('sessionDays', []))}
 - Stated Goals (from profile): {', '.join(user_profile.get('goals', [])) or 'none listed'}
 - Profile-listed Injuries (standing baseline): {', '.join(user_profile.get('injuries', [])) or 'none listed'}
+- Training Interests (sports the athlete wants in their life): {', '.join(user_profile.get('sportPreferences', [])) or 'not specified — they are set in the profile card or recorded with update_sport_preferences when the athlete volunteers them; do NOT ask about them unprompted'}
 
 USER DATA:
 - {len(data_context.get('exercises', []))} exercises in library
@@ -797,6 +811,7 @@ USER PROFILE:
 - Units: {units}
 - Stated Goals (from profile): {', '.join(user_profile.get('goals', [])) or 'none listed'}
 - Profile-listed Injuries (standing baseline): {', '.join(user_profile.get('injuries', [])) or 'none listed'}
+- Training Interests (sports the athlete wants in their life): {', '.join(user_profile.get('sportPreferences', [])) or 'not specified — they are set in the profile card or recorded with update_sport_preferences when the athlete volunteers them; do NOT ask about them unprompted'}
 
 USER DATA:
 - {len(data_context.get('exercises', []))} exercises

--- a/ai-coach-service/app/core/agents/skills/__init__.py
+++ b/ai-coach-service/app/core/agents/skills/__init__.py
@@ -34,6 +34,7 @@ from app.core.agents.skills import resolve_week_skill  # noqa: F401,E402
 from app.core.agents.skills import show_plan_skill  # noqa: F401,E402
 from app.core.agents.skills import daily_recommendation_skill  # noqa: F401,E402
 from app.core.agents.skills import propose_exercise_swap_skill  # noqa: F401,E402
+from app.core.agents.skills import update_sport_preferences_skill  # noqa: F401,E402
 
 __all__ = [
     "SkillContext",

--- a/ai-coach-service/app/core/agents/skills/update_sport_preferences_skill.py
+++ b/ai-coach-service/app/core/agents/skills/update_sport_preferences_skill.py
@@ -1,0 +1,110 @@
+"""
+Skill: update_sport_preferences
+
+Record a change the athlete VOLUNTEERED to their training interests
+(profile.sportPreferences) — "I want to get into climbing", "drop the yoga".
+Never used to interrogate: interests are set in the profile card or offered in
+conversation, and the sensei must not ask about them unprompted.
+
+Writes are atomic dot-path $addToSet/$pull on the one field, so they compose
+with the backend's per-key profile updates instead of clobbering them.
+NOTE: `users` is backend-owned under the approved single-writer refactor —
+when coach writes move behind the backend internal API, this write moves too.
+"""
+
+from typing import Any, Dict, List
+
+from bson import ObjectId
+from pymongo import ReturnDocument
+
+from app.core.disciplines import DISCIPLINES
+from app.core.agents.skills.registry import SkillContext, skill
+
+
+def _clean(values: Any) -> List[str]:
+    """Lowercase, keep only canonical disciplines, dedupe preserving order."""
+    out: List[str] = []
+    for value in values or []:
+        if not isinstance(value, str):
+            continue
+        lower = value.strip().lower()
+        if lower in DISCIPLINES and lower not in out:
+            out.append(lower)
+    return out
+
+
+@skill(
+    name="update_sport_preferences",
+    description=(
+        "Update the athlete's Training Interests (the sports they want in their "
+        "life, shown in their profile) — ONLY when they explicitly state an "
+        "interest change ('I want to get into climbing', 'I'm done with yoga'). "
+        "Add and/or remove specific sports; never rewrite the whole list, and "
+        "never call this to ask or guess. Confirm the change conversationally "
+        "afterwards. NOT for spectator sports they watch (news follows) and NOT "
+        "for logging activity."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "add": {
+                "type": "array",
+                "items": {"type": "string", "enum": list(DISCIPLINES)},
+                "description": "Sports the athlete said they want in their training.",
+            },
+            "remove": {
+                "type": "array",
+                "items": {"type": "string", "enum": list(DISCIPLINES)},
+                "description": "Sports the athlete said they no longer want.",
+            },
+        },
+    },
+)
+async def update_sport_preferences(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    add = _clean(args.get("add"))
+    remove = _clean(args.get("remove"))
+    # A sport in both lists is a contradictory instruction — drop it from both
+    # rather than guessing which the athlete meant.
+    both = set(add) & set(remove)
+    add = [d for d in add if d not in both]
+    remove = [d for d in remove if d not in both]
+    if not add and not remove:
+        return {
+            "success": False,
+            "message": "Nothing to change — pass the sports to add and/or remove (canonical disciplines only).",
+        }
+
+    try:
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "message": "Invalid user id."}
+
+    # Mongo forbids $addToSet and $pull on the same path in one update
+    # ("would create a conflict"), so apply them as two atomic updates.
+    result = None
+    if remove:
+        result = await ctx.db.users.find_one_and_update(
+            {"_id": user_oid},
+            {"$pull": {"profile.sportPreferences": {"$in": remove}}},
+            return_document=ReturnDocument.AFTER,
+        )
+    if add:
+        result = await ctx.db.users.find_one_and_update(
+            {"_id": user_oid},
+            {"$addToSet": {"profile.sportPreferences": {"$each": add}}},
+            return_document=ReturnDocument.AFTER,
+        )
+    if result is None:
+        return {"success": False, "message": "User not found."}
+
+    current = (result.get("profile") or {}).get("sportPreferences", [])
+    parts = []
+    if add:
+        parts.append(f"added {', '.join(add)}")
+    if remove:
+        parts.append(f"removed {', '.join(remove)}")
+    return {
+        "success": True,
+        "message": f"Training interests updated ({'; '.join(parts)}). Current interests: {', '.join(current) or 'none'}.",
+        "sportPreferences": current,
+    }

--- a/ai-coach-service/app/core/disciplines.py
+++ b/ai-coach-service/app/core/disciplines.py
@@ -14,8 +14,10 @@ filtered:
 - `log_session` / `get_session_history` tool enums
   (app/core/agents/tool_definitions/session_tools.py)
 - the Today's Pick prompt (app/services/daily_pick_service.py)
-- Strava's imported activities, which write `discipline` straight into
-  sessionlogs (backend/src/services/StravaIntegrationService.js)
+- Strava's imported activities, which are mapped to a canonical discipline at
+  sync time and land on externalactivities + completed calendarevents
+  (sessionDetails.discipline) — NOT sessionlogs
+  (backend/src/services/StravaIntegrationService.js mapStravaTypeToDiscipline)
 - the frontend's discipline colours / imagery
   (frontend/src/styles/designTokens.js, frontend/src/pages/TrainNow.jsx)
 
@@ -23,7 +25,9 @@ Rules:
 - ADDITIVE ONLY. Values are persisted on calendarevents.sessionDetails.discipline
   and sessionlogs.discipline (neither is enum-constrained in Mongo), so removing
   or renaming a value orphans real user data.
-- Anything added here must also get a colour in the frontend's designTokens.
+- Anything added here must also get a colour in the frontend's designTokens
+  and be added to the mirrors: backend/src/config/disciplines.js and
+  frontend/src/constants/disciplines.js.
 """
 
 from typing import Tuple

--- a/ai-coach-service/evals/harness.py
+++ b/ai-coach-service/evals/harness.py
@@ -114,7 +114,7 @@ def is_write(call: ToolCall) -> bool:
     if name in ("create_session_template", "add_exercise", "log_session",
                 "create_plan", "create_goal", "update_plan", "update_goal",
                 "add_plan_session", "remove_plan_session",
-                "update_calendar_session"):
+                "update_calendar_session", "update_sport_preferences"):
         return True
     return False
 

--- a/ai-coach-service/evals/scenarios.py
+++ b/ai-coach-service/evals/scenarios.py
@@ -691,6 +691,79 @@ MIXED_DISCIPLINE_PLAN = Scenario(
 )
 
 
+# ----- training interests (update_sport_preferences) -----
+
+
+async def _get_interests(db, user_id):
+    user = await db.users.find_one({"_id": ObjectId(user_id)})
+    return ((user or {}).get("profile") or {}).get("sportPreferences", [])
+
+
+async def _seed_nothing(db, user_id):
+    return {}
+
+
+async def _check_interest_added(db, user_id, refs, trace):
+    interests = await _get_interests(db, user_id)
+    if "climbing" not in interests:
+        return [f"climbing not recorded in profile.sportPreferences ({interests!r})"]
+    return []
+
+
+VOLUNTEER_INTEREST = Scenario(
+    id="volunteered-interest-recorded",
+    turns=["By the way, I really want to get climbing into my training — add it to my interests"],
+    seed=_seed_nothing,
+    final_state_check=_check_interest_added,
+    trajectory_checks=[assert_no_false_success],
+)
+
+
+async def _seed_climbing_yoga_interests(db, user_id):
+    await db.users.update_one(
+        {"_id": ObjectId(user_id)},
+        {"$set": {"profile.sportPreferences": ["climbing", "yoga"]}},
+    )
+    return {}
+
+
+async def _check_yoga_removed(db, user_id, refs, trace):
+    problems = []
+    interests = await _get_interests(db, user_id)
+    if "yoga" in interests:
+        problems.append(f"yoga still in interests ({interests!r})")
+    if "climbing" not in interests:
+        problems.append("climbing was wrongly dropped — only remove what was said")
+    return problems
+
+
+DROP_INTEREST = Scenario(
+    id="volunteered-interest-removed",
+    turns=["I'm done with yoga for now — take it off my training interests"],
+    seed=_seed_climbing_yoga_interests,
+    final_state_check=_check_yoga_removed,
+    trajectory_checks=[assert_no_false_success],
+)
+
+
+async def _check_no_interest_write(db, user_id, refs, trace):
+    problems = []
+    if await _get_interests(db, user_id):
+        problems.append("interests were written although the athlete volunteered none")
+    if any(c.name == "update_sport_preferences" for c in trace.calls):
+        problems.append("update_sport_preferences called on an unrelated turn")
+    return problems
+
+
+NO_UNPROMPTED_INTEREST_WRITE = Scenario(
+    id="no-unprompted-interest-write",
+    turns=["What should I train today?"],
+    seed=_seed_exercises_only,
+    final_state_check=_check_no_interest_write,
+    trajectory_checks=[assert_no_false_success],
+)
+
+
 SCENARIOS = [
     SCHEDULE_EXISTING,
     SCHEDULE_NONEXISTENT,
@@ -704,4 +777,7 @@ SCENARIOS = [
     CLIMBING_SESSION,
     LOG_BIKE_RIDE,
     MIXED_DISCIPLINE_PLAN,
+    VOLUNTEER_INTEREST,
+    DROP_INTEREST,
+    NO_UNPROMPTED_INTEREST_WRITE,
 ]

--- a/ai-coach-service/tests/test_interest_mix.py
+++ b/ai-coach-service/tests/test_interest_mix.py
@@ -1,0 +1,159 @@
+"""
+Tests for the training-interest mix block (interest_mix.py) and the
+update_sport_preferences skill.
+"""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from bson import ObjectId
+from pymongo import ReturnDocument
+
+from app.core.agents.interest_mix import (
+    MIX_WINDOW_DAYS,
+    build_interest_mix_block,
+    load_recent_discipline_counts,
+)
+from app.core.agents.skills.update_sport_preferences_skill import (
+    update_sport_preferences,
+)
+
+USER_ID = str(ObjectId())
+
+
+class TestBuildInterestMixBlock:
+    def test_no_interests_no_block(self):
+        assert build_interest_mix_block([], {"strength": 6}) is None
+
+    def test_too_little_activity_no_block(self):
+        # < 3 recorded activities in the window -> say nothing about mix
+        assert build_interest_mix_block(["climbing"], {"strength": 2}) is None
+
+    def test_neglected_interests_listed(self):
+        block = build_interest_mix_block(
+            ["climbing", "yoga", "strength"], {"strength": 6, "cardio": 2}
+        )
+        assert "Declared interests: climbing, yoga, strength" in block
+        assert "strength 6" in block
+        assert "little/no recorded volume: climbing, yoga" in block
+        # priority + anti-nag rules always ride along with the data
+        assert "ALWAYS take priority" in block
+        assert "ask, don't assert" in block
+
+    def test_no_neglected_line_when_all_covered(self):
+        block = build_interest_mix_block(["strength"], {"strength": 4})
+        assert block is not None
+        assert "little/no recorded volume" not in block
+
+    def test_endurance_counts_toward_cardio_and_running(self):
+        block = build_interest_mix_block(
+            ["running", "cardio", "climbing"], {"endurance": 4}
+        )
+        assert "little/no recorded volume: climbing" in block
+
+    def test_other_carries_no_signal(self):
+        block = build_interest_mix_block(["climbing"], {"other": 5})
+        assert "little/no recorded volume: climbing" in block
+
+
+class TestLoadRecentDisciplineCounts:
+    def _db(self, cal_rows, log_rows):
+        db = MagicMock()
+        cal_cursor = MagicMock()
+        cal_cursor.to_list = AsyncMock(return_value=cal_rows)
+        db.calendarevents.aggregate = MagicMock(return_value=cal_cursor)
+        log_cursor = MagicMock()
+        log_cursor.to_list = AsyncMock(return_value=log_rows)
+        db.sessionlogs.aggregate = MagicMock(return_value=log_cursor)
+        return db
+
+    async def test_unions_calendar_and_unlinked_logs(self):
+        db = self._db(
+            [{"_id": "running", "count": 2}, {"_id": "strength", "count": 1}],
+            [{"_id": "strength", "count": 3}, {"_id": None, "count": 9}],
+        )
+        counts = await load_recent_discipline_counts(db, USER_ID, datetime(2026, 7, 27))
+        assert counts == {"running": 2, "strength": 4}
+
+    async def test_log_query_skips_calendar_linked_and_uses_window(self):
+        db = self._db([], [])
+        local_now = datetime(2026, 7, 27, 8, 0, tzinfo=timezone.utc)
+        await load_recent_discipline_counts(db, USER_ID, local_now)
+        log_match = db.sessionlogs.aggregate.call_args[0][0][0]["$match"]
+        # linked logs are excluded — they're already counted via their event
+        assert log_match["calendarEventId"] is None
+        # 21-day boundary, tz stripped for naive-UTC stored dates
+        cutoff = log_match["startedAt"]["$gte"]
+        assert cutoff == datetime(2026, 7, 27, 8, 0) - timedelta(days=MIX_WINDOW_DAYS)
+        cal_match = db.calendarevents.aggregate.call_args[0][0][0]["$match"]
+        assert cal_match["status"] == "completed"
+
+
+class TestDataReaderSportPreferences:
+    async def test_load_user_profile_returns_sport_preferences(self):
+        from app.core.agents.data_reader import DataReaderAgent
+
+        db = MagicMock()
+        db.users.find_one = AsyncMock(return_value={
+            "_id": ObjectId(USER_ID),
+            "name": "Test",
+            "profile": {"sportPreferences": ["climbing", "yoga"], "goals": []},
+            "settings": {},
+        })
+        reader = DataReaderAgent(db)
+        profile = await reader._load_user_profile(USER_ID)
+        assert profile["sportPreferences"] == ["climbing", "yoga"]
+
+    async def test_missing_field_defaults_to_empty_list(self):
+        from app.core.agents.data_reader import DataReaderAgent
+
+        db = MagicMock()
+        db.users.find_one = AsyncMock(return_value={"_id": ObjectId(USER_ID), "profile": {}, "settings": {}})
+        reader = DataReaderAgent(db)
+        profile = await reader._load_user_profile(USER_ID)
+        assert profile["sportPreferences"] == []
+
+
+class TestUpdateSportPreferencesSkill:
+    def _ctx(self, user_after):
+        ctx = MagicMock()
+        ctx.db.users.find_one_and_update = AsyncMock(return_value=user_after)
+        return ctx
+
+    async def test_add_and_remove_are_two_atomic_updates(self):
+        ctx = self._ctx({"profile": {"sportPreferences": ["climbing", "yoga"]}})
+        res = await update_sport_preferences(
+            ctx, USER_ID, {"add": ["climbing"], "remove": ["strength"]}
+        )
+        assert res["success"] is True
+        assert res["sportPreferences"] == ["climbing", "yoga"]
+        calls = ctx.db.users.find_one_and_update.call_args_list
+        assert len(calls) == 2  # $pull and $addToSet must not share one update
+        assert calls[0][0][1] == {"$pull": {"profile.sportPreferences": {"$in": ["strength"]}}}
+        assert calls[1][0][1] == {"$addToSet": {"profile.sportPreferences": {"$each": ["climbing"]}}}
+        assert calls[1][1]["return_document"] == ReturnDocument.AFTER
+
+    async def test_off_vocabulary_values_rejected(self):
+        ctx = self._ctx({"profile": {"sportPreferences": []}})
+        res = await update_sport_preferences(ctx, USER_ID, {"add": ["crossfit", ""]})
+        assert res["success"] is False
+        ctx.db.users.find_one_and_update.assert_not_called()
+
+    async def test_same_sport_added_and_removed_is_dropped(self):
+        ctx = self._ctx({"profile": {"sportPreferences": []}})
+        res = await update_sport_preferences(
+            ctx, USER_ID, {"add": ["climbing"], "remove": ["climbing"]}
+        )
+        assert res["success"] is False
+        ctx.db.users.find_one_and_update.assert_not_called()
+
+    async def test_values_normalized_to_lowercase(self):
+        ctx = self._ctx({"profile": {"sportPreferences": ["climbing"]}})
+        res = await update_sport_preferences(ctx, USER_ID, {"add": ["Climbing"]})
+        assert res["success"] is True
+        update = ctx.db.users.find_one_and_update.call_args[0][1]
+        assert update == {"$addToSet": {"profile.sportPreferences": {"$each": ["climbing"]}}}
+
+    async def test_user_not_found(self):
+        ctx = self._ctx(None)
+        res = await update_sport_preferences(ctx, USER_ID, {"add": ["climbing"]})
+        assert res["success"] is False


### PR DESCRIPTION
## What

Wires `profile.sportPreferences` (PR #154) into the sensei: awareness in chat, a tool to record volunteered interest changes, and a gentle "revisit a quiet interest" signal. Elicitation stays in the profile card — the coach never asks unprompted, and the dashboard check-in question is explicitly kept interest-free.

## Changes

- **Fixed the dropped field**: `_load_user_profile` now returns `sportPreferences` — previously `suggestions.py`/`coach_question.py` read it but always got "not specified". Side-effect surfaces called explicitly: `/suggestions` becomes passively interest-aware (verified below); `coach_question.py`'s line is **removed** so the dashboard check-in can't start asking about interests.
- **Chat prompt**: Training Interests line in both USER PROFILE blocks; when unset, inline guidance says do NOT ask unprompted.
- **`interest_mix.py`** (new): last-21-days activity mix — completed `calendarevents` by `sessionDetails.discipline` (covers Strava, which is canonically mapped at sync time and never hits sessionlogs) unioned with `sessionlogs` that have no `calendarEventId` (exact dedup, no same-day heuristic). `endurance` counts toward cardio+running. The block renders only when interests are declared AND ≥3 activities are recorded, and embeds the nudging rules: goals/plans/injuries always first, at most one light suggestion per conversation, interrogative phrasing ("still getting on the wall these days?"), never repeat, never frame as failure. Chat-only by construction (built solely in `_build_extra_context`).
- **`update_sport_preferences` skill** (skill path only, no legacy tool_definitions copy): enum-constrained `add`/`remove`, atomic `$pull` then `$addToSet` as two updates (Mongo forbids both operators on one path in a single update), added to `_WRITE_ALWAYS` so a persisted call is classified as a write. Code comment flags the future move behind the backend internal API per the single-writer plan.
- **`disciplines.py`**: fixed the stale claim that Strava writes discipline into sessionlogs (it lands on externalactivities + completed calendarevents).

## Verification

- 15 new unit tests (mix block incl. endurance aliasing + ≥3 gate, loader window boundary + linked-log dedup + completed-only filter, skill add/remove/enum-rejection/conflict-drop/casefold, data_reader field). Full suite: **610 passed**.
- 3 new real-LLM eval scenarios, run live against scratch DB: volunteered add → climbing recorded; volunteered remove → yoga removed, climbing kept; unrelated turn → no interest write, no tool call. **All pass.**
- `/suggestions` eyeballed in-process for a scratch user with `["climbing","yoga"]`: output included "Create a climbing-focused training plan" and "Make me a yoga and mobility session" — aware, not asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)