### PR TITLE
TOR-57: Fix Exercise Library truncation to the first 50 of 174 exercises

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -100,13 +100,33 @@ class APIService {
     // typeahead does not download the whole catalog. Falls back to substring today;
     // upgrades to Atlas $search transparently once the search index lands.
     list: async (params = {}) => {
-      const query = new URLSearchParams(
-        Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== '')
+      const buildQuery = (p) => new URLSearchParams(
+        Object.entries(p).filter(([, v]) => v !== undefined && v !== null && v !== '')
       ).toString();
-      const response = await this.request(`/exercises${query ? `?${query}` : ''}`);
-      // Backend returns { exercises: [...], pagination: {...} }
-      // Extract just the exercises array
-      return response.exercises || response;
+
+      // Callers that page explicitly (typeahead search with { search, limit })
+      // get exactly the page they asked for.
+      if (params.page !== undefined || params.limit !== undefined) {
+        const query = buildQuery(params);
+        const response = await this.request(`/exercises${query ? `?${query}` : ''}`);
+        return response.exercises || response;
+      }
+
+      // Catalog callers (Exercise.list()) get the WHOLE catalog: the backend
+      // always paginates (default limit 50), so follow the pagination metadata
+      // until every page is fetched — otherwise the library, pickers and the
+      // Exercise.get fallback only ever see the first 50 exercises.
+      const limit = 200;
+      const all = [];
+      for (let page = 1; page <= 50; page++) {
+        const response = await this.request(`/exercises?${buildQuery({ ...params, page, limit })}`);
+        const batch = response.exercises || response;
+        if (!Array.isArray(batch)) return batch;
+        all.push(...batch);
+        const pagination = response.pagination;
+        if (!pagination || page >= pagination.pages || batch.length === 0) break;
+      }
+      return all;
     },
     get: (id) => this.request(`/exercises/${id}`),
     // Semantically similar exercises (swap/alternative suggestions) via vector search.


### PR DESCRIPTION
## What changed

`apiService.exercises.list` sent no page/limit, so every paramless catalog caller (`Exercise.list()` → the Exercise Library page, SessionModal, ProgressionNavigator, TrainNow, CreateExercise, CreateSessionTemplate, Goals, Sessions, and the `Exercise.get` fallback) received only the backend's first page — 50 of 174 exercises — and the pagination metadata was discarded so callers couldn't know more pages existed.

The shared `list` method now:
- **Paramless callers**: fetches the whole catalog by following the returned `pagination` metadata (limit 200 per request, hard cap of 50 pages as a runaway guard; a response without pagination metadata degrades to the old single-fetch behavior).
- **Explicit `page`/`limit` callers** (the server-side search typeaheads in `useExerciseSearch`, `materializeExercise`, `InlineCreateExercise`): unchanged single-request behavior.

Because the library page filters/searches client-side over `Exercise.list()`'s result and the header count is `filteredExercises.length`, this one change makes all 174 exercises browsable/searchable, fixes the header count, and lets the `Exercise.get` fallback resolve exercises beyond the first 50 — no page-level changes needed.

## Verification

- Node simulation of the paging loop against a mock backend honoring page/limit exactly like `exerciseController`: 174-item catalog → 174 returned in 1 call; 450 → 3 calls; 400 → exactly 2 calls (no wasted trailing request); empty catalog → 1 call; backend without pagination metadata → single fetch, no loop; explicit `{search, limit: 5}` → 5 items in 1 call. **ALL PASS**
- `npx eslint src/services/api.js`: clean (0 findings)
- `npm run build --prefix frontend`: ✓ built in 3.85s

## Acceptance criteria

- [x] All catalog exercises are reachable and searchable from `/exercises` (client-side search now runs over the full catalog)
- [x] The header count reflects the true total
- [x] Exercise pickers (workout builder, replace modals) can reach the full catalog
- [x] `Exercise.get` resolves exercises beyond the first 50

Linear: https://linear.app/torii-fitness/issue/TOR-57/fix-exercise-library-truncation-to-the-first-50-of-174-exercises

🤖 Generated with [Claude Code](https://claude.com/claude-code)