### PR TITLE
Frontend: block-aware live session with round tracking

### DIFF
--- a/backend/src/controllers/sessionLogController.js
+++ b/backend/src/controllers/sessionLogController.js
@@ -150,6 +150,7 @@ const createSessionLog = async (req, res) => {
       completedAt,
       actualDuration,
       exercises,
+      blocks,
       perceivedDifficulty,
       mood,
       notes,
@@ -197,6 +198,8 @@ const createSessionLog = async (req, res) => {
       completedAt: completedAtDate,
       actualDuration: resolvedDuration,
       exercises: resolvedExercises,
+      // Typed-block summary; blockLogSchema casts and drops unknown keys.
+      ...(Array.isArray(blocks) && blocks.length > 0 ? { blocks } : {}),
       perceivedDifficulty,
       mood,
       notes

--- a/backend/src/models/SessionLog.js
+++ b/backend/src/models/SessionLog.js
@@ -38,6 +38,18 @@ const exerciseLogSchema = new mongoose.Schema({
   avgRpe: Number
 }, { _id: false });
 
+// Summary of a typed session block as it was actually trained (rounds done,
+// structure). Absent for flat/legacy sessions.
+const blockLogSchema = new mongoose.Schema({
+  name: String,
+  type: String, // straight_sets|circuit|tabata|amrap|emom|interval|duration
+  rounds: Number, // planned rounds
+  rounds_completed: Number, // rounds actually finished (AMRAP: user-counted)
+  work_seconds: Number,
+  rest_seconds: Number,
+  duration_seconds: Number
+}, { _id: false });
+
 const sessionLogSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
@@ -70,6 +82,9 @@ const sessionLogSchema = new mongoose.Schema({
   actualDuration: Number, // in minutes
   // Exercises performed
   exercises: [exerciseLogSchema],
+  // Typed-block structure summary (how the session was organized and how many
+  // rounds were done). Optional — flat sessions have none.
+  blocks: [blockLogSchema],
   // Strain/intensity metrics
   totalStrain: {
     type: Number,

--- a/frontend/src/components/livesession/BlockHeader.jsx
+++ b/frontend/src/components/livesession/BlockHeader.jsx
@@ -1,0 +1,83 @@
+import { Plus, Minus, Check } from "lucide-react";
+import { BLOCK_TYPE_META, MULTI_ROUND_BLOCK_TYPES, formatBlockSummary } from "@/constants/blocks";
+
+/**
+ * Header card above a live-session block's exercise cards: block name, type
+ * chip, structural summary, round progress and +/- round controls.
+ *
+ * The current round is DERIVED from set completion (min completed sets across
+ * the block's exercises), so it survives reloads and stays consistent with
+ * per-set logging. AMRAP blocks have no set-derived rounds — they count
+ * `rounds_completed` via the +/- controls instead.
+ */
+export default function BlockHeader({ block, items, onCompleteRound, onAdjustRounds }) {
+  if (!block) return null;
+  const meta = BLOCK_TYPE_META[block.type] || BLOCK_TYPE_META.straight_sets;
+  const summary = formatBlockSummary(block);
+  const isMultiRound = MULTI_ROUND_BLOCK_TYPES.has(block.type);
+  const isAmrap = block.type === 'amrap';
+
+  const completedRounds = isMultiRound && items.length > 0
+    ? Math.min(...items.map(({ exercise }) => exercise.sets.filter(s => s.is_completed).length))
+    : 0;
+  const totalRounds = Math.max(1, block.rounds || 1);
+  const blockDone = isMultiRound && completedRounds >= totalRounds;
+  const currentRound = Math.min(completedRounds + 1, totalRounds);
+
+  return (
+    <div className="bg-gray-900 text-white rounded-2xl px-4 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="font-bold text-base truncate">{block.name}</h2>
+            {meta.chip && (
+              <span className="shrink-0 px-1.5 py-0.5 rounded bg-white/15 text-[10px] font-bold tracking-wider">
+                {meta.chip}
+              </span>
+            )}
+          </div>
+          {summary && <p className="text-xs text-white/60 mt-0.5">{summary}</p>}
+        </div>
+
+        {(isMultiRound || isAmrap) && (
+          <div className="shrink-0 flex items-center gap-1.5">
+            <button
+              onClick={() => onAdjustRounds(-1)}
+              aria-label="One round less"
+              className="w-7 h-7 rounded-full bg-white/10 flex items-center justify-center active:bg-white/25"
+            >
+              <Minus className="w-4 h-4" />
+            </button>
+            <span className="text-sm font-semibold tabular-nums min-w-[64px] text-center">
+              {isAmrap
+                ? `${block.rounds_completed || 0} rounds`
+                : blockDone
+                  ? `${totalRounds}/${totalRounds} ✓`
+                  : `Round ${currentRound}/${totalRounds}`}
+            </span>
+            <button
+              onClick={() => onAdjustRounds(1)}
+              aria-label="One round more"
+              className="w-7 h-7 rounded-full bg-white/10 flex items-center justify-center active:bg-white/25"
+            >
+              <Plus className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {block.instructions && (
+        <p className="text-xs text-white/70 mt-2">{block.instructions}</p>
+      )}
+
+      {isMultiRound && !blockDone && (
+        <button
+          onClick={onCompleteRound}
+          className="mt-2.5 w-full py-2 rounded-xl bg-white/10 active:bg-white/25 text-sm font-semibold flex items-center justify-center gap-1.5"
+        >
+          <Check className="w-4 h-4" /> Complete round {currentRound}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/constants/blocks.js
+++ b/frontend/src/constants/blocks.js
@@ -1,0 +1,72 @@
+/**
+ * Session-block structure vocabulary — frontend mirror.
+ *
+ * Canonical source is BLOCK_TYPES in backend/src/models/SessionTemplate.js;
+ * keep the values identical. A block with no `type` (all pre-typed-blocks
+ * data) is treated as 'straight_sets' everywhere.
+ */
+
+export const BLOCK_TYPES = [
+  'straight_sets',
+  'circuit',
+  'tabata',
+  'amrap',
+  'emom',
+  'interval',
+  'duration',
+];
+
+// Which structural fields are meaningful per type. Used by the live-session
+// header and the template editors so they can't drift.
+export const BLOCK_TYPE_META = {
+  straight_sets: { label: 'Sets × reps', chip: null, fields: [] },
+  circuit: { label: 'Circuit', chip: 'CIRCUIT', fields: ['rounds', 'rest_seconds'] },
+  tabata: { label: 'Tabata', chip: 'TABATA', fields: ['rounds', 'work_seconds', 'rest_seconds'] },
+  amrap: { label: 'AMRAP', chip: 'AMRAP', fields: ['duration_seconds'] },
+  emom: { label: 'EMOM', chip: 'EMOM', fields: ['rounds', 'work_seconds'] },
+  interval: { label: 'Intervals', chip: 'INTERVALS', fields: ['rounds', 'work_seconds', 'rest_seconds'] },
+  duration: { label: 'Continuous', chip: 'CONTINUOUS', fields: ['duration_seconds'] },
+};
+
+// Types where one completed set per exercise means one finished round, so the
+// live session shows a round counter and +/- round controls.
+export const MULTI_ROUND_BLOCK_TYPES = new Set(['circuit', 'tabata', 'emom', 'interval']);
+
+// Seconds → compact human label: 90 → "1:30", 600 → "10:00", 45 → "45s".
+export const formatBlockSeconds = (seconds) => {
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${String(secs).padStart(2, '0')}`;
+};
+
+/**
+ * One-line structural summary of a block, e.g. "8 × 20s on / 10s off",
+ * "3 rounds · 1:00 rest", "Cap 20:00", "10:00 continuous".
+ * Returns null for straight_sets / typeless blocks.
+ */
+export function formatBlockSummary(block) {
+  if (!block) return null;
+  const rounds = Math.max(1, block.rounds || 1);
+  const work = formatBlockSeconds(block.work_seconds);
+  const rest = formatBlockSeconds(block.rest_seconds);
+  const duration = formatBlockSeconds(block.duration_seconds);
+
+  switch (block.type) {
+    case 'tabata':
+      return `${rounds} × ${work || '20s'} on / ${rest || '10s'} off`;
+    case 'circuit':
+      return `${rounds} rounds${rest ? ` · ${rest} rest` : ''}`;
+    case 'emom':
+      return `Every minute for ${rounds} min${work ? ` · ${work} work` : ''}`;
+    case 'interval':
+      return `${rounds} × ${work || 'interval'}${rest ? ` / ${rest} rest` : ''}`;
+    case 'amrap':
+      return duration ? `As many rounds as possible in ${duration}` : 'As many rounds as possible';
+    case 'duration':
+      return duration ? `${duration} continuous` : 'Continuous effort';
+    default:
+      return null;
+  }
+}

--- a/frontend/src/pages/LiveSession.jsx
+++ b/frontend/src/pages/LiveSession.jsx
@@ -817,8 +817,14 @@ export default function LiveSession() {
   // regenerate defaults from the new exercise's strain.
   const handleReplaceExercise = (exIndex, picked, opts = {}) => {
     const old = workout.exercises[exIndex];
-    // The replacement stays in the block it replaces from.
-    const built = buildSessionExercise(picked, exIndex, { blockIndex: old.block_index ?? null });
+    // The replacement stays in the block it replaces from, and its default
+    // sets are generated from that block's structure (a tabata replacement
+    // gets `rounds` sets, not the catalog's 3x12).
+    const oldBlockIndex = Number.isInteger(old.block_index) ? old.block_index : null;
+    const built = buildSessionExercise(picked, exIndex, {
+      blockIndex: oldBlockIndex,
+      block: oldBlockIndex === null ? null : workout.blocks?.[oldBlockIndex] ?? null,
+    });
     // Session exercises ALWAYS have a sets array, so "has sets" is always true.
     // We only want to preserve actually-logged work; otherwise adopt the new
     // exercise's own generated defaults (e.g. swapping Plank 3×60s → Bench Press
@@ -880,11 +886,17 @@ export default function LiveSession() {
 
   const handleAddExercise = (exIndex, position, picked) => {
     const insertAt = position === 'above' ? exIndex : exIndex + 1;
-    // Inherit the anchor exercise's block so an insert mid-block stays in it.
-    const anchorBlockIndex = workout.exercises[exIndex]?.block_index ?? null;
+    // Inherit the anchor exercise's block so an insert mid-block stays in it,
+    // and generate block-shaped sets (rounds count) to keep the round counter
+    // coherent.
+    const rawAnchor = workout.exercises[exIndex]?.block_index;
+    const anchorBlockIndex = Number.isInteger(rawAnchor) ? rawAnchor : null;
     const nextExercises = withOrder([
       ...workout.exercises.slice(0, insertAt),
-      buildSessionExercise(picked, insertAt, { blockIndex: anchorBlockIndex }),
+      buildSessionExercise(picked, insertAt, {
+        blockIndex: anchorBlockIndex,
+        block: anchorBlockIndex === null ? null : workout.blocks?.[anchorBlockIndex] ?? null,
+      }),
       ...workout.exercises.slice(insertAt),
     ]);
     setWorkout({ ...workout, exercises: nextExercises });
@@ -907,12 +919,35 @@ export default function LiveSession() {
     setIsSaving(true);
 
     try {
+      // Typed-block summary for history/stats: what the structure was and how
+      // many rounds actually got done. rounds_completed is derived the same
+      // way the header does it (min completed sets across the block), except
+      // AMRAP where the user counts rounds explicitly.
+      const blocksSummary = (workout.blocks || []).map((block, blockIndex) => {
+        const inBlock = workout.exercises.filter(e => e.block_index === blockIndex);
+        const roundsCompleted = block.type === 'amrap'
+          ? (block.rounds_completed || 0)
+          : inBlock.length > 0
+            ? Math.min(...inBlock.map(e => e.sets.filter(s => s.is_completed).length))
+            : 0;
+        return {
+          name: block.name,
+          type: block.type,
+          rounds: block.rounds,
+          rounds_completed: roundsCompleted,
+          ...(block.work_seconds ? { work_seconds: block.work_seconds } : {}),
+          ...(Number.isFinite(block.rest_seconds) ? { rest_seconds: block.rest_seconds } : {}),
+          ...(block.duration_seconds ? { duration_seconds: block.duration_seconds } : {})
+        };
+      });
+
       const sessionLogData = {
         title: workout.title || 'Session',
         discipline: getDiscipline(workout.type),
         startedAt: workoutStartTime.toISOString(),
         completedAt: new Date().toISOString(),
         actualDuration: Math.ceil(totalSessionTime / 60) || workout.duration_minutes || 60,
+        ...(blocksSummary.length > 0 ? { blocks: blocksSummary } : {}),
         exercises: workout.exercises.map((ex, i) => ({
           exerciseId: ex.exercise_id,
           exerciseName: ex.exercise_name,

--- a/frontend/src/pages/LiveSession.jsx
+++ b/frontend/src/pages/LiveSession.jsx
@@ -7,8 +7,10 @@ import {
   saveSessionProgress,
   clearActiveSession,
   startLiveSession,
-  buildSessionExercise
+  buildSessionExercise,
+  groupExercisesByBlock
 } from "@/utils/liveSession";
+import BlockHeader from "@/components/livesession/BlockHeader";
 import {
   Drawer,
   DrawerContent,
@@ -428,6 +430,9 @@ function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComp
               <MoreVertical className="w-5 h-5" />
             </button>
           </div>
+          {exercise.volume_label && (
+            <p className="text-sm font-medium text-primary-600">{exercise.volume_label}</p>
+          )}
           {exercise.notes && (
             <p className="text-sm text-gray-500">{exercise.notes}</p>
           )}
@@ -629,6 +634,78 @@ export default function LiveSession() {
     setWorkout(newWorkout);
   };
 
+  // --- Block round handlers (typed blocks: circuit / tabata / emom / interval / amrap) ---
+
+  // One round done = the next uncompleted set of every exercise in the block.
+  const handleCompleteRound = (blockIndex) => {
+    setWorkout(w => ({
+      ...w,
+      exercises: w.exercises.map(ex => {
+        if (ex.block_index !== blockIndex) return ex;
+        const nextIdx = ex.sets.findIndex(s => !s.is_completed);
+        if (nextIdx === -1) return ex;
+        return {
+          ...ex,
+          sets: ex.sets.map((s, i) => (
+            i === nextIdx ? { ...s, is_completed: true, reps: s.reps || s.target_reps || 0 } : s
+          ))
+        };
+      })
+    }));
+    if (navigator.vibrate) navigator.vibrate(40);
+  };
+
+  // Adjust a block's round count mid-session: one set per exercise is added
+  // or removed at the tail. Completed sets are never removed, so rounds can't
+  // drop below what's already been done. AMRAP has no set-backed rounds — the
+  // +/- drives its rounds_completed counter instead.
+  const handleAdjustRounds = (blockIndex, delta) => {
+    setWorkout(w => {
+      const block = w.blocks?.[blockIndex];
+      if (!block) return w;
+
+      if (block.type === 'amrap') {
+        const blocks = w.blocks.map((b, i) => (
+          i === blockIndex ? { ...b, rounds_completed: Math.max(0, (b.rounds_completed || 0) + delta) } : b
+        ));
+        return { ...w, blocks };
+      }
+
+      const inBlock = w.exercises.filter(e => e.block_index === blockIndex);
+      const maxCompleted = inBlock.reduce(
+        (m, e) => Math.max(m, e.sets.filter(s => s.is_completed).length), 0
+      );
+      const nextRounds = Math.max(1, maxCompleted, (block.rounds || 1) + delta);
+      if (nextRounds === (block.rounds || 1)) return w;
+
+      const growing = nextRounds > (block.rounds || 1);
+      const blocks = w.blocks.map((b, i) => (i === blockIndex ? { ...b, rounds: nextRounds } : b));
+      const exercises = w.exercises.map(ex => {
+        if (ex.block_index !== blockIndex) return ex;
+        if (growing) {
+          const last = ex.sets[ex.sets.length - 1];
+          return {
+            ...ex,
+            sets: [...ex.sets, {
+              target_reps: last?.target_reps ?? null,
+              reps: 0,
+              weight: last?.weight || 0,
+              rest_seconds: last?.rest_seconds ?? null,
+              is_completed: false
+            }]
+          };
+        }
+        const lastSet = ex.sets[ex.sets.length - 1];
+        if (ex.sets.length > 1 && lastSet && !lastSet.is_completed) {
+          return { ...ex, sets: ex.sets.slice(0, -1) };
+        }
+        return ex;
+      });
+      return { ...w, blocks, exercises };
+    });
+    if (navigator.vibrate) navigator.vibrate(30);
+  };
+
   // --- Exercise modification handlers ---
 
   // Re-normalize the cosmetic `order` field to match array position.
@@ -739,8 +816,9 @@ export default function LiveSession() {
   // sets array (counts + completion). Only when the old exercise had no sets do we
   // regenerate defaults from the new exercise's strain.
   const handleReplaceExercise = (exIndex, picked, opts = {}) => {
-    const built = buildSessionExercise(picked, exIndex);
     const old = workout.exercises[exIndex];
+    // The replacement stays in the block it replaces from.
+    const built = buildSessionExercise(picked, exIndex, { blockIndex: old.block_index ?? null });
     // Session exercises ALWAYS have a sets array, so "has sets" is always true.
     // We only want to preserve actually-logged work; otherwise adopt the new
     // exercise's own generated defaults (e.g. swapping Plank 3×60s → Bench Press
@@ -802,9 +880,11 @@ export default function LiveSession() {
 
   const handleAddExercise = (exIndex, position, picked) => {
     const insertAt = position === 'above' ? exIndex : exIndex + 1;
+    // Inherit the anchor exercise's block so an insert mid-block stays in it.
+    const anchorBlockIndex = workout.exercises[exIndex]?.block_index ?? null;
     const nextExercises = withOrder([
       ...workout.exercises.slice(0, insertAt),
-      buildSessionExercise(picked, insertAt),
+      buildSessionExercise(picked, insertAt, { blockIndex: anchorBlockIndex }),
       ...workout.exercises.slice(insertAt),
     ]);
     setWorkout({ ...workout, exercises: nextExercises });
@@ -921,20 +1001,40 @@ export default function LiveSession() {
         />
       </div>
 
-      {/* Exercise Cards List */}
+      {/* Exercise Cards List — grouped into block sections. Legacy sessions
+          (no blocks / no block_index) yield one null-block section and render
+          exactly like the old flat list. Cards keep their true flat index so
+          every set/swap/delete handler is untouched. */}
       <div className="px-4 space-y-4">
-        {workout.exercises.map((exercise, index) => (
-          <SwipeableExerciseCard
-            key={index}
-            exercise={exercise}
-            exerciseIndex={index}
-            onSetUpdate={handleSetUpdate}
-            onSetComplete={handleSetComplete}
-            onCompleteAll={handleCompleteAllSets}
-            onOpenMenu={setMenuIndex}
-            onReplace={setReplaceIndex}
-            onDelete={requestDeleteExercise}
-          />
+        {groupExercisesByBlock(workout).map((section, sectionIdx) => (
+          <div key={sectionIdx} className="space-y-4">
+            {section.block && section.block.type !== 'straight_sets' && (
+              <BlockHeader
+                block={section.block}
+                items={section.items}
+                onCompleteRound={() => handleCompleteRound(section.blockIndex)}
+                onAdjustRounds={(delta) => handleAdjustRounds(section.blockIndex, delta)}
+              />
+            )}
+            {section.block && section.block.type === 'straight_sets' && workout.blocks?.length > 1 && (
+              <h2 className="font-bold text-gray-500 text-sm uppercase tracking-wide px-1">
+                {section.block.name}
+              </h2>
+            )}
+            {section.items.map(({ exercise, index }) => (
+              <SwipeableExerciseCard
+                key={index}
+                exercise={exercise}
+                exerciseIndex={index}
+                onSetUpdate={handleSetUpdate}
+                onSetComplete={handleSetComplete}
+                onCompleteAll={handleCompleteAllSets}
+                onOpenMenu={setMenuIndex}
+                onReplace={setReplaceIndex}
+                onDelete={requestDeleteExercise}
+              />
+            ))}
+          </div>
         ))}
       </div>
 

--- a/frontend/src/utils/liveSession.js
+++ b/frontend/src/utils/liveSession.js
@@ -24,7 +24,21 @@ const ACTIVE_SESSION_TTL = 24 * 60 * 60 * 1000; // 24 hours
  * @property {string} exercise_id
  * @property {string} exercise_name
  * @property {string} notes
+ * @property {number|null} block_index - index into SessionData.blocks (null for ad-hoc / legacy sessions)
+ * @property {string|null} volume_label - raw volume text shown when sets aren't a parseable NxM ("400m @ 5k pace")
  * @property {SessionSet[]} sets
+ */
+
+/**
+ * @typedef {Object} SessionBlock - structural metadata mirrored from the template's typed blocks
+ * @property {string} name
+ * @property {string} type - straight_sets|circuit|tabata|amrap|emom|interval|duration
+ * @property {number} rounds
+ * @property {number} [work_seconds]
+ * @property {number} [rest_seconds]
+ * @property {number} [duration_seconds]
+ * @property {string} [instructions]
+ * @property {number} rounds_completed - runtime counter (AMRAP)
  */
 
 /**
@@ -34,6 +48,7 @@ const ACTIVE_SESSION_TTL = 24 * 60 * 60 * 1000; // 24 hours
  * @property {number} duration_minutes
  * @property {string|null} sourceTemplateId - SessionTemplate this session started from (null for ad-hoc sessions)
  * @property {boolean} sourceTemplateIsCommon - whether that template is shared/common (permanent edits clone it)
+ * @property {SessionBlock[]} [blocks] - absent on ad-hoc sessions and blobs written before typed blocks
  * @property {SessionExercise[]} exercises
  */
 
@@ -271,29 +286,47 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
     duration_minutes: workout.estimated_duration || workout.duration_minutes || null,
     sourceTemplateId: isValidObjectId(String(sourceTemplateId || '')) ? String(sourceTemplateId) : null,
     sourceTemplateIsCommon: sourceTemplateIsCommon === true,
+    blocks: [],
     exercises: []
   };
 
-  // Handle both blocks format and flat exercises array
+  // Handle both blocks format and flat exercises array. Exercises keep a
+  // pointer to their block (block_index) instead of nesting, so set logging,
+  // swap/delete and the SessionLog mapping stay flat-index based.
   const exerciseList = [];
 
   if (workout.blocks && Array.isArray(workout.blocks)) {
     workout.blocks.forEach(block => {
+      const blockIndex = sessionData.blocks.length;
+      sessionData.blocks.push({
+        name: block.name || `Block ${blockIndex + 1}`,
+        // Missing type = every pre-typed-blocks template = classic sets x reps.
+        type: block.type || 'straight_sets',
+        rounds: Math.max(1, block.rounds || 1),
+        work_seconds: block.work_seconds || null,
+        rest_seconds: Number.isFinite(block.rest_seconds) ? block.rest_seconds : null,
+        duration_seconds: block.duration_seconds || null,
+        instructions: block.instructions || '',
+        rounds_completed: 0
+      });
       if (block.exercises && Array.isArray(block.exercises)) {
-        block.exercises.forEach(ex => exerciseList.push(ex));
+        block.exercises.forEach(ex => exerciseList.push({ ex, blockIndex }));
       }
     });
   }
 
   if (workout.exercises && Array.isArray(workout.exercises)) {
-    workout.exercises.forEach(ex => exerciseList.push(ex));
+    workout.exercises.forEach(ex => exerciseList.push({ ex, blockIndex: null }));
   }
 
-  exerciseList.forEach((ex, index) => {
+  exerciseList.forEach(({ ex, blockIndex }, index) => {
     if (!ex.exercise_name && !ex.exerciseName && !ex.name) {
       console.warn(`[LiveSession] Skipping exercise at index ${index}: missing name`);
       return;
     }
+
+    const block = blockIndex === null ? null : sessionData.blocks[blockIndex];
+    const blockType = block?.type || 'straight_sets';
 
     // exercise_id may arrive populated as an object ({_id, name, ...}) — the
     // Sessions-page list populates it — or as a plain id string.
@@ -305,9 +338,14 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
       exercise_id: isValidObjectId(rawExerciseId) ? rawExerciseId : null,
       exercise_name: ex.exercise_name || ex.exerciseName || ex.name,
       notes: ex.notes || '',
+      block_index: blockIndex,
+      volume_label: null,
       order: index,
       sets: []
     };
+
+    const volume = ex.volume || ex.sets_reps;
+    const parsedVolume = parseVolume(volume);
 
     // If exercise already has a sets array, use it
     if (ex.sets && Array.isArray(ex.sets) && ex.sets.length > 0) {
@@ -318,12 +356,41 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
         rest_seconds: set.rest_seconds || set.restSeconds || null,
         is_completed: false
       }));
+    } else if (blockType === 'duration' || blockType === 'amrap') {
+      // One continuous effort (tempo run, ARC climb) or an open AMRAP: one
+      // set, no rep target — the raw volume text is the target.
+      newExercise.volume_label = typeof volume === 'string' && volume ? volume : null;
+      newExercise.sets = [{
+        target_reps: null,
+        reps: 0,
+        weight: 0,
+        rest_seconds: Number.isFinite(block?.rest_seconds) ? block.rest_seconds : (parseRest(ex.rest) || null),
+        is_completed: false
+      }];
+    } else if (block && blockType !== 'straight_sets') {
+      // circuit / tabata / emom / interval: one set per round. Rep targets
+      // come from an NxM volume when present; otherwise the raw volume text
+      // ("400m @ 5k pace", "30s hard") is carried as a label instead of
+      // faking a 3x10.
+      const targetReps = parsedVolume?.numReps ?? null;
+      if (targetReps === null) {
+        newExercise.volume_label = typeof volume === 'string' && volume ? volume : null;
+      }
+      const restSeconds = Number.isFinite(block.rest_seconds)
+        ? block.rest_seconds
+        : (parseRest(ex.rest) || 90);
+      for (let i = 0; i < block.rounds; i++) {
+        newExercise.sets.push({
+          target_reps: targetReps,
+          reps: 0,
+          weight: 0,
+          rest_seconds: restSeconds,
+          is_completed: false
+        });
+      }
     } else {
-      // Parse from volume string or numeric fields
-      const volume = ex.volume || ex.sets_reps;
-      const parsedVolume = parseVolume(volume);
-
-      // Check for numeric sets/reps fields (from calendar format)
+      // straight_sets / typeless legacy blocks / flat calendar exercises:
+      // parse from volume string or numeric fields (unchanged behavior).
       const numericSets = typeof ex.sets === 'number' && ex.sets > 0 ? ex.sets : null;
       const numericReps = typeof ex.reps === 'number' && ex.reps > 0 ? ex.reps : null;
 
@@ -334,6 +401,7 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
 
       if (!parsedVolume && !numericSets && !numericReps) {
         console.warn(`[LiveSession] Exercise "${newExercise.exercise_name}" has no valid volume data (got: "${volume}"). Using defaults: ${numSets}x${numReps}`);
+        newExercise.volume_label = typeof volume === 'string' && volume ? volume : null;
       }
 
       for (let i = 0; i < numSets; i++) {
@@ -360,6 +428,35 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
 }
 
 /**
+ * Group a session's flat exercise list into renderable block sections.
+ *
+ * Groups CONSECUTIVE exercises sharing a block_index; ad-hoc additions and
+ * legacy blobs (no blocks array / no block_index) fall into null-block
+ * sections that render exactly like the pre-blocks flat list. Each item keeps
+ * its true flat index so set-logging/swap/delete handlers stay untouched.
+ *
+ * @param {SessionData} sessionData
+ * @returns {Array<{block: SessionBlock|null, blockIndex: number|null, items: Array<{exercise: SessionExercise, index: number}>}>}
+ */
+export function groupExercisesByBlock(sessionData) {
+  const exercises = sessionData?.exercises || [];
+  const blocks = Array.isArray(sessionData?.blocks) ? sessionData.blocks : [];
+
+  const sections = [];
+  let current = null;
+  exercises.forEach((exercise, index) => {
+    const rawIndex = exercise.block_index;
+    const blockIndex = Number.isInteger(rawIndex) && blocks[rawIndex] ? rawIndex : null;
+    if (!current || current.blockIndex !== blockIndex) {
+      current = { block: blockIndex === null ? null : blocks[blockIndex], blockIndex, items: [] };
+      sections.push(current);
+    }
+    current.items.push({ exercise, index });
+  });
+  return sections;
+}
+
+/**
  * Build a single live-session exercise from a catalog/generated exercise object.
  * Used when replacing or inserting an exercise mid-workout.
  *
@@ -372,9 +469,11 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
  *
  * @param {Object} exercise - a catalog exercise ({ id|_id, name, strain })
  * @param {number} [order=0]
+ * @param {Object} [options]
+ * @param {number|null} [options.blockIndex=null] - block the exercise joins (inherit the neighbor's when inserting mid-block)
  * @returns {SessionExercise}
  */
-export function buildSessionExercise(exercise, order = 0) {
+export function buildSessionExercise(exercise, order = 0, { blockIndex = null } = {}) {
   const rawId = exercise?.id || exercise?._id;
   const typicalVolume = exercise?.strain?.typicalVolume;
   const parsedVolume = parseVolume(typicalVolume);
@@ -397,6 +496,8 @@ export function buildSessionExercise(exercise, order = 0) {
     exercise_id: isValidObjectId(rawId) ? rawId : null,
     exercise_name: exercise?.name || exercise?.exercise_name || 'Exercise',
     notes: '',
+    block_index: Number.isInteger(blockIndex) ? blockIndex : null,
+    volume_label: null,
     order,
     sets
   };

--- a/frontend/src/utils/liveSession.js
+++ b/frontend/src/utils/liveSession.js
@@ -471,25 +471,61 @@ export function groupExercisesByBlock(sessionData) {
  * @param {number} [order=0]
  * @param {Object} [options]
  * @param {number|null} [options.blockIndex=null] - block the exercise joins (inherit the neighbor's when inserting mid-block)
+ * @param {SessionBlock|null} [options.block=null] - that block's metadata. REQUIRED for multi-round
+ *   blocks: set counts must match the block's rounds, or the derived round counter
+ *   (min completed sets across the block) would cap at this exercise's count forever.
  * @returns {SessionExercise}
  */
-export function buildSessionExercise(exercise, order = 0, { blockIndex = null } = {}) {
+export function buildSessionExercise(exercise, order = 0, { blockIndex = null, block = null } = {}) {
   const rawId = exercise?.id || exercise?._id;
   const typicalVolume = exercise?.strain?.typicalVolume;
   const parsedVolume = parseVolume(typicalVolume);
+  const blockType = block?.type || 'straight_sets';
 
-  const numSets = parsedVolume?.numSets || 3;
-  const numReps = parsedVolume?.numReps || 10;
-
+  let volumeLabel = null;
   const sets = [];
-  for (let i = 0; i < numSets; i++) {
+
+  if (block && (blockType === 'duration' || blockType === 'amrap')) {
+    // Continuous / open blocks: one set, no rep target.
+    volumeLabel = !parsedVolume && typeof typicalVolume === 'string' && typicalVolume ? typicalVolume : null;
     sets.push({
-      target_reps: numReps,
+      target_reps: null,
       reps: 0,
       weight: 0,
-      rest_seconds: 90,
+      rest_seconds: Number.isFinite(block.rest_seconds) ? block.rest_seconds : null,
       is_completed: false
     });
+  } else if (block && blockType !== 'straight_sets') {
+    // circuit / tabata / emom / interval: one set per round, same as
+    // parseTemplateToSessionData, so the new exercise stays round-coherent
+    // with its block neighbors.
+    const rounds = Math.max(1, block.rounds || 1);
+    const targetReps = parsedVolume?.numReps ?? null;
+    if (targetReps === null) {
+      volumeLabel = typeof typicalVolume === 'string' && typicalVolume ? typicalVolume : null;
+    }
+    const restSeconds = Number.isFinite(block.rest_seconds) ? block.rest_seconds : 90;
+    for (let i = 0; i < rounds; i++) {
+      sets.push({
+        target_reps: targetReps,
+        reps: 0,
+        weight: 0,
+        rest_seconds: restSeconds,
+        is_completed: false
+      });
+    }
+  } else {
+    const numSets = parsedVolume?.numSets || 3;
+    const numReps = parsedVolume?.numReps || 10;
+    for (let i = 0; i < numSets; i++) {
+      sets.push({
+        target_reps: numReps,
+        reps: 0,
+        weight: 0,
+        rest_seconds: 90,
+        is_completed: false
+      });
+    }
   }
 
   return {
@@ -497,7 +533,7 @@ export function buildSessionExercise(exercise, order = 0, { blockIndex = null } 
     exercise_name: exercise?.name || exercise?.exercise_name || 'Exercise',
     notes: '',
     block_index: Number.isInteger(blockIndex) ? blockIndex : null,
-    volume_label: null,
+    volume_label: volumeLabel,
     order,
     sets
   };


### PR DESCRIPTION
## PR B of the typed-blocks / sport-templates series (pairs with #167)

Typed template blocks now survive into LiveSession instead of being flattened into an anonymous exercise list.

### Design: flat exercises + block metadata alongside
`SessionData.exercises` stays flat; each exercise carries a `block_index` pointer into a new `SessionData.blocks` array, and rendering groups consecutive exercises by block. This means:
- Set logging, swap/replace/delete/add, the SessionLog completion mapping, and `getWorkoutStats` are untouched (all flat-index based).
- **No localStorage migration needed**: an `activeSession` blob written before this change has no `blocks` → renders exactly like today; a new blob read by an old build ignores the extra fields.

### What's new in the training screen
- **BlockHeader** card per typed block: name, type chip (TABATA / CIRCUIT / …), structural summary ("8 × 20s on / 10s off"), block `instructions`.
- **Round counter** ("Round 2/8") derived from set completion — `min(completed sets across the block's exercises) + 1` — so it survives mid-session reload for free and can't disagree with per-set logging.
- **Complete round** button: marks the next uncompleted set of every exercise in the block.
- **+/− rounds mid-session**: appends/removes one trailing set per exercise; completed sets are never removed (rounds can't drop below work already done). For AMRAP the +/− drives a pure `rounds_completed` counter.
- **`volume_label`**: when an exercise's volume isn't a parseable "NxM" ("30s AMRAP", "400m @ 5k pace"), the raw text is shown on the card instead of fabricating 3×10 targets. The 3×10 default now only applies to straight-sets/legacy blocks.
- Replace keeps the replaced exercise's block; add-above/below inherits the anchor's block; ad-hoc exercises (no block) render in plain sections.

### Set generation per block type
| type | sets per exercise | target |
|---|---|---|
| straight_sets / legacy | unchanged (parseVolume → 3×10 fallback) | reps |
| circuit / tabata / emom / interval | one per `rounds` | NxM reps if parseable, else `volume_label` |
| duration / amrap | 1 | `volume_label` / block duration |

### Files
- `frontend/src/constants/blocks.js` (new) — block-type vocabulary + summary formatting, shared with the upcoming editor PR
- `frontend/src/components/livesession/BlockHeader.jsx` (new)
- `frontend/src/utils/liveSession.js` — parse + `groupExercisesByBlock` + `buildSessionExercise(blockIndex)`
- `frontend/src/pages/LiveSession.jsx` — grouped render + round handlers

Verified with `npm run build`. Renders identically to today for: legacy templates (no block types), ad-hoc sessions, and pre-existing in-flight sessions.

Merge order: after #167 (backend fields), though this PR is safe standalone — it only reads fields that don't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)