### PR TITLE
Sport interests 5: free-text sports — 'triathlon' is its own sport

### DIFF
--- a/ai-coach-service/app/core/agents/interest_mix.py
+++ b/ai-coach-service/app/core/agents/interest_mix.py
@@ -16,11 +16,14 @@ Data sources (union, deduped):
   already represented by their (completed) calendar event
 """
 
+import json
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from bson import ObjectId
+
+from app.core.disciplines import DISCIPLINES, DISCIPLINES_LIST
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +39,99 @@ ACTIVITY_DISCIPLINE_ALIASES: Dict[str, tuple] = {
     "endurance": ("cardio", "running"),
     "other": (),
 }
+
+# Shared (cross-user) cache of custom-sport -> canonical-discipline mappings,
+# so "triathlon" is LLM-resolved once, ever. Owned by the coach service.
+RESOLUTION_COLLECTION = "sportinterestresolutions"
+
+RESOLVE_PROMPT = (
+    "Athletes name sports in their own words. For each sport below, list which "
+    "of these training disciplines an activity log would fall under when "
+    f"training for it: {DISCIPLINES_LIST}.\n"
+    "Examples: triathlon -> running, cycling, swimming; ninja -> calisthenics, "
+    "climbing. Use 1-3 disciplines; use an empty list if none fit.\n"
+    'Return ONLY JSON: {"mappings": [{"label": "<sport verbatim>", '
+    '"disciplines": ["running"]}]}.'
+)
+
+
+async def resolve_interest_disciplines(
+    db, llm_client, settings, interests: List[str]
+) -> Dict[str, Tuple[str, ...]]:
+    """label -> canonical disciplines whose recorded activity serves that
+    interest. Canonical labels map to themselves; custom labels ("triathlon")
+    resolve through the shared cache, with one batched fast-model call for
+    misses. Unmappable labels map to () — the mix must then treat them as
+    unmeasurable, never as neglected. Failures resolve to () uncached."""
+    out: Dict[str, Tuple[str, ...]] = {}
+    unresolved = []
+    for label in interests:
+        key = (label or "").strip().lower()
+        if not key:
+            continue
+        if key in DISCIPLINES:
+            out[label] = (key,)
+        else:
+            unresolved.append((label, key))
+
+    if not unresolved:
+        return out
+
+    cached = {
+        doc["label"]: doc
+        async for doc in db[RESOLUTION_COLLECTION].find(
+            {"label": {"$in": [key for _, key in unresolved]}}
+        )
+    }
+    misses = []
+    for label, key in unresolved:
+        if key in cached:
+            out[label] = tuple(cached[key].get("disciplines", []))
+        else:
+            misses.append((label, key))
+    if not misses:
+        return out
+
+    try:
+        prompt = (
+            "SPORTS:\n" + "\n".join(f"- {key}" for _, key in misses)
+            + f"\n\n{RESOLVE_PROMPT}"
+        )
+        response = await llm_client.chat.completions.create(
+            model=settings.openai_model_fast,
+            messages=[{"role": "user", "content": prompt}],
+            max_completion_tokens=500,
+            response_format={"type": "json_object"},
+            **settings.llm_tuning_params(temperature=0.1),
+        )
+        raw = (response.choices[0].message.content or "").strip()
+        mapped = {
+            str(m.get("label", "")).strip().lower():
+                tuple(d for d in (m.get("disciplines") or []) if d in DISCIPLINES)[:3]
+            for m in json.loads(raw).get("mappings", [])
+        }
+        for label, key in misses:
+            disciplines = mapped.get(key)
+            if disciplines is None:
+                out[label] = ()
+                continue  # model skipped it — don't cache, retry next time
+            out[label] = disciplines
+            await db[RESOLUTION_COLLECTION].update_one(
+                {"label": key},
+                {"$setOnInsert": {
+                    "label": key,
+                    "disciplines": list(disciplines),
+                    "source": "llm",
+                    "createdAt": datetime.utcnow(),
+                }},
+                upsert=True,
+            )
+    except Exception as e:
+        logger.error(f"Interest resolution failed ({[k for _, k in misses]}): {e}")
+        for label, _ in misses:
+            out.setdefault(label, ())
+    return out
+
 
 NUDGE_RULES = (
     "Nudging rules: goals, active plans, injuries and recovery ALWAYS take "
@@ -82,18 +178,28 @@ async def load_recent_discipline_counts(
 
 
 def build_interest_mix_block(
-    interests: List[str], counts: Dict[str, int], days: int = MIX_WINDOW_DAYS
+    interests: List[str],
+    counts: Dict[str, int],
+    days: int = MIX_WINDOW_DAYS,
+    resolutions: Optional[Dict[str, Tuple[str, ...]]] = None,
 ) -> Optional[str]:
     """Pure: the prompt block, or None when there's nothing worth saying
-    (no declared interests, or too little recorded activity to judge mix)."""
+    (no declared interests, or too little recorded activity to judge mix).
+
+    `resolutions` maps each interest label to the canonical disciplines whose
+    activity serves it (see resolve_interest_disciplines). Without an entry, a
+    canonical label maps to itself and a custom label is UNMEASURABLE — listed
+    as declared but never called neglected (a false "you haven't done X" is
+    the one failure this feature must not have)."""
     interests = [i for i in (interests or []) if i]
     if not interests:
         return None
     total = sum(counts.values())
     if total < MIN_ACTIVITIES_FOR_MIX:
         return None
+    resolutions = resolutions or {}
 
-    # Which interests got any volume, counting aliased off-vocab activity
+    # Which disciplines got any volume, counting aliased off-vocab activity
     # (an 'endurance' ride serves both a cardio and a running interest).
     covered = set()
     for raw, count in counts.items():
@@ -101,7 +207,17 @@ def build_interest_mix_block(
             continue
         for target in ACTIVITY_DISCIPLINE_ALIASES.get(raw, (raw,)):
             covered.add(target)
-    neglected = [i for i in interests if i not in covered]
+
+    neglected, mappings_shown = [], []
+    for interest in interests:
+        key = interest.strip().lower()
+        mapped = resolutions.get(interest, (key,) if key in DISCIPLINES else ())
+        if not mapped:
+            continue  # unmeasurable custom sport — never call it neglected
+        if key not in DISCIPLINES and set(mapped) != {key}:
+            mappings_shown.append(f"{interest} counts activity from {', '.join(mapped)}")
+        if not any(d in covered for d in mapped):
+            neglected.append(interest)
 
     mix = ", ".join(f"{d} {c}" for d, c in sorted(counts.items(), key=lambda x: -x[1]))
     lines = [
@@ -109,6 +225,8 @@ def build_interest_mix_block(
         f"- Declared interests: {', '.join(interests)}",
         f"- Activity by discipline: {mix}",
     ]
+    if mappings_shown:
+        lines.append(f"- Custom sport mapping: {'; '.join(mappings_shown)}")
     if neglected:
         lines.append(f"- Interests with little/no recorded volume: {', '.join(neglected)}")
     lines.append(NUDGE_RULES)

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -31,7 +31,11 @@ from app.core.agents.services import (
     MemoryService,
 )
 from app.core.agents.services.calendar_service import format_calendar_anchors
-from app.core.agents.interest_mix import build_interest_mix_block, load_recent_discipline_counts
+from app.core.agents.interest_mix import (
+    build_interest_mix_block,
+    load_recent_discipline_counts,
+    resolve_interest_disciplines,
+)
 from app.services.coach_question_service import CoachQuestionService
 from app.services.recommendation_service import RecommendationService
 from app.services.short_term_context_service import ShortTermContextService
@@ -464,7 +468,10 @@ class AgentOrchestrator:
             interests = (data_context or {}).get("user_profile", {}).get("sportPreferences", [])
             if interests:
                 counts = await load_recent_discipline_counts(self.db, user_id, local_now)
-                mix_block = build_interest_mix_block(interests, counts)
+                resolutions = await resolve_interest_disciplines(
+                    self.db, self.client, self.settings, interests
+                )
+                mix_block = build_interest_mix_block(interests, counts, resolutions=resolutions)
                 if mix_block:
                     blocks.append(mix_block)
         except Exception as e:

--- a/ai-coach-service/app/core/agents/skills/update_sport_preferences_skill.py
+++ b/ai-coach-service/app/core/agents/skills/update_sport_preferences_skill.py
@@ -22,13 +22,15 @@ from app.core.agents.skills.registry import SkillContext, skill
 
 
 def _clean(values: Any) -> List[str]:
-    """Lowercase, keep only canonical disciplines, dedupe preserving order."""
+    """Lowercase, trim, dedupe preserving order. Free text is allowed BY
+    DESIGN — 'triathlon' or 'ninja' is a sport in its own right, not just its
+    component disciplines — so the only rejections are empty/oversized junk."""
     out: List[str] = []
     for value in values or []:
         if not isinstance(value, str):
             continue
         lower = value.strip().lower()
-        if lower in DISCIPLINES and lower not in out:
+        if lower and len(lower) <= 60 and lower not in out:
             out.append(lower)
     return out
 
@@ -38,24 +40,30 @@ def _clean(values: Any) -> List[str]:
     description=(
         "Update the athlete's Training Interests (the sports they want in their "
         "life, shown in their profile) — ONLY when they explicitly state an "
-        "interest change ('I want to get into climbing', 'I'm done with yoga'). "
-        "Add and/or remove specific sports; never rewrite the whole list, and "
-        "never call this to ask or guess. Confirm the change conversationally "
-        "afterwards. NOT for spectator sports they watch (news follows) and NOT "
-        "for logging activity."
+        "interest change ('I want to get into climbing', 'I'm training for a "
+        "triathlon', 'I'm done with yoga'). Any sport is valid, in the "
+        "athlete's own words — keep 'triathlon' as 'triathlon', don't split it "
+        "into swimming/cycling/running. Add and/or remove specific sports; "
+        "never rewrite the whole list, and never call this to ask or guess. "
+        "Confirm the change conversationally afterwards. NOT for spectator "
+        "sports they watch (news follows) and NOT for logging activity."
     ),
     parameters={
         "type": "object",
         "properties": {
             "add": {
                 "type": "array",
-                "items": {"type": "string", "enum": list(DISCIPLINES)},
-                "description": "Sports the athlete said they want in their training.",
+                "items": {"type": "string"},
+                "description": (
+                    "Sports the athlete said they want in their training, in "
+                    f"their own words. Common disciplines: {', '.join(DISCIPLINES)} "
+                    "— but any sport is valid ('triathlon', 'ninja', 'surfing')."
+                ),
             },
             "remove": {
                 "type": "array",
-                "items": {"type": "string", "enum": list(DISCIPLINES)},
-                "description": "Sports the athlete said they no longer want.",
+                "items": {"type": "string"},
+                "description": "Sports the athlete said they no longer want (match their existing list).",
             },
         },
     },

--- a/ai-coach-service/evals/scenarios.py
+++ b/ai-coach-service/evals/scenarios.py
@@ -746,6 +746,26 @@ DROP_INTEREST = Scenario(
 )
 
 
+async def _check_custom_interest_added(db, user_id, refs, trace):
+    interests = await _get_interests(db, user_id)
+    if "triathlon" not in interests:
+        return [f"triathlon not recorded verbatim in profile.sportPreferences ({interests!r})"]
+    for part in ("swimming", "cycling", "running"):
+        if part in interests:
+            return [f"triathlon was split into component disciplines ({interests!r}) — "
+                    "it must stay one sport"]
+    return []
+
+
+CUSTOM_INTEREST = Scenario(
+    id="volunteered-custom-sport-kept-verbatim",
+    turns=["I'm training for a triathlon these days — make sure it's in my training interests"],
+    seed=_seed_nothing,
+    final_state_check=_check_custom_interest_added,
+    trajectory_checks=[assert_no_false_success],
+)
+
+
 async def _check_no_interest_write(db, user_id, refs, trace):
     problems = []
     if await _get_interests(db, user_id):
@@ -779,5 +799,6 @@ SCENARIOS = [
     MIXED_DISCIPLINE_PLAN,
     VOLUNTEER_INTEREST,
     DROP_INTEREST,
+    CUSTOM_INTEREST,
     NO_UNPROMPTED_INTEREST_WRITE,
 ]

--- a/ai-coach-service/tests/test_interest_mix.py
+++ b/ai-coach-service/tests/test_interest_mix.py
@@ -10,8 +10,10 @@ from pymongo import ReturnDocument
 
 from app.core.agents.interest_mix import (
     MIX_WINDOW_DAYS,
+    RESOLUTION_COLLECTION,
     build_interest_mix_block,
     load_recent_discipline_counts,
+    resolve_interest_disciplines,
 )
 from app.core.agents.skills.update_sport_preferences_skill import (
     update_sport_preferences,
@@ -53,6 +55,91 @@ class TestBuildInterestMixBlock:
     def test_other_carries_no_signal(self):
         block = build_interest_mix_block(["climbing"], {"other": 5})
         assert "little/no recorded volume: climbing" in block
+
+
+class TestCustomInterestMix:
+    def test_custom_sport_covered_via_mapped_disciplines(self):
+        # a logged ride serves the triathlon interest
+        block = build_interest_mix_block(
+            ["triathlon", "strength"], {"cycling": 4},
+            resolutions={"triathlon": ("running", "cycling", "swimming"), "strength": ("strength",)},
+        )
+        assert "Declared interests: triathlon, strength" in block
+        assert "triathlon counts activity from running, cycling, swimming" in block
+        assert "little/no recorded volume: strength" in block  # not triathlon
+
+    def test_custom_sport_neglected_when_no_mapped_activity(self):
+        block = build_interest_mix_block(
+            ["triathlon"], {"strength": 5},
+            resolutions={"triathlon": ("running", "cycling", "swimming")},
+        )
+        assert "little/no recorded volume: triathlon" in block
+
+    def test_unmeasurable_custom_sport_never_called_neglected(self):
+        # unmapped ("ninja" resolution failed / empty) -> listed, not nudged
+        block = build_interest_mix_block(
+            ["ninja"], {"strength": 5}, resolutions={"ninja": ()},
+        )
+        assert "Declared interests: ninja" in block
+        assert "little/no recorded volume" not in block
+
+
+class TestResolveInterestDisciplines:
+    def _db(self, cached_docs):
+        db = MagicMock()
+        cursor = MagicMock()
+
+        async def gen():
+            for doc in cached_docs:
+                yield doc
+        db[RESOLUTION_COLLECTION].find = MagicMock(return_value=gen())
+        db[RESOLUTION_COLLECTION].update_one = AsyncMock()
+        return db
+
+    def _llm(self, payload):
+        llm = MagicMock()
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = payload
+        llm.chat.completions.create = AsyncMock(return_value=response)
+        return llm
+
+    def _settings(self):
+        settings = MagicMock()
+        settings.openai_model_fast = "fast"
+        settings.llm_tuning_params = MagicMock(return_value={})
+        return settings
+
+    async def test_canonical_labels_skip_db_and_llm(self):
+        db, llm = self._db([]), self._llm("{}")
+        out = await resolve_interest_disciplines(db, llm, self._settings(), ["climbing", "yoga"])
+        assert out == {"climbing": ("climbing",), "yoga": ("yoga",)}
+        db[RESOLUTION_COLLECTION].find.assert_not_called()
+        llm.chat.completions.create.assert_not_called()
+
+    async def test_cache_hit_skips_llm(self):
+        db = self._db([{"label": "triathlon", "disciplines": ["running", "cycling", "swimming"]}])
+        llm = self._llm("{}")
+        out = await resolve_interest_disciplines(db, llm, self._settings(), ["Triathlon"])
+        assert out == {"Triathlon": ("running", "cycling", "swimming")}
+        llm.chat.completions.create.assert_not_called()
+
+    async def test_cache_miss_resolves_and_caches(self):
+        db = self._db([])
+        llm = self._llm('{"mappings": [{"label": "ninja", "disciplines": ["calisthenics", "climbing", "junk"]}]}')
+        out = await resolve_interest_disciplines(db, llm, self._settings(), ["ninja"])
+        assert out == {"ninja": ("calisthenics", "climbing")}  # off-vocab filtered
+        upsert = db[RESOLUTION_COLLECTION].update_one.call_args
+        assert upsert[0][0] == {"label": "ninja"}
+        assert upsert[0][1]["$setOnInsert"]["disciplines"] == ["calisthenics", "climbing"]
+
+    async def test_llm_failure_resolves_to_unmeasurable_uncached(self):
+        db = self._db([])
+        llm = MagicMock()
+        llm.chat.completions.create = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await resolve_interest_disciplines(db, llm, self._settings(), ["ninja"])
+        assert out == {"ninja": ()}
+        db[RESOLUTION_COLLECTION].update_one.assert_not_called()
 
 
 class TestLoadRecentDisciplineCounts:
@@ -132,9 +219,19 @@ class TestUpdateSportPreferencesSkill:
         assert calls[1][0][1] == {"$addToSet": {"profile.sportPreferences": {"$each": ["climbing"]}}}
         assert calls[1][1]["return_document"] == ReturnDocument.AFTER
 
-    async def test_off_vocabulary_values_rejected(self):
+    async def test_custom_sports_accepted_verbatim(self):
+        # free text is a feature: triathlon is its own sport, not its parts
+        ctx = self._ctx({"profile": {"sportPreferences": ["triathlon"]}})
+        res = await update_sport_preferences(ctx, USER_ID, {"add": ["Triathlon"]})
+        assert res["success"] is True
+        update = ctx.db.users.find_one_and_update.call_args[0][1]
+        assert update == {"$addToSet": {"profile.sportPreferences": {"$each": ["triathlon"]}}}
+
+    async def test_empty_and_oversized_values_rejected(self):
         ctx = self._ctx({"profile": {"sportPreferences": []}})
-        res = await update_sport_preferences(ctx, USER_ID, {"add": ["crossfit", ""]})
+        res = await update_sport_preferences(
+            ctx, USER_ID, {"add": ["", "   ", "x" * 61, 42]}
+        )
         assert res["success"] is False
         ctx.db.users.find_one_and_update.assert_not_called()
 

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,7 +1,6 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
-const { DISCIPLINES } = require('../config/disciplines');
 
 const userSchema = new mongoose.Schema({
   email: {
@@ -75,10 +74,15 @@ const userSchema = new mongoose.Schema({
       default: 'beginner'
     },
     goals: [String],
-    // Sports the user wants in their training (canonical discipline
-    // vocabulary, e.g. ['running', 'climbing', 'yoga']) — feeds AI-coach
-    // context. Distinct from settings.sportsNews.follows (leagues they watch).
-    sportPreferences: { type: [String], enum: DISCIPLINES },
+    // Sports the user wants in their training — feeds AI-coach context.
+    // Deliberately free text (no enum): canonical disciplines are quick-pick
+    // chips in Settings, but any sport is allowed ('triathlon', 'ninja') —
+    // a triathlon is its own sport, not just swimming+cycling+running. The
+    // coach reads labels verbatim; the interest-mix nudge resolves custom
+    // labels to canonical disciplines via a cached LLM mapping
+    // (ai-coach sportinterestresolutions). Distinct from
+    // settings.sportsNews.follows (leagues they watch).
+    sportPreferences: [{ type: String, trim: true, maxlength: 60 }],
     injuries: [String], // any injuries to be aware of
     preferences: {
       sessionDuration: Number, // preferred minutes

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -6,7 +6,7 @@ import { Switch } from '@/components/ui/switch';
 import { useTheme } from '@/contexts/ThemeContext';
 import { StravaIntegration } from '@/api/entities';
 import apiService from '@/services/api';
-import { DISCIPLINE_GROUPS } from '@/constants/disciplines';
+import { DISCIPLINES, DISCIPLINE_GROUPS } from '@/constants/disciplines';
 import { getDisciplineColor } from '@/styles/designTokens';
 import {
   AlertDialog,
@@ -29,6 +29,7 @@ export default function Settings() {
   const [editingField, setEditingField] = useState(null);
   const [newGoal, setNewGoal] = useState('');
   const [newInjury, setNewInjury] = useState('');
+  const [newSport, setNewSport] = useState('');
 
   // Sports-news follows state (free-text add flow)
   const [newsQuery, setNewsQuery] = useState('');
@@ -429,11 +430,22 @@ export default function Settings() {
     commitProfile({ ...formData.profile, sportPreferences: next });
   };
 
+  const addCustomSport = () => {
+    const v = newSport.trim().toLowerCase();
+    setNewSport('');
+    if (!v || v.length > 60) return;
+    const current = formData.profile.sportPreferences || [];
+    if (current.some((s) => s.toLowerCase() === v)) return;
+    commitProfile({ ...formData.profile, sportPreferences: [...current, v] });
+  };
+
   // Plain render function for the same focus-preservation reason as
-  // renderChipEditor. Fixed-choice toggle chips — the canonical discipline
-  // vocabulary, never free text.
+  // renderChipEditor. Canonical disciplines are quick-pick toggle chips;
+  // any other sport can be typed ('triathlon', 'ninja') — a sport like
+  // triathlon is its own identity, not just its component disciplines.
   const renderDisciplinePicker = () => {
     const selected = formData.profile.sportPreferences || [];
+    const customSports = selected.filter((s) => !DISCIPLINES.includes(s));
     return (
       <div className="py-4 border-b border-gray-100 dark:border-gray-800">
         <div className="flex items-center gap-2 mb-3">
@@ -470,6 +482,49 @@ export default function Settings() {
               </div>
             </div>
           ))}
+          <div>
+            <p className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1.5">
+              Your sports
+            </p>
+            {customSports.length > 0 && (
+              <div className="flex flex-wrap gap-2 mb-2">
+                {customSports.map((sport) => (
+                  <span
+                    key={sport}
+                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full border text-sm capitalize font-semibold text-gray-900 dark:text-white border-primary-400 bg-primary-400/10"
+                  >
+                    {sport}
+                    <button onClick={() => toggleSportPreference(sport)} className="hover:text-red-500" title="Remove">
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={newSport}
+                onChange={(e) => setNewSport(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addCustomSport();
+                  }
+                }}
+                maxLength={60}
+                placeholder="Add your own — e.g. triathlon, ninja, surfing"
+                className="flex-1 px-4 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-400/50"
+              />
+              <button
+                onClick={addCustomSport}
+                disabled={!newSport.trim() || isSaving}
+                className="px-4 py-2 bg-primary-400 text-gray-900 font-semibold rounded-xl hover:bg-primary-500 transition-colors disabled:opacity-50"
+              >
+                Add
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## What

Training interests become fully flexible (user request): canonical disciplines remain quick-pick chips, but any sport can be added in the athlete's own words — "triathlon", "ninja", "surfing". The design principle: **the label is the sport's identity**. Triathlon is very different from swimming+cycling+running separately, so it's never split — the coach sees and reasons about "triathlon" verbatim; decomposition to disciplines happens only where recorded activity must be counted.

## Changes

- **`User.js`**: enum dropped *by design* (trim + maxlength 60 kept); comment documents the intent so a future cleanup doesn't "fix" it back.
- **`Settings.jsx`**: "Your sports" free-text input + removable custom chips below the quick-pick groups.
- **`update_sport_preferences` skill**: free-text args; prompt instructs keeping the athlete's own words.
- **`interest_mix.py`**: new `resolve_interest_disciplines()` — custom labels resolve to the canonical disciplines that serve them via a new shared **`sportinterestresolutions`** cache collection (SportResolution pattern: one batched fast-model call per new label ever, `$setOnInsert` upsert, coach-owned). Canonical labels map to themselves without touching DB/LLM. **Unmappable or failed labels are unmeasurable — listed as declared, never called neglected** (a false "you haven't done X" is the one failure this feature must not have). The mix block surfaces the mapping: `triathlon counts activity from running, cycling, swimming`.

## Verification

- 23 unit tests in `test_interest_mix.py`: cache hit skips LLM, miss resolves + caches (off-vocab filtered), LLM failure → unmeasurable + uncached, coverage via mapped disciplines (a logged ride serves triathlon), unmeasurable never neglected, skill free-text accept / junk reject.
- New real-LLM eval `volunteered-custom-sport-kept-verbatim` run live: "I'm training for a triathlon" → `triathlon` recorded verbatim, NOT split into components. Passes.
- Full suites: 618 pytest, 65 jest, vite build — green.

Note: PR 4 (enums on Exercise/SessionTemplate) is unaffected — content taxonomy stays canonical; only *user interests* are free-text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)