### PR TITLE
TOR-64: Fix duplicated exercises in live workout from template blocks + inline exercises

### DIFF
--- a/frontend/src/pages/TrainNow.jsx
+++ b/frontend/src/pages/TrainNow.jsx
@@ -415,11 +415,10 @@ export default function TrainNow() {
               name: scheduledEvent.title,
               estimated_duration: scheduledEvent.sessionDetails?.estimatedDuration || 45,
               primary_disciplines: [scheduledEvent.sessionDetails?.discipline || 'strength'],
-              // parseTemplateToSessionData concatenates blocks and exercises,
-              // so exactly one of the two may be non-empty or every exercise
-              // duplicates.
+              // parseTemplateToSessionData prefers blocks and only falls back
+              // to the flat exercises list when the blocks yield nothing.
               blocks: templateBlocks,
-              exercises: templateBlocks.length > 0 ? [] : convertedExercises,
+              exercises: convertedExercises,
               calendarEventId: scheduledEvent._id,
               sourceTemplateId: scheduledEvent.sessionTemplateId?._id,
               isCommon: scheduledEvent.sessionTemplateId?.isCommon

--- a/frontend/src/utils/liveSession.js
+++ b/frontend/src/utils/liveSession.js
@@ -274,7 +274,10 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
     exercises: []
   };
 
-  // Handle both blocks format and flat exercises array
+  // Handle both blocks format and flat exercises array. Blocks win when they
+  // yield exercises — some callers carry both shapes at once (e.g. a calendar
+  // event with a populated template's blocks AND embedded sessionDetails
+  // exercises), and appending both renders every exercise twice.
   const exerciseList = [];
 
   if (workout.blocks && Array.isArray(workout.blocks)) {
@@ -285,7 +288,7 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
     });
   }
 
-  if (workout.exercises && Array.isArray(workout.exercises)) {
+  if (exerciseList.length === 0 && workout.exercises && Array.isArray(workout.exercises)) {
     workout.exercises.forEach(ex => exerciseList.push(ex));
   }
 


### PR DESCRIPTION
## What changed

`parseTemplateToSessionData` in [frontend/src/utils/liveSession.js](../blob/main/frontend/src/utils/liveSession.js) appended exercises from **both** `blocks[].exercises` and the flat `exercises` array with no either/or guard. A calendar Today's Pick that carries a populated template's blocks AND embedded `sessionDetails.exercises` therefore rendered every exercise twice, each copy with its own set checklist.

- The flat `exercises` list is now a **fallback**, used only when blocks yield no exercises (either/or guard at the root cause).
- `TrainNow.jsx`'s caller-side workaround (`exercises: templateBlocks.length > 0 ? [] : convertedExercises`) is simplified to always pass `convertedExercises` — the parser now owns the preference, and events whose template blocks are empty correctly fall back to the embedded exercises instead of producing an empty session.

Note: the ticket's code pointers (`workoutSession.js`, `parseWorkoutToSessionData`) predate the workout→session rename; the same code now lives in `liveSession.js` / `parseTemplateToSessionData`.

## Verification

- Node unit check of the parser against 4 shapes — both-shapes (4 exercises in → 4 out, previously 8), blocks-only (2→2), flat-only (3→3), empty-blocks-with-flat fallback (1→1): **ALL PASS**
- `npm run build --prefix frontend`: ✓ built in 3.77s
- `npx eslint` on both changed files vs origin/main baseline: 38 pre-existing errors before, 38 after — **no new lint findings**

## Acceptance criteria

- [x] Starting Today's Pick shows each exercise exactly once
- [x] Blocks-only workouts (pure AI suggestion) and flat-only workouts (calendar) still build correct sessions
- [x] Set completion applies to the single card for that exercise (single card per exercise; LiveSession render maps the list once)

Linear: https://linear.app/torii-fitness/issue/TOR-64/fix-duplicated-exercises-in-live-workout-from-template-blocks-inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)