### PR TITLE
Sport interests 3/4: LLM-assisted discipline classification + apply migration

### DIFF
--- a/ai-coach-service/scripts/classify_disciplines.py
+++ b/ai-coach-service/scripts/classify_disciplines.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Phase A of the canonical-discipline migration: classify every exercise and
+session template whose discipline values aren't canonical, and write a
+human-review artifact. READ-ONLY — the DB is never written; the apply step is
+backend/scripts/migrate-canonical-disciplines.js (Phase B), which consumes the
+artifact this script produces.
+
+Two passes per document:
+1. Deterministic — exact canonical values (case-folded) plus the pinned
+   synonym map (endurance/Conditioning→cardio, powerlifting/power/
+   'Strength Training'→strength; mirrors backend/src/config/disciplines.js
+   LEGACY_DISCIPLINE_MAP). Docs fully resolved here are tagged
+   source="synonym" and skip the LLM.
+2. LLM — only for values no rule can place (warm_up, core, corrective,
+   balance, stability, 'General Fitness', ...) because each document needs
+   individual judgment: classified by name+description into 1-2 canonical
+   disciplines with confidence + reason.
+
+Review contract: EVERY row must end up approved=true before Phase B will run
+(low-confidence LLM rows default to approved=false and must be flipped by a
+human, editing `proposed` as needed). Unchanged all-canonical docs produce no
+row at all.
+
+Usage:
+    python scripts/classify_disciplines.py                 # full run
+    python scripts/classify_disciplines.py --limit 20      # smoke test
+    python scripts/classify_disciplines.py --collection exercises
+    python scripts/classify_disciplines.py --out artifacts/run2.json
+
+Connection comes from MONGODB_URL / MONGODB_DATABASE env (.env) — no prod
+fallback: the DB name must always be an explicit choice.
+"""
+
+import argparse
+import asyncio
+import csv
+import json
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+from motor.motor_asyncio import AsyncIOMotorClient
+from openai import AsyncOpenAI
+
+load_dotenv()
+
+from app.config import get_settings  # noqa: E402 — needs load_dotenv first
+from app.core.disciplines import DISCIPLINES, DISCIPLINES_LIST  # noqa: E402
+
+MONGODB_URL = os.getenv("MONGODB_URL", "mongodb://localhost:27017")
+# No prod fallback on purpose — see module docstring.
+DATABASE_NAME = os.getenv("MONGODB_DATABASE")
+
+CANONICAL = set(DISCIPLINES)
+
+# Keep in lockstep with backend/src/config/disciplines.js LEGACY_DISCIPLINE_MAP.
+LEGACY_DISCIPLINE_MAP = {
+    "endurance": "cardio",
+    "conditioning": "cardio",
+    "powerlifting": "strength",
+    "power": "strength",
+    "strength training": "strength",
+}
+
+COLLECTIONS = {
+    "exercises": "discipline",
+    "sessiontemplates": "primary_disciplines",
+}
+
+CLASSIFY_PROMPT = (
+    "You classify fitness-app items into a fixed discipline vocabulary. A "
+    "discipline is the SPORT a session belongs to — pick the sport each item "
+    f"primarily serves. Valid values (use ONLY these): {DISCIPLINES_LIST}.\n"
+    "For each item, propose 1-2 disciplines. confidence is 'high' only when "
+    "the choice is obvious from the name/description; use 'low' when you had "
+    "to guess.\n"
+    'Return ONLY JSON: {"items": [{"id": "d1", "proposed": ["strength"], '
+    '"confidence": "high", "reason": "short reason"}]} — one entry per item.'
+)
+
+CHUNK_SIZE = 10
+
+
+def resolve_value(value: str):
+    """canonical value for a raw discipline string, or None if unmappable."""
+    lower = (value or "").strip().lower()
+    if not lower:
+        return None
+    if lower in CANONICAL:
+        return lower
+    return LEGACY_DISCIPLINE_MAP.get(lower)
+
+
+def describe_doc(collection: str, doc: dict) -> str:
+    if collection == "exercises":
+        bits = [
+            f"name: {doc.get('name', '?')}",
+            f"description: {(doc.get('description') or '')[:200]}",
+            f"muscles: {', '.join(doc.get('muscles') or [])}",
+            f"equipment: {', '.join(doc.get('equipment') or [])}",
+        ]
+    else:
+        block_names = ", ".join(b.get("name", "") for b in (doc.get("blocks") or []))
+        bits = [
+            f"name: {doc.get('name', '?')}",
+            f"goal: {(doc.get('goal') or '')[:200]}",
+            f"blocks: {block_names}",
+        ]
+    bits.append(f"current disciplines: {doc.get('_current')}")
+    return " | ".join(bits)
+
+
+async def classify_with_llm(client, settings, collection: str, docs: list) -> dict:
+    """doc_index -> {proposed, confidence, reason} for docs needing judgment."""
+    out = {}
+    for start in range(0, len(docs), CHUNK_SIZE):
+        chunk = docs[start:start + CHUNK_SIZE]
+        lines = [
+            f"[d{start + offset + 1}] {describe_doc(collection, doc)}"
+            for offset, doc in enumerate(chunk)
+        ]
+        prompt = "ITEMS:\n" + "\n".join(lines) + f"\n\n{CLASSIFY_PROMPT}"
+        response = await client.chat.completions.create(
+            model=settings.openai_model_fast,
+            messages=[{"role": "user", "content": prompt}],
+            max_completion_tokens=2000,
+            response_format={"type": "json_object"},
+            **settings.llm_tuning_params(temperature=0.1),
+        )
+        raw = (response.choices[0].message.content or "").strip()
+        try:
+            items = json.loads(raw).get("items", [])
+        except Exception:
+            print(f"  !! non-JSON output for chunk at {start} — those docs left unclassified")
+            continue
+        for item in items:
+            label = str(item.get("id") or "").strip().strip("[]")
+            if not label.startswith("d"):
+                continue
+            try:
+                idx = int(label[1:]) - 1
+            except ValueError:
+                continue
+            proposed = [v for v in (item.get("proposed") or []) if v in CANONICAL][:2]
+            if not proposed:
+                continue
+            out[idx] = {
+                "proposed": proposed,
+                "confidence": "high" if item.get("confidence") == "high" else "low",
+                "reason": (item.get("reason") or "").strip()[:200],
+            }
+    return out
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=0, help="first N docs per collection")
+    parser.add_argument("--collection", choices=list(COLLECTIONS), help="one collection only")
+    parser.add_argument("--out", default=None, help="artifact path (.json)")
+    args = parser.parse_args()
+
+    if not DATABASE_NAME:
+        sys.exit("MONGODB_DATABASE not set — refusing to guess a database.")
+
+    settings = get_settings()
+    llm = AsyncOpenAI(api_key=settings.openai_api_key)
+    db = AsyncIOMotorClient(MONGODB_URL)[DATABASE_NAME]
+
+    stamp = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")
+    out_path = args.out or os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        f"discipline-classification-{stamp}.json",
+    )
+
+    rows = []
+    collections = [args.collection] if args.collection else list(COLLECTIONS)
+    for collection in collections:
+        field = COLLECTIONS[collection]
+        cursor = db[collection].find({}, {
+            "name": 1, "description": 1, "muscles": 1, "equipment": 1,
+            "goal": 1, "blocks.name": 1, field: 1, "isCommon": 1,
+        })
+        if args.limit:
+            cursor = cursor.limit(args.limit)
+        docs = await cursor.to_list(length=None)
+        print(f"{collection}: {len(docs)} docs")
+
+        needs_llm = []
+        for doc in docs:
+            raw_values = doc.get(field) or []
+            if isinstance(raw_values, str):
+                raw_values = [raw_values]
+            resolved, unmappable = [], []
+            for value in raw_values:
+                canonical = resolve_value(value)
+                if canonical:
+                    if canonical not in resolved:
+                        resolved.append(canonical)
+                else:
+                    unmappable.append(value)
+
+            if not unmappable:
+                if resolved == raw_values:
+                    continue  # already fully canonical — no row, no write
+                rows.append({
+                    "collection": collection,
+                    "_id": str(doc["_id"]),
+                    "name": doc.get("name", ""),
+                    "isCommon": bool(doc.get("isCommon")),
+                    "current": raw_values,
+                    "proposed": resolved,
+                    "source": "synonym",
+                    "confidence": "high",
+                    "reason": "case-fold / pinned synonym map",
+                    "approved": True,
+                })
+            else:
+                doc["_current"] = raw_values
+                doc["_resolved"] = resolved
+                doc["_field"] = field
+                needs_llm.append(doc)
+
+        if not needs_llm:
+            continue
+        print(f"  {len(needs_llm)} docs need LLM judgment")
+        verdicts = await classify_with_llm(llm, settings, collection, needs_llm)
+        for idx, doc in enumerate(needs_llm):
+            verdict = verdicts.get(idx)
+            resolved = doc["_resolved"]
+            if verdict:
+                proposed = resolved + [v for v in verdict["proposed"] if v not in resolved]
+                confidence, reason = verdict["confidence"], verdict["reason"]
+            else:
+                proposed, confidence, reason = resolved, "low", "LLM returned no verdict"
+            rows.append({
+                "collection": collection,
+                "_id": str(doc["_id"]),
+                "name": doc.get("name", ""),
+                "isCommon": bool(doc.get("isCommon")),
+                "current": doc["_current"],
+                "proposed": proposed,
+                "source": "llm",
+                "confidence": confidence,
+                "reason": reason,
+                "approved": confidence == "high" and bool(proposed),
+            })
+
+    artifact = {
+        "generatedAt": stamp,
+        "database": DATABASE_NAME,
+        "vocabulary": list(DISCIPLINES),
+        "rows": rows,
+    }
+    with open(out_path, "w") as f:
+        json.dump(artifact, f, indent=2)
+    csv_path = out_path.replace(".json", ".csv")
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["collection", "_id", "name", "isCommon", "current",
+                         "proposed", "source", "confidence", "reason", "approved"])
+        for row in rows:
+            writer.writerow([
+                row["collection"], row["_id"], row["name"], row["isCommon"],
+                "; ".join(map(str, row["current"])), "; ".join(row["proposed"]),
+                row["source"], row["confidence"], row["reason"], row["approved"],
+            ])
+
+    unapproved = [r for r in rows if not r["approved"]]
+    common_rows = [r for r in rows if r["isCommon"]]
+    print(f"\n{len(rows)} rows -> {out_path} (+ .csv)")
+    print(f"  {sum(1 for r in rows if r['source'] == 'synonym')} synonym / "
+          f"{sum(1 for r in rows if r['source'] == 'llm')} llm")
+    print(f"  {len(unapproved)} rows need human adjudication (approved=false)")
+    print(f"  {len(common_rows)} rows touch SHARED (isCommon) docs — review those extra carefully")
+    print("Every row must be approved=true before Phase B "
+          "(migrate-canonical-disciplines.js) will run.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/discipline-classification-2026-07-27.csv
+++ b/backend/scripts/discipline-classification-2026-07-27.csv
@@ -1,0 +1,87 @@
+collection,_id,name,isCommon,current,proposed,source,confidence,reason,approved
+exercises,710000000000000000000014,Prisoner/Bodyweight Jumping Squat,True,power; calisthenics,strength; calisthenics,synonym,high,case-fold / pinned synonym map,True
+exercises,710000000000000000000015,Explosive Bodyweight Rows,True,power; calisthenics,strength; calisthenics,synonym,high,case-fold / pinned synonym map,True
+exercises,6a514248d14834fc3bb847b3,Shoulder External Rotation 90/90,False,Mobility; Strength Training,mobility; strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a514336d14834fc3bb847b4,Dumbbell Row,False,Strength Training,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532fb72d70d50d1f9cd123,Barbell Bench Press,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532fc52d70d50d1f9cd14e,Barbell Deadlift,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532fc62d70d50d1f9cd151,Sumo Deadlift,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532fc72d70d50d1f9cd154,Trap Bar Deadlift,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532fc82d70d50d1f9cd157,Rack Pull,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532fca2d70d50d1f9cd15d,Pendlay Row,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532fd52d70d50d1f9cd184,Push Press,True,strength; power,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532ff42d70d50d1f9cd1e1,Barbell Back Squat,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a532ff62d70d50d1f9cd1e7,Box Squat,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a5330032d70d50d1f9cd20e,Good Morning,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a5330062d70d50d1f9cd217,Glute-Ham Raise,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a5330072d70d50d1f9cd21a,Barbell Hip Thrust,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a5330082d70d50d1f9cd21d,Barbell Glute Bridge,True,strength; powerlifting,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a53301a2d70d50d1f9cd256,Power Clean,True,strength; power,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a53301b2d70d50d1f9cd259,Kettlebell Swing,True,strength; power,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a53301c2d70d50d1f9cd25c,Kettlebell Clean and Press,True,strength; power,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a53301e2d70d50d1f9cd265,Farmer's Walk,True,strength; power,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a53301f2d70d50d1f9cd268,Sled Push,True,strength; power; cardio,strength; cardio,synonym,high,case-fold / pinned synonym map,True
+exercises,6a5330202d70d50d1f9cd26b,Box Jump,True,power,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a5330212d70d50d1f9cd26e,Medicine Ball Slam,True,power; cardio,strength; cardio,synonym,high,case-fold / pinned synonym map,True
+exercises,6a5330222d70d50d1f9cd271,Battle Rope Waves,True,cardio; power,cardio; strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a55306fa63a5c9bd5d9323e,180° Band Pull Apart (With External Rotation),False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a553072a63a5c9bd5d93247,Dip Scapula Shrugs (Depression-Elevation) + Hold at the Top,False,Calisthenics,calisthenics,synonym,high,case-fold / pinned synonym map,True
+exercises,6a553072a63a5c9bd5d9324a,Active to Passive Hang (Elevation-Depression) + Hold at the Top,False,Calisthenics,calisthenics,synonym,high,case-fold / pinned synonym map,True
+exercises,6a553073a63a5c9bd5d9324d,Single Arm Scapula Push Ups (Protraction-Depression),False,Calisthenics,calisthenics,synonym,high,case-fold / pinned synonym map,True
+exercises,6a553074a63a5c9bd5d93251,Bird Dog,False,Calisthenics,calisthenics,synonym,high,case-fold / pinned synonym map,True
+exercises,6a553075a63a5c9bd5d93254,Reverse Crunch,False,Calisthenics,calisthenics,synonym,high,case-fold / pinned synonym map,True
+exercises,6a553076a63a5c9bd5d93257,Child's Pose,False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a553076a63a5c9bd5d9325a,Cobra Stretch,False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a553c7ded7c1ccc091047eb,Easy Run,False,Cardio,cardio,synonym,high,case-fold / pinned synonym map,True
+exercises,6a5864c3262224ba29966405,Easy Walk,False,Cardio,cardio,synonym,high,case-fold / pinned synonym map,True
+exercises,6a624688f47be556a93e0558,Standing Banded Hip Abduction,False,Strength Training; Mobility,strength; mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a65843b78ab8e738927fe9e,World's Greatest Stretch,False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a65843b78ab8e738927fe9f,Deep Squat Hold,False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a65843c78ab8e738927fea0,Shoulder Dislocates,False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a65843c78ab8e738927fea1,90/90 Hip Switches,False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a65843c78ab8e738927fea2,Child's Pose,False,Mobility; Yoga,mobility; yoga,synonym,high,case-fold / pinned synonym map,True
+exercises,6a65844078ab8e738927fea3,Thread the Needle,False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a663413a6e6b963554cecbb,Push Ups,False,Calisthenics; Strength Training,calisthenics; strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a663413a6e6b963554cecbc,Pull Ups,False,Calisthenics; Strength Training,calisthenics; strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a663414a6e6b963554cecbd,Standing Side Leg Raises,False,Strength Training; Mobility,strength; mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a663415a6e6b963554cecbe,Crab Walks,False,Strength Training; Mobility,strength; mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a663415a6e6b963554cecbf,Wall Sits with Toe Raises,False,Strength Training; Mobility,strength; mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a663416a6e6b963554cecc0,Step Downs,False,Strength Training; Mobility,strength; mobility,synonym,high,case-fold / pinned synonym map,True
+exercises,6a663416a6e6b963554cecc1,Toe Ups,False,Calisthenics; Strength Training,calisthenics; strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a663619a6e6b963554cecc3,Band Rows,False,Strength Training,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,6a66361aa6e6b963554cecc4,Banded Romanian Deadlifts,False,Strength Training,strength,synonym,high,case-fold / pinned synonym map,True
+exercises,700000000000000000000001,Body Heat Warm Up,True,warm_up,mobility,llm,low,General warm-up primarily prepares the body for movement.,False
+exercises,700000000000000000000002,Band Straight Arm Lat Pull Down,True,warm_up; strength,strength,llm,high,Resistance-band lat activation is a strength exercise.,True
+exercises,700000000000000000000005,Hanging L-Sit Hold,True,calisthenics; core,calisthenics,llm,high,Hanging isometric core hold uses bodyweight and a pull-up bar.,True
+exercises,700000000000000000000009,Toes To Bar,True,calisthenics; core,calisthenics,llm,high,Toes-to-bar is a bodyweight bar exercise.,True
+exercises,70000000000000000000000e,Alternating Pistol Squats,True,strength; mobility; balance,strength; mobility,llm,high,"Single-leg squats develop leg strength, balance, and mobility.",True
+exercises,700000000000000000000010,Glute Bridges,True,strength; corrective,strength,llm,high,Glute bridges train hip extension and posterior-chain strength.,True
+exercises,700000000000000000000011,Russian Twists,True,strength; core,strength,llm,high,Russian twists are a core-strength exercise.,True
+exercises,710000000000000000000001,Body Heat Warm Up 1,True,warm_up; mobility,mobility,llm,low,A structured full-body warm-up most closely supports movement preparation.,False
+exercises,710000000000000000000002,Scapula Warm Up 1,True,warm_up; mobility,mobility,llm,high,Scapular mobility and activation directly indicate mobility training.,True
+exercises,710000000000000000000003,Scapula Warm Up 2,True,mobility; warm_up,mobility,llm,high,The exercise focuses on scapular mobility and activation.,True
+exercises,710000000000000000000004,Band Shoulder Warm Up 1,True,warm_up; mobility,mobility,llm,high,Resistance-band shoulder warm-up primarily supports mobility and preparation.,True
+exercises,71000000000000000000000d,Wall Slides,True,mobility; corrective,mobility,llm,high,Wall slides are explicitly a shoulder mobility exercise.,True
+exercises,710000000000000000000010,L-Sit Hold on Parallettes,True,calisthenics; core,calisthenics,llm,high,L-sit on parallettes is a bodyweight calisthenics skill.,True
+exercises,710000000000000000000017,Side Plank On Arms,True,strength; stability,strength,llm,high,Side plank is primarily a core-strength and stabilization exercise.,True
+exercises,710000000000000000000018,Face Pulls,True,strength; corrective,strength,llm,high,Face pulls are a strengthening exercise for the rear shoulders and upper back.,True
+exercises,710000000000000000000019,Cuban Rotations,True,strength; corrective,strength,llm,high,Cuban rotations build rotator-cuff and rear-delt strength.,True
+exercises,710000000000000000000024,Body Heat Warm Up 2,True,warm_up,recovery,llm,low,"It is a general warm-up, but no sport-specific discipline is identified.",False
+exercises,6a510abba98ad661bca4e244,Exercise 1,False,General Fitness,strength,llm,low,The generic exercise label provides no clear sport context; strength is the best fit.,False
+exercises,6a510abba98ad661bca4e245,Exercise 2,False,General Fitness,strength,llm,low,The generic exercise label provides no clear sport context; strength is the best fit.,False
+exercises,6a510b4ba98ad661bca4e273,Workout 1,False,General Fitness,strength,llm,low,The description references a strength and conditioning workout template.,False
+exercises,6a510b4ca98ad661bca4e274,Workout 2,False,General Fitness,strength,llm,low,"A strength and conditioning template is referenced, but the workout contents are unspecified.",False
+exercises,6a532ffa7622880fe213e98a,Scapula Warm Up 2,False,mobility; warm_up; calisthenics,mobility; calisthenics,llm,high,Scapular mobility and active-hang control directly support mobility and calisthenics.,True
+exercises,6a54db72ee8a105df573c6ce,Squats,False,General Fitness,strength,llm,high,Controlled-tempo squats are primarily a strength exercise.,True
+exercises,6a54db73ee8a105df573c6cf,Push-ups,False,General Fitness,strength; calisthenics,llm,high,Push-ups primarily develop upper-body strength using body weight.,True
+exercises,6a55384bed7c1ccc091047df,Cat-Cow,False,General Fitness,mobility,llm,low,"Cat-Cow is primarily a spinal mobility exercise, though the generated-workout context is nonspecific.",False
+sessiontemplates,720000000000000000000002,Endurance 1,True,endurance; calisthenics,cardio; calisthenics,synonym,high,case-fold / pinned synonym map,True
+sessiontemplates,720000000000000000000003,Endurance 2,True,endurance; calisthenics,cardio; calisthenics,synonym,high,case-fold / pinned synonym map,True
+sessiontemplates,6a53b1ee3e7427385bae2fe4,Scapula Warm Up 1,False,Calisthenics; Mobility; Conditioning,calisthenics; mobility; cardio,synonym,high,case-fold / pinned synonym map,True
+sessiontemplates,6a54dbefee8a105df573c6d3,Quick Core Blast,False,Calisthenics; Strength Training,calisthenics; strength,synonym,high,case-fold / pinned synonym map,True
+sessiontemplates,6a5864c6262224ba29966406,20-Minute Stretch + Walk,False,Mobility; Cardio,mobility; cardio,synonym,high,case-fold / pinned synonym map,True
+sessiontemplates,6a65844178ab8e738927fea4,Full-Body Mobility,False,Mobility,mobility,synonym,high,case-fold / pinned synonym map,True
+sessiontemplates,6a65e05a70338dd42aecbada,Endurance 2,False,endurance; calisthenics,cardio; calisthenics,synonym,high,case-fold / pinned synonym map,True
+sessiontemplates,6a663419a6e6b963554cecc2,"Regular Arms, Knee Recovery & Abs",False,Calisthenics; Strength Training; Mobility,calisthenics; strength; mobility,synonym,high,case-fold / pinned synonym map,True
+sessiontemplates,6a54db74ee8a105df573c6d0,Beginner Full Body Bodyweight (Jul 14),False,General Fitness,calisthenics,llm,high,Beginner full-body workout explicitly uses bodyweight exercises.,True
+sessiontemplates,6a66362da6e6b963554cecc5,"Regular Arms, Knee Recovery & Abs — Today’s Variation",False,General Fitness,strength; recovery,llm,low,"Arms and abs suggest strength training, while knee recovery adds a recovery focus.",False

--- a/backend/scripts/discipline-classification-2026-07-27.json
+++ b/backend/scripts/discipline-classification-2026-07-27.json
@@ -1,0 +1,1487 @@
+{
+  "generatedAt": "2026-07-27T16-03-39",
+  "database": "production",
+  "vocabulary": [
+    "strength",
+    "cardio",
+    "hiit",
+    "hybrid",
+    "recovery",
+    "mobility",
+    "flexibility",
+    "calisthenics",
+    "running",
+    "cycling",
+    "climbing",
+    "swimming",
+    "walking",
+    "yoga",
+    "meditation"
+  ],
+  "rows": [
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000014",
+      "name": "Prisoner/Bodyweight Jumping Squat",
+      "isCommon": true,
+      "current": [
+        "power",
+        "calisthenics"
+      ],
+      "proposed": [
+        "strength",
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000015",
+      "name": "Explosive Bodyweight Rows",
+      "isCommon": true,
+      "current": [
+        "power",
+        "calisthenics"
+      ],
+      "proposed": [
+        "strength",
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a514248d14834fc3bb847b3",
+      "name": "Shoulder External Rotation 90/90",
+      "isCommon": false,
+      "current": [
+        "Mobility",
+        "Strength Training"
+      ],
+      "proposed": [
+        "mobility",
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a514336d14834fc3bb847b4",
+      "name": "Dumbbell Row",
+      "isCommon": false,
+      "current": [
+        "Strength Training"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532fb72d70d50d1f9cd123",
+      "name": "Barbell Bench Press",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532fc52d70d50d1f9cd14e",
+      "name": "Barbell Deadlift",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532fc62d70d50d1f9cd151",
+      "name": "Sumo Deadlift",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532fc72d70d50d1f9cd154",
+      "name": "Trap Bar Deadlift",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532fc82d70d50d1f9cd157",
+      "name": "Rack Pull",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532fca2d70d50d1f9cd15d",
+      "name": "Pendlay Row",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532fd52d70d50d1f9cd184",
+      "name": "Push Press",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "power"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532ff42d70d50d1f9cd1e1",
+      "name": "Barbell Back Squat",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532ff62d70d50d1f9cd1e7",
+      "name": "Box Squat",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a5330032d70d50d1f9cd20e",
+      "name": "Good Morning",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a5330062d70d50d1f9cd217",
+      "name": "Glute-Ham Raise",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a5330072d70d50d1f9cd21a",
+      "name": "Barbell Hip Thrust",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a5330082d70d50d1f9cd21d",
+      "name": "Barbell Glute Bridge",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "powerlifting"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a53301a2d70d50d1f9cd256",
+      "name": "Power Clean",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "power"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a53301b2d70d50d1f9cd259",
+      "name": "Kettlebell Swing",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "power"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a53301c2d70d50d1f9cd25c",
+      "name": "Kettlebell Clean and Press",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "power"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a53301e2d70d50d1f9cd265",
+      "name": "Farmer's Walk",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "power"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a53301f2d70d50d1f9cd268",
+      "name": "Sled Push",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "power",
+        "cardio"
+      ],
+      "proposed": [
+        "strength",
+        "cardio"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a5330202d70d50d1f9cd26b",
+      "name": "Box Jump",
+      "isCommon": true,
+      "current": [
+        "power"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a5330212d70d50d1f9cd26e",
+      "name": "Medicine Ball Slam",
+      "isCommon": true,
+      "current": [
+        "power",
+        "cardio"
+      ],
+      "proposed": [
+        "strength",
+        "cardio"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a5330222d70d50d1f9cd271",
+      "name": "Battle Rope Waves",
+      "isCommon": true,
+      "current": [
+        "cardio",
+        "power"
+      ],
+      "proposed": [
+        "cardio",
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a55306fa63a5c9bd5d9323e",
+      "name": "180\u00b0 Band Pull Apart (With External Rotation)",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a553072a63a5c9bd5d93247",
+      "name": "Dip Scapula Shrugs (Depression-Elevation) + Hold at the Top",
+      "isCommon": false,
+      "current": [
+        "Calisthenics"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a553072a63a5c9bd5d9324a",
+      "name": "Active to Passive Hang (Elevation-Depression) + Hold at the Top",
+      "isCommon": false,
+      "current": [
+        "Calisthenics"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a553073a63a5c9bd5d9324d",
+      "name": "Single Arm Scapula Push Ups (Protraction-Depression)",
+      "isCommon": false,
+      "current": [
+        "Calisthenics"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a553074a63a5c9bd5d93251",
+      "name": "Bird Dog",
+      "isCommon": false,
+      "current": [
+        "Calisthenics"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a553075a63a5c9bd5d93254",
+      "name": "Reverse Crunch",
+      "isCommon": false,
+      "current": [
+        "Calisthenics"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a553076a63a5c9bd5d93257",
+      "name": "Child's Pose",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a553076a63a5c9bd5d9325a",
+      "name": "Cobra Stretch",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a553c7ded7c1ccc091047eb",
+      "name": "Easy Run",
+      "isCommon": false,
+      "current": [
+        "Cardio"
+      ],
+      "proposed": [
+        "cardio"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a5864c3262224ba29966405",
+      "name": "Easy Walk",
+      "isCommon": false,
+      "current": [
+        "Cardio"
+      ],
+      "proposed": [
+        "cardio"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a624688f47be556a93e0558",
+      "name": "Standing Banded Hip Abduction",
+      "isCommon": false,
+      "current": [
+        "Strength Training",
+        "Mobility"
+      ],
+      "proposed": [
+        "strength",
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a65843b78ab8e738927fe9e",
+      "name": "World's Greatest Stretch",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a65843b78ab8e738927fe9f",
+      "name": "Deep Squat Hold",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a65843c78ab8e738927fea0",
+      "name": "Shoulder Dislocates",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a65843c78ab8e738927fea1",
+      "name": "90/90 Hip Switches",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a65843c78ab8e738927fea2",
+      "name": "Child's Pose",
+      "isCommon": false,
+      "current": [
+        "Mobility",
+        "Yoga"
+      ],
+      "proposed": [
+        "mobility",
+        "yoga"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a65844078ab8e738927fea3",
+      "name": "Thread the Needle",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a663413a6e6b963554cecbb",
+      "name": "Push Ups",
+      "isCommon": false,
+      "current": [
+        "Calisthenics",
+        "Strength Training"
+      ],
+      "proposed": [
+        "calisthenics",
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a663413a6e6b963554cecbc",
+      "name": "Pull Ups",
+      "isCommon": false,
+      "current": [
+        "Calisthenics",
+        "Strength Training"
+      ],
+      "proposed": [
+        "calisthenics",
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a663414a6e6b963554cecbd",
+      "name": "Standing Side Leg Raises",
+      "isCommon": false,
+      "current": [
+        "Strength Training",
+        "Mobility"
+      ],
+      "proposed": [
+        "strength",
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a663415a6e6b963554cecbe",
+      "name": "Crab Walks",
+      "isCommon": false,
+      "current": [
+        "Strength Training",
+        "Mobility"
+      ],
+      "proposed": [
+        "strength",
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a663415a6e6b963554cecbf",
+      "name": "Wall Sits with Toe Raises",
+      "isCommon": false,
+      "current": [
+        "Strength Training",
+        "Mobility"
+      ],
+      "proposed": [
+        "strength",
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a663416a6e6b963554cecc0",
+      "name": "Step Downs",
+      "isCommon": false,
+      "current": [
+        "Strength Training",
+        "Mobility"
+      ],
+      "proposed": [
+        "strength",
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a663416a6e6b963554cecc1",
+      "name": "Toe Ups",
+      "isCommon": false,
+      "current": [
+        "Calisthenics",
+        "Strength Training"
+      ],
+      "proposed": [
+        "calisthenics",
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a663619a6e6b963554cecc3",
+      "name": "Band Rows",
+      "isCommon": false,
+      "current": [
+        "Strength Training"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a66361aa6e6b963554cecc4",
+      "name": "Banded Romanian Deadlifts",
+      "isCommon": false,
+      "current": [
+        "Strength Training"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "700000000000000000000001",
+      "name": "Body Heat Warm Up",
+      "isCommon": true,
+      "current": [
+        "warm_up"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "General warm-up primarily prepares the body for movement.",
+      "approved": false
+    },
+    {
+      "collection": "exercises",
+      "_id": "700000000000000000000002",
+      "name": "Band Straight Arm Lat Pull Down",
+      "isCommon": true,
+      "current": [
+        "warm_up",
+        "strength"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Resistance-band lat activation is a strength exercise.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "700000000000000000000005",
+      "name": "Hanging L-Sit Hold",
+      "isCommon": true,
+      "current": [
+        "calisthenics",
+        "core"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Hanging isometric core hold uses bodyweight and a pull-up bar.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "700000000000000000000009",
+      "name": "Toes To Bar",
+      "isCommon": true,
+      "current": [
+        "calisthenics",
+        "core"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Toes-to-bar is a bodyweight bar exercise.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "70000000000000000000000e",
+      "name": "Alternating Pistol Squats",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "mobility",
+        "balance"
+      ],
+      "proposed": [
+        "strength",
+        "mobility"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Single-leg squats develop leg strength, balance, and mobility.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "700000000000000000000010",
+      "name": "Glute Bridges",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "corrective"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Glute bridges train hip extension and posterior-chain strength.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "700000000000000000000011",
+      "name": "Russian Twists",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "core"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Russian twists are a core-strength exercise.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000001",
+      "name": "Body Heat Warm Up 1",
+      "isCommon": true,
+      "current": [
+        "warm_up",
+        "mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "A structured full-body warm-up most closely supports movement preparation.",
+      "approved": false
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000002",
+      "name": "Scapula Warm Up 1",
+      "isCommon": true,
+      "current": [
+        "warm_up",
+        "mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Scapular mobility and activation directly indicate mobility training.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000003",
+      "name": "Scapula Warm Up 2",
+      "isCommon": true,
+      "current": [
+        "mobility",
+        "warm_up"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "The exercise focuses on scapular mobility and activation.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000004",
+      "name": "Band Shoulder Warm Up 1",
+      "isCommon": true,
+      "current": [
+        "warm_up",
+        "mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Resistance-band shoulder warm-up primarily supports mobility and preparation.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "71000000000000000000000d",
+      "name": "Wall Slides",
+      "isCommon": true,
+      "current": [
+        "mobility",
+        "corrective"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Wall slides are explicitly a shoulder mobility exercise.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000010",
+      "name": "L-Sit Hold on Parallettes",
+      "isCommon": true,
+      "current": [
+        "calisthenics",
+        "core"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "L-sit on parallettes is a bodyweight calisthenics skill.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000017",
+      "name": "Side Plank On Arms",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "stability"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Side plank is primarily a core-strength and stabilization exercise.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000018",
+      "name": "Face Pulls",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "corrective"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Face pulls are a strengthening exercise for the rear shoulders and upper back.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000019",
+      "name": "Cuban Rotations",
+      "isCommon": true,
+      "current": [
+        "strength",
+        "corrective"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Cuban rotations build rotator-cuff and rear-delt strength.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "710000000000000000000024",
+      "name": "Body Heat Warm Up 2",
+      "isCommon": true,
+      "current": [
+        "warm_up"
+      ],
+      "proposed": [
+        "recovery"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "It is a general warm-up, but no sport-specific discipline is identified.",
+      "approved": false
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a510abba98ad661bca4e244",
+      "name": "Exercise 1",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "The generic exercise label provides no clear sport context; strength is the best fit.",
+      "approved": false
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a510abba98ad661bca4e245",
+      "name": "Exercise 2",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "The generic exercise label provides no clear sport context; strength is the best fit.",
+      "approved": false
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a510b4ba98ad661bca4e273",
+      "name": "Workout 1",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "The description references a strength and conditioning workout template.",
+      "approved": false
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a510b4ca98ad661bca4e274",
+      "name": "Workout 2",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "A strength and conditioning template is referenced, but the workout contents are unspecified.",
+      "approved": false
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a532ffa7622880fe213e98a",
+      "name": "Scapula Warm Up 2",
+      "isCommon": false,
+      "current": [
+        "mobility",
+        "warm_up",
+        "calisthenics"
+      ],
+      "proposed": [
+        "mobility",
+        "calisthenics"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Scapular mobility and active-hang control directly support mobility and calisthenics.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a54db72ee8a105df573c6ce",
+      "name": "Squats",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "strength"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Controlled-tempo squats are primarily a strength exercise.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a54db73ee8a105df573c6cf",
+      "name": "Push-ups",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "strength",
+        "calisthenics"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Push-ups primarily develop upper-body strength using body weight.",
+      "approved": true
+    },
+    {
+      "collection": "exercises",
+      "_id": "6a55384bed7c1ccc091047df",
+      "name": "Cat-Cow",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "Cat-Cow is primarily a spinal mobility exercise, though the generated-workout context is nonspecific.",
+      "approved": false
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "720000000000000000000002",
+      "name": "Endurance 1",
+      "isCommon": true,
+      "current": [
+        "endurance",
+        "calisthenics"
+      ],
+      "proposed": [
+        "cardio",
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "720000000000000000000003",
+      "name": "Endurance 2",
+      "isCommon": true,
+      "current": [
+        "endurance",
+        "calisthenics"
+      ],
+      "proposed": [
+        "cardio",
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "6a53b1ee3e7427385bae2fe4",
+      "name": "Scapula Warm Up 1",
+      "isCommon": false,
+      "current": [
+        "Calisthenics",
+        "Mobility",
+        "Conditioning"
+      ],
+      "proposed": [
+        "calisthenics",
+        "mobility",
+        "cardio"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "6a54dbefee8a105df573c6d3",
+      "name": "Quick Core Blast",
+      "isCommon": false,
+      "current": [
+        "Calisthenics",
+        "Strength Training"
+      ],
+      "proposed": [
+        "calisthenics",
+        "strength"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "6a5864c6262224ba29966406",
+      "name": "20-Minute Stretch + Walk",
+      "isCommon": false,
+      "current": [
+        "Mobility",
+        "Cardio"
+      ],
+      "proposed": [
+        "mobility",
+        "cardio"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "6a65844178ab8e738927fea4",
+      "name": "Full-Body Mobility",
+      "isCommon": false,
+      "current": [
+        "Mobility"
+      ],
+      "proposed": [
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "6a65e05a70338dd42aecbada",
+      "name": "Endurance 2",
+      "isCommon": false,
+      "current": [
+        "endurance",
+        "calisthenics"
+      ],
+      "proposed": [
+        "cardio",
+        "calisthenics"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "6a663419a6e6b963554cecc2",
+      "name": "Regular Arms, Knee Recovery & Abs",
+      "isCommon": false,
+      "current": [
+        "Calisthenics",
+        "Strength Training",
+        "Mobility"
+      ],
+      "proposed": [
+        "calisthenics",
+        "strength",
+        "mobility"
+      ],
+      "source": "synonym",
+      "confidence": "high",
+      "reason": "case-fold / pinned synonym map",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "6a54db74ee8a105df573c6d0",
+      "name": "Beginner Full Body Bodyweight (Jul 14)",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "calisthenics"
+      ],
+      "source": "llm",
+      "confidence": "high",
+      "reason": "Beginner full-body workout explicitly uses bodyweight exercises.",
+      "approved": true
+    },
+    {
+      "collection": "sessiontemplates",
+      "_id": "6a66362da6e6b963554cecc5",
+      "name": "Regular Arms, Knee Recovery & Abs \u2014 Today\u2019s Variation",
+      "isCommon": false,
+      "current": [
+        "General Fitness"
+      ],
+      "proposed": [
+        "strength",
+        "recovery"
+      ],
+      "source": "llm",
+      "confidence": "low",
+      "reason": "Arms and abs suggest strength training, while knee recovery adds a recovery focus.",
+      "approved": false
+    }
+  ]
+}

--- a/backend/scripts/migrate-canonical-disciplines.js
+++ b/backend/scripts/migrate-canonical-disciplines.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * MANUAL ADMIN SCRIPT
+ *
+ * Phase B of the canonical-discipline migration: apply the human-reviewed
+ * classification artifact produced by
+ * ai-coach-service/scripts/classify_disciplines.py (Phase A) to
+ * exercises.discipline and sessiontemplates.primary_disciplines.
+ *
+ * Refuses to run while ANY artifact row has approved !== true — review must
+ * adjudicate every row (flip approved, editing `proposed` as needed). This is
+ * load-bearing: the forward-validation PR's enums and this script's postflight
+ * `distinct ⊆ canonical` check only hold if no doc keeps an off-vocab value.
+ *
+ * Modes:
+ *   node migrate-canonical-disciplines.js <artifact.json>            → dry-run
+ *   node migrate-canonical-disciplines.js <artifact.json> --apply    → write
+ *   --collection exercises|sessiontemplates                          → filter
+ *   --db <name>                                                      → override DB (rehearsal)
+ *
+ * Apply flow: preflight audit doc (write-once) + mongodump of both
+ * collections → per-row $set of the deduped canonical array → postflight
+ * verify (distinct ⊆ canonical, doc counts unchanged) + completion audit doc
+ * recording artifact filename + git SHA. Idempotent: re-apply is a no-op.
+ *
+ * Rollback: mongorestore the dump (path printed).
+ */
+
+const { MongoClient, ObjectId } = require('mongodb');
+const { spawnSync, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+
+const { DISCIPLINE_SET } = require('../src/config/disciplines');
+
+const FIELD_BY_COLLECTION = {
+  exercises: 'discipline',
+  sessiontemplates: 'primary_disciplines',
+};
+
+const APPLY = process.argv.includes('--apply');
+const COLLECTION_FILTER = (() => {
+  const i = process.argv.indexOf('--collection');
+  return i >= 0 ? process.argv[i + 1] : null;
+})();
+const DB_OVERRIDE = (() => {
+  const i = process.argv.indexOf('--db');
+  return i >= 0 ? process.argv[i + 1] : null;
+})();
+const artifactPath = process.argv.slice(2).find((a) => !a.startsWith('--')
+  && a !== COLLECTION_FILTER && a !== DB_OVERRIDE);
+
+const redact = (s) => String(s).replace(/\/\/[^@/]+@/, '//<credentials>@');
+
+/** URI with its database path replaced by dbName (for mongodump --uri). */
+function uriWithDb(uri, dbName) {
+  const u = new URL(uri);
+  u.pathname = `/${dbName}`;
+  return u.toString();
+}
+
+async function main() {
+  if (!artifactPath) throw new Error('Usage: migrate-canonical-disciplines.js <artifact.json> [--apply]');
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+  let rows = artifact.rows || [];
+  if (COLLECTION_FILTER) {
+    if (!FIELD_BY_COLLECTION[COLLECTION_FILTER]) throw new Error(`Unknown collection ${COLLECTION_FILTER}`);
+    rows = rows.filter((r) => r.collection === COLLECTION_FILTER);
+  }
+  if (!rows.length) throw new Error('Artifact has no rows for the selected collection(s).');
+
+  // Review contract: every row adjudicated. No partial applies — a row nobody
+  // looked at must block the run, loudly.
+  const unapproved = rows.filter((r) => r.approved !== true);
+  if (unapproved.length) {
+    console.error(`REFUSING to run: ${unapproved.length} row(s) not adjudicated (approved !== true):`);
+    for (const r of unapproved) {
+      console.error(`  ${r.collection}/${r._id} "${r.name}" current=${JSON.stringify(r.current)} proposed=${JSON.stringify(r.proposed)} (${r.confidence}: ${r.reason})`);
+    }
+    process.exit(1);
+  }
+
+  const bad = rows.filter((r) => !FIELD_BY_COLLECTION[r.collection]
+    || !Array.isArray(r.proposed) || r.proposed.length === 0
+    || r.proposed.some((d) => !DISCIPLINE_SET.has(d)));
+  if (bad.length) {
+    console.error(`REFUSING to run: ${bad.length} row(s) with an empty/off-vocabulary proposal or unknown collection:`);
+    for (const r of bad) console.error(`  ${r.collection}/${r._id} proposed=${JSON.stringify(r.proposed)}`);
+    process.exit(1);
+  }
+
+  const uri = process.env.MONGODB_URI;
+  if (!uri) throw new Error('MONGODB_URI not set');
+  // Never fall back to a default DB silently.
+  const uriDb = new URL(uri).pathname.replace(/^\//, '') || null;
+  const dbName = DB_OVERRIDE || uriDb;
+  if (!dbName) throw new Error('No database in MONGODB_URI path and no --db given — refusing to guess.');
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(dbName);
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'dry-run'} · DB: ${dbName} · artifact: ${path.basename(artifactPath)} · ${rows.length} rows`);
+
+  const affected = [...new Set(rows.map((r) => r.collection))];
+  const counts = async () => {
+    const out = {};
+    for (const c of affected) out[c] = await db.collection(c).countDocuments();
+    return out;
+  };
+  const pre = await counts();
+  console.table(pre);
+
+  // Plan every write first; verify each doc still exists and report drift
+  // between the artifact's `current` and what's in the DB now.
+  let unchanged = 0; const ops = []; const missing = []; const drifted = [];
+  for (const row of rows) {
+    const field = FIELD_BY_COLLECTION[row.collection];
+    const doc = await db.collection(row.collection).findOne(
+      { _id: new ObjectId(row._id) }, { projection: { [field]: 1, name: 1 } }
+    );
+    if (!doc) { missing.push(row); continue; }
+    const live = doc[field] == null ? [] : (Array.isArray(doc[field]) ? doc[field] : [doc[field]]);
+    const proposed = [...new Set(row.proposed)];
+    if (JSON.stringify(live) === JSON.stringify(proposed)) { unchanged++; continue; }
+    if (JSON.stringify(live) !== JSON.stringify(row.current)) drifted.push({ row, live });
+    ops.push({ row, field, live, proposed });
+  }
+
+  for (const { row, live, proposed } of ops) {
+    console.log(`  ${row.collection}/${row._id} "${row.name}": ${JSON.stringify(live)} -> ${JSON.stringify(proposed)}`);
+  }
+  if (missing.length) console.log(`  ${missing.length} artifact row(s) reference docs that no longer exist (skipped)`);
+  if (drifted.length) {
+    console.log(`  WARNING: ${drifted.length} doc(s) changed since classification (live differs from artifact "current") — re-check before applying:`);
+    for (const { row, live } of drifted) console.log(`    ${row.collection}/${row._id} live=${JSON.stringify(live)} artifact.current=${JSON.stringify(row.current)}`);
+  }
+  console.log(`\n${ops.length} write(s) planned, ${unchanged} already applied (no-op), ${missing.length} missing`);
+
+  if (!APPLY) {
+    console.log('Dry-run only. Re-run with --apply to write.');
+    await client.close();
+    return;
+  }
+  if (drifted.length) {
+    console.error('REFUSING to apply while docs have drifted since classification — re-run Phase A or fix the artifact.');
+    await client.close();
+    process.exit(1);
+  }
+
+  // Preflight: write-once audit doc + dump (rollback path)
+  await db.collection('_migration_audit').updateOne(
+    { migration: 'canonical-disciplines', phase: 'preflight' },
+    { $setOnInsert: { migration: 'canonical-disciplines', phase: 'preflight', at: new Date(), preCounts: pre, artifact: path.basename(artifactPath) } },
+    { upsert: true }
+  );
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const dumpDir = path.join(__dirname, '..', `migration-dump-${stamp}`);
+  const dumpUri = uriWithDb(uri, dbName);
+  const haveMongodump = spawnSync('mongodump', ['--version'], { stdio: 'pipe' }).status === 0;
+  if (haveMongodump) {
+    for (const c of affected) {
+      const r = spawnSync('mongodump', [`--uri=${dumpUri}`, `--collection=${c}`, `--out=${dumpDir}`], { stdio: 'pipe' });
+      if (r.status !== 0) {
+        throw new Error(`mongodump failed for ${c} — aborting before any change: ${redact(r.stderr ? r.stderr.toString() : '(no stderr)')}`);
+      }
+    }
+    console.log(`Dump written to ${dumpDir} (mongodump — rollback via mongorestore)`);
+  } else {
+    // Fallback when mongodump isn't installed: full-doc EJSON dump via the
+    // driver. Rollback = replaceOne per doc from these files. Both
+    // collections are small (hundreds of docs), so this is fine.
+    const { EJSON } = require('bson');
+    fs.mkdirSync(dumpDir, { recursive: true });
+    for (const c of affected) {
+      const docs = await db.collection(c).find({}).toArray();
+      fs.writeFileSync(path.join(dumpDir, `${c}.ejson`), EJSON.stringify(docs, { relaxed: false }));
+      console.log(`  dumped ${docs.length} ${c} docs`);
+    }
+    console.log(`Dump written to ${dumpDir} (driver EJSON fallback — mongodump not installed)`);
+  }
+
+  let applied = 0;
+  for (const { row, field, proposed } of ops) {
+    const res = await db.collection(row.collection).updateOne(
+      { _id: new ObjectId(row._id) },
+      { $set: { [field]: proposed, updatedAt: new Date() } }
+    );
+    if (res.modifiedCount) applied++;
+  }
+  console.log(`${applied} doc(s) updated`);
+
+  // Postflight: counts unchanged + every stored value canonical
+  const post = await counts();
+  for (const c of affected) {
+    if (post[c] !== pre[c]) throw new Error(`doc count changed for ${c}: ${pre[c]} -> ${post[c]}`);
+  }
+  const offVocab = {};
+  for (const c of affected) {
+    const values = await db.collection(c).distinct(FIELD_BY_COLLECTION[c]);
+    const bad = values.filter((v) => v != null && !DISCIPLINE_SET.has(v));
+    if (bad.length) offVocab[c] = bad;
+  }
+  if (Object.keys(offVocab).length) {
+    console.error('POSTFLIGHT: off-vocabulary values remain (docs the artifact never covered?):', offVocab);
+    console.error('Re-run Phase A against this DB to classify them.');
+  } else {
+    console.log('POSTFLIGHT OK: every stored discipline value is canonical.');
+  }
+
+  let gitSha = 'unknown';
+  try { gitSha = execSync('git rev-parse HEAD', { cwd: __dirname }).toString().trim(); } catch { /* best effort */ }
+  await db.collection('_migration_audit').insertOne({
+    migration: 'canonical-disciplines', phase: 'complete', at: new Date(),
+    postCounts: post, applied, artifact: path.basename(artifactPath), gitSha,
+    offVocabRemaining: offVocab,
+  });
+  console.log('APPLY complete.');
+  await client.close();
+}
+
+main().catch((err) => { console.error(redact(err.message)); process.exit(1); });


### PR DESCRIPTION
## What

Phase A + Phase B of categorizing existing exercises (231) and session templates (16) into the canonical 15-value discipline vocabulary, with a mandatory human-review checkpoint between them. **The committed artifact contains 9 low-confidence rows that need your adjudication before the prod apply** — see below.

## How it works

**Phase A — `ai-coach-service/scripts/classify_disciplines.py`** (read-only, `rescore_memories.py` conventions: no prod DB-name fallback, valid OpenAI key from ai-coach-service/.env):
1. Deterministic pass: case-folds + the pinned synonym map (`endurance`/`Conditioning`→cardio, `powerlifting`/`power`/`Strength Training`→strength) — tagged `source: synonym`, skips the LLM. Already-canonical docs produce no row.
2. Per-doc LLM pass only for values no rule can place (`warm_up`, `core`, `corrective`, `balance`, `stability`, `General Fitness`): 1-2 disciplines by name+description, confidence + reason. Low confidence → `approved: false`.
3. Writes `discipline-classification-<date>.json` + `.csv`.

**Phase B — `backend/scripts/migrate-canonical-disciplines.js`** (`migrate-workout-to-session.js` conventions): dry-run default, `--apply` to write, `--collection` filter, `--db` override for rehearsal. Hard gates: refuses while ANY row has `approved !== true` (prints them); refuses off-vocab/empty proposals; refuses `--apply` if a doc drifted since classification. Apply flow: write-once preflight `_migration_audit` doc → full dump (`mongodump`, or driver EJSON fallback when not installed) → per-row `$set` of the deduped canonical array → postflight `distinct ⊆ canonical` + unchanged doc counts → completion audit doc with artifact name + git SHA. Idempotent by construction.

## The artifact (run 2026-07-27 against prod)

86 rows: 59 synonym / 27 LLM, 42 touching shared `isCommon` docs. **9 rows await adjudication** (`approved: false`) — mostly `warm_up` exercises (proposed mobility/recovery) and the placeholder-named `General Fitness` items (Exercise 1/2, Workout 1/2 → strength). Review the CSV, edit `proposed` if you disagree, flip `approved` to `true` in the JSON.

## Verified on a scratch copy of prod (dropped after)

- Dry-run diffs sane (e.g. `["endurance","calisthenics"]` → `["cardio","calisthenics"]`, case-folds, `General Fitness` → per-doc judgments).
- `--apply`: 86 docs updated, postflight all-canonical, counts unchanged, audit docs written.
- Re-apply: 0 writes (idempotent). Refusal gate blocks the 9 unadjudicated rows with a per-row listing.
- Smoke run `--limit 20` first, per plan.

## Prod apply (after review — not part of this PR's merge)

```
# 1. adjudicate the 9 rows in backend/scripts/discipline-classification-2026-07-27.json
# 2. cd backend && node scripts/migrate-canonical-disciplines.js scripts/discipline-classification-2026-07-27.json          # dry-run
# 3. node scripts/migrate-canonical-disciplines.js scripts/discipline-classification-2026-07-27.json --apply
```

PR 4 (enum validation on Exercise/SessionTemplate + consolidating the drifted 6-value VALID_DISCIPLINES lists) is gated on this apply having run in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)