### PR TITLE
Frontend: block structure controls in both template editors

### DIFF
--- a/backend/src/controllers/sessionLogController.js
+++ b/backend/src/controllers/sessionLogController.js
@@ -150,6 +150,7 @@ const createSessionLog = async (req, res) => {
       completedAt,
       actualDuration,
       exercises,
+      blocks,
       perceivedDifficulty,
       mood,
       notes,
@@ -197,6 +198,8 @@ const createSessionLog = async (req, res) => {
       completedAt: completedAtDate,
       actualDuration: resolvedDuration,
       exercises: resolvedExercises,
+      // Typed-block summary; blockLogSchema casts and drops unknown keys.
+      ...(Array.isArray(blocks) && blocks.length > 0 ? { blocks } : {}),
       perceivedDifficulty,
       mood,
       notes

--- a/backend/src/models/SessionLog.js
+++ b/backend/src/models/SessionLog.js
@@ -38,6 +38,18 @@ const exerciseLogSchema = new mongoose.Schema({
   avgRpe: Number
 }, { _id: false });
 
+// Summary of a typed session block as it was actually trained (rounds done,
+// structure). Absent for flat/legacy sessions.
+const blockLogSchema = new mongoose.Schema({
+  name: String,
+  type: String, // straight_sets|circuit|tabata|amrap|emom|interval|duration
+  rounds: Number, // planned rounds
+  rounds_completed: Number, // rounds actually finished (AMRAP: user-counted)
+  work_seconds: Number,
+  rest_seconds: Number,
+  duration_seconds: Number
+}, { _id: false });
+
 const sessionLogSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
@@ -70,6 +82,9 @@ const sessionLogSchema = new mongoose.Schema({
   actualDuration: Number, // in minutes
   // Exercises performed
   exercises: [exerciseLogSchema],
+  // Typed-block structure summary (how the session was organized and how many
+  // rounds were done). Optional — flat sessions have none.
+  blocks: [blockLogSchema],
   // Strain/intensity metrics
   totalStrain: {
     type: Number,

--- a/frontend/src/components/livesession/BlockHeader.jsx
+++ b/frontend/src/components/livesession/BlockHeader.jsx
@@ -1,0 +1,83 @@
+import { Plus, Minus, Check } from "lucide-react";
+import { BLOCK_TYPE_META, MULTI_ROUND_BLOCK_TYPES, formatBlockSummary } from "@/constants/blocks";
+
+/**
+ * Header card above a live-session block's exercise cards: block name, type
+ * chip, structural summary, round progress and +/- round controls.
+ *
+ * The current round is DERIVED from set completion (min completed sets across
+ * the block's exercises), so it survives reloads and stays consistent with
+ * per-set logging. AMRAP blocks have no set-derived rounds — they count
+ * `rounds_completed` via the +/- controls instead.
+ */
+export default function BlockHeader({ block, items, onCompleteRound, onAdjustRounds }) {
+  if (!block) return null;
+  const meta = BLOCK_TYPE_META[block.type] || BLOCK_TYPE_META.straight_sets;
+  const summary = formatBlockSummary(block);
+  const isMultiRound = MULTI_ROUND_BLOCK_TYPES.has(block.type);
+  const isAmrap = block.type === 'amrap';
+
+  const completedRounds = isMultiRound && items.length > 0
+    ? Math.min(...items.map(({ exercise }) => exercise.sets.filter(s => s.is_completed).length))
+    : 0;
+  const totalRounds = Math.max(1, block.rounds || 1);
+  const blockDone = isMultiRound && completedRounds >= totalRounds;
+  const currentRound = Math.min(completedRounds + 1, totalRounds);
+
+  return (
+    <div className="bg-gray-900 text-white rounded-2xl px-4 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="font-bold text-base truncate">{block.name}</h2>
+            {meta.chip && (
+              <span className="shrink-0 px-1.5 py-0.5 rounded bg-white/15 text-[10px] font-bold tracking-wider">
+                {meta.chip}
+              </span>
+            )}
+          </div>
+          {summary && <p className="text-xs text-white/60 mt-0.5">{summary}</p>}
+        </div>
+
+        {(isMultiRound || isAmrap) && (
+          <div className="shrink-0 flex items-center gap-1.5">
+            <button
+              onClick={() => onAdjustRounds(-1)}
+              aria-label="One round less"
+              className="w-7 h-7 rounded-full bg-white/10 flex items-center justify-center active:bg-white/25"
+            >
+              <Minus className="w-4 h-4" />
+            </button>
+            <span className="text-sm font-semibold tabular-nums min-w-[64px] text-center">
+              {isAmrap
+                ? `${block.rounds_completed || 0} rounds`
+                : blockDone
+                  ? `${totalRounds}/${totalRounds} ✓`
+                  : `Round ${currentRound}/${totalRounds}`}
+            </span>
+            <button
+              onClick={() => onAdjustRounds(1)}
+              aria-label="One round more"
+              className="w-7 h-7 rounded-full bg-white/10 flex items-center justify-center active:bg-white/25"
+            >
+              <Plus className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {block.instructions && (
+        <p className="text-xs text-white/70 mt-2">{block.instructions}</p>
+      )}
+
+      {isMultiRound && !blockDone && (
+        <button
+          onClick={onCompleteRound}
+          className="mt-2.5 w-full py-2 rounded-xl bg-white/10 active:bg-white/25 text-sm font-semibold flex items-center justify-center gap-1.5"
+        >
+          <Check className="w-4 h-4" /> Complete round {currentRound}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/predefined/BlockStructureControls.jsx
+++ b/frontend/src/components/predefined/BlockStructureControls.jsx
@@ -23,20 +23,23 @@ const TYPE_LABELS = {
   duration: "Continuous",
 };
 
-const numberOrNull = (raw) => {
+// Values below the schema's floor are coerced to null (field omitted) rather
+// than saved and rejected: work_seconds/duration_seconds require >= 1,
+// rest_seconds legitimately allows 0.
+const numberOrNull = (raw, minimum) => {
   const value = parseInt(raw, 10);
-  return Number.isFinite(value) && value >= 0 ? value : null;
+  return Number.isFinite(value) && value >= minimum ? value : null;
 };
 
-const SecondsField = ({ label, value, onChange }) => (
+const SecondsField = ({ label, value, onChange, minimum = 1 }) => (
   <div className="w-24">
     <label className="text-[10px] font-semibold text-gray-400 uppercase mb-1 block">{label}</label>
     <div className="relative">
       <input
         type="number"
-        min="0"
+        min={minimum}
         value={value ?? ""}
-        onChange={(e) => onChange(numberOrNull(e.target.value))}
+        onChange={(e) => onChange(numberOrNull(e.target.value, minimum))}
         className="w-full bg-white border-none rounded-lg text-sm py-2 pl-3 pr-7 font-medium text-gray-700 focus:ring-2 focus:ring-[#FE755D]/20 shadow-sm"
         placeholder="—"
       />
@@ -62,6 +65,14 @@ export default function BlockStructureControls({ block, onUpdate }) {
 
   const handleTypeChange = (nextType) => {
     const patch = { type: nextType };
+    // Null out fields the new type doesn't use so stale values (tabata's
+    // 8x20/10 after switching to duration) don't linger in the saved doc.
+    const nextFields = BLOCK_TYPE_META[nextType]?.fields || [];
+    for (const field of ["rounds", "work_seconds", "rest_seconds", "duration_seconds"]) {
+      if (!nextFields.includes(field)) {
+        patch[field] = field === "rounds" ? 1 : null;
+      }
+    }
     const defaults = TYPE_DEFAULTS[nextType] || {};
     for (const [field, value] of Object.entries(defaults)) {
       if (block[field] == null || (field === "rounds" && (block.rounds || 1) <= 1)) {
@@ -114,6 +125,7 @@ export default function BlockStructureControls({ block, onUpdate }) {
           <SecondsField
             label="Rest"
             value={block.rest_seconds}
+            minimum={0}
             onChange={(value) => onUpdate({ rest_seconds: value })}
           />
         )}

--- a/frontend/src/components/predefined/BlockStructureControls.jsx
+++ b/frontend/src/components/predefined/BlockStructureControls.jsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { BLOCK_TYPES, BLOCK_TYPE_META } from "@/constants/blocks";
+
+// Sensible starting values applied when the author switches a block's type
+// and the relevant fields are still empty. Tabata gets its 8x20/10 convention.
+const TYPE_DEFAULTS = {
+  straight_sets: { rounds: 1 },
+  circuit: { rounds: 3, rest_seconds: 60 },
+  tabata: { rounds: 8, work_seconds: 20, rest_seconds: 10 },
+  amrap: { duration_seconds: 600 },
+  emom: { rounds: 10, work_seconds: 40 },
+  interval: { rounds: 4, rest_seconds: 90 },
+  duration: { duration_seconds: 1200 },
+};
+
+const TYPE_LABELS = {
+  straight_sets: "Sets × reps",
+  circuit: "Circuit",
+  tabata: "Tabata",
+  amrap: "AMRAP",
+  emom: "EMOM",
+  interval: "Intervals",
+  duration: "Continuous",
+};
+
+const numberOrNull = (raw) => {
+  const value = parseInt(raw, 10);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+};
+
+const SecondsField = ({ label, value, onChange }) => (
+  <div className="w-24">
+    <label className="text-[10px] font-semibold text-gray-400 uppercase mb-1 block">{label}</label>
+    <div className="relative">
+      <input
+        type="number"
+        min="0"
+        value={value ?? ""}
+        onChange={(e) => onChange(numberOrNull(e.target.value))}
+        className="w-full bg-white border-none rounded-lg text-sm py-2 pl-3 pr-7 font-medium text-gray-700 focus:ring-2 focus:ring-[#FE755D]/20 shadow-sm"
+        placeholder="—"
+      />
+      <span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-gray-400">sec</span>
+    </div>
+  </div>
+);
+
+/**
+ * Structural controls for a session block: type select plus the fields that
+ * matter for that type (rounds / work / rest / total duration) and optional
+ * block-level instructions. Shared by CreateSessionTemplate and
+ * CreateSessionModal so the two editors can't drift.
+ *
+ * @param {{block: Object, onUpdate: (patch: Object) => void}} props
+ *   onUpdate merges a partial block patch in one state update (a field-by-field
+ *   API would drop keys when several fields change in the same tick, e.g. on
+ *   type switch).
+ */
+export default function BlockStructureControls({ block, onUpdate }) {
+  const type = block.type || "straight_sets";
+  const fields = BLOCK_TYPE_META[type]?.fields || [];
+
+  const handleTypeChange = (nextType) => {
+    const patch = { type: nextType };
+    const defaults = TYPE_DEFAULTS[nextType] || {};
+    for (const [field, value] of Object.entries(defaults)) {
+      if (block[field] == null || (field === "rounds" && (block.rounds || 1) <= 1)) {
+        patch[field] = value;
+      }
+    }
+    onUpdate(patch);
+  };
+
+  return (
+    <div className="px-4 py-3 bg-gray-50/50 border-b border-gray-100">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="w-36">
+          <label className="text-[10px] font-semibold text-gray-400 uppercase mb-1 block">Block type</label>
+          <select
+            value={type}
+            onChange={(e) => handleTypeChange(e.target.value)}
+            className="w-full bg-white border-none rounded-lg text-sm py-2 px-3 font-medium text-gray-700 focus:ring-2 focus:ring-[#FE755D]/20 shadow-sm appearance-none cursor-pointer"
+          >
+            {BLOCK_TYPES.map((t) => (
+              <option key={t} value={t}>{TYPE_LABELS[t] || t}</option>
+            ))}
+          </select>
+        </div>
+
+        {fields.includes("rounds") && (
+          <div className="w-20">
+            <label className="text-[10px] font-semibold text-gray-400 uppercase mb-1 block">
+              {type === "emom" ? "Minutes" : "Rounds"}
+            </label>
+            <input
+              type="number"
+              min="1"
+              value={block.rounds ?? 1}
+              onChange={(e) => onUpdate({ rounds: Math.max(1, parseInt(e.target.value, 10) || 1) })}
+              className="w-full bg-white border-none rounded-lg text-sm py-2 px-3 font-medium text-gray-700 focus:ring-2 focus:ring-[#FE755D]/20 shadow-sm"
+            />
+          </div>
+        )}
+
+        {fields.includes("work_seconds") && (
+          <SecondsField
+            label="Work"
+            value={block.work_seconds}
+            onChange={(value) => onUpdate({ work_seconds: value })}
+          />
+        )}
+
+        {fields.includes("rest_seconds") && (
+          <SecondsField
+            label="Rest"
+            value={block.rest_seconds}
+            onChange={(value) => onUpdate({ rest_seconds: value })}
+          />
+        )}
+
+        {fields.includes("duration_seconds") && (
+          <SecondsField
+            label={type === "amrap" ? "Time cap" : "Duration"}
+            value={block.duration_seconds}
+            onChange={(value) => onUpdate({ duration_seconds: value })}
+          />
+        )}
+      </div>
+
+      {type !== "straight_sets" && (
+        <input
+          type="text"
+          placeholder="Block instructions (e.g. stay below pump, all-out on work intervals)..."
+          value={block.instructions || ""}
+          onChange={(e) => onUpdate({ instructions: e.target.value })}
+          className="mt-3 w-full bg-white border-none rounded-lg text-sm py-2 px-3 text-gray-600 placeholder-gray-400 focus:ring-2 focus:ring-[#FE755D]/20 shadow-sm"
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/predefined/CreateSessionModal.jsx
+++ b/frontend/src/components/predefined/CreateSessionModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { X, Plus, Trash2, GripVertical, Search, Clock, Activity, Dumbbell, ChevronDown, ChevronUp, Save } from "lucide-react";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 import { Exercise } from "@/api/entities";
+import BlockStructureControls from "@/components/predefined/BlockStructureControls";
 
 // Inline Search Component for "Spotlight" feel
 const BlockSearch = ({ allExercises, onSelect }) => {
@@ -115,6 +116,13 @@ export default function CreateSessionModal({ exercises, onClose, onSave, editWor
         blocks: editWorkout.blocks?.length > 0
           ? editWorkout.blocks.map(block => ({
               name: block.name || "Block",
+              // Structural fields must ride along or editing would strip them.
+              type: block.type || "straight_sets",
+              rounds: block.rounds || 1,
+              work_seconds: block.work_seconds ?? null,
+              rest_seconds: block.rest_seconds ?? null,
+              duration_seconds: block.duration_seconds ?? null,
+              instructions: block.instructions || "",
               exercises: block.exercises?.map(ex => ({
                 exercise_id: ex.exercise_id?._id || ex.exercise_id || ex.exercise?.id,
                 exercise_name: ex.exercise_name || ex.exercise?.name || "Unknown Exercise",
@@ -123,7 +131,7 @@ export default function CreateSessionModal({ exercises, onClose, onSave, editWor
                 notes: ex.notes || ""
               })) || []
             }))
-          : [{ name: "Main Block", exercises: [] }]
+          : [{ name: "Main Block", type: "straight_sets", rounds: 1, exercises: [] }]
       };
     }
     return {
@@ -133,7 +141,7 @@ export default function CreateSessionModal({ exercises, onClose, onSave, editWor
       duration_minutes: 45,
       primary_disciplines: [],
       isCommon: false,
-      blocks: [{ name: "Main Block", exercises: [] }]
+      blocks: [{ name: "Main Block", type: "straight_sets", rounds: 1, exercises: [] }]
     };
   };
 
@@ -149,7 +157,7 @@ export default function CreateSessionModal({ exercises, onClose, onSave, editWor
   const handleAddBlock = () => {
     setWorkout(prev => ({
       ...prev,
-      blocks: [...prev.blocks, { name: `Block ${prev.blocks.length + 1}`, exercises: [] }]
+      blocks: [...prev.blocks, { name: `Block ${prev.blocks.length + 1}`, type: "straight_sets", rounds: 1, exercises: [] }]
     }));
   };
 
@@ -166,6 +174,15 @@ export default function CreateSessionModal({ exercises, onClose, onSave, editWor
     const newBlocks = [...workout.blocks];
     newBlocks[index][field] = value;
     setWorkout(prev => ({ ...prev, blocks: newBlocks }));
+  };
+
+  // Merge several structural fields in one update (a type switch patches
+  // type + defaults together).
+  const updateBlockStructure = (index, patch) => {
+    setWorkout(prev => ({
+      ...prev,
+      blocks: prev.blocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
+    }));
   };
 
   const handleSelectExercise = (blockIndex, exercise) => {
@@ -395,6 +412,12 @@ export default function CreateSessionModal({ exercises, onClose, onSave, editWor
                                 <Trash2 className="w-5 h-5" />
                               </button>
                             </div>
+
+                            {/* Block structure (type / rounds / work / rest) */}
+                            <BlockStructureControls
+                              block={block}
+                              onUpdate={(patch) => updateBlockStructure(index, patch)}
+                            />
 
                             {/* Exercises List */}
                             <div className="p-4 space-y-2">

--- a/frontend/src/components/predefined/SessionDetailModal.jsx
+++ b/frontend/src/components/predefined/SessionDetailModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { X, Clock, Target, Calendar, MoreVertical, ChevronDown, ChevronUp, Dumbbell, Zap, Users, Timer, Star, Bookmark, Pencil, Trash2, Play } from "lucide-react";
+import { formatBlockSummary } from "@/constants/blocks";
 
 const intensityColors = {
   low: "bg-green-100 text-green-800",
@@ -366,7 +367,10 @@ export default function SessionDetailModal({ workout, exercises, onClose, onAppl
                         </div>
                         <div className="flex-1">
                           <p className="text-sm font-bold text-gray-900">{block.name}</p>
-                          <p className="text-xs text-gray-500 mt-0.5">{block.exercises.length} exercises</p>
+                          <p className="text-xs text-gray-500 mt-0.5">
+                            {block.exercises.length} exercises
+                            {formatBlockSummary(block) ? ` · ${formatBlockSummary(block)}` : ''}
+                          </p>
                         </div>
                         {isExpanded ? (
                           <ChevronUp className="w-5 h-5 text-gray-400" />

--- a/frontend/src/constants/blocks.js
+++ b/frontend/src/constants/blocks.js
@@ -1,0 +1,72 @@
+/**
+ * Session-block structure vocabulary — frontend mirror.
+ *
+ * Canonical source is BLOCK_TYPES in backend/src/models/SessionTemplate.js;
+ * keep the values identical. A block with no `type` (all pre-typed-blocks
+ * data) is treated as 'straight_sets' everywhere.
+ */
+
+export const BLOCK_TYPES = [
+  'straight_sets',
+  'circuit',
+  'tabata',
+  'amrap',
+  'emom',
+  'interval',
+  'duration',
+];
+
+// Which structural fields are meaningful per type. Used by the live-session
+// header and the template editors so they can't drift.
+export const BLOCK_TYPE_META = {
+  straight_sets: { label: 'Sets × reps', chip: null, fields: [] },
+  circuit: { label: 'Circuit', chip: 'CIRCUIT', fields: ['rounds', 'rest_seconds'] },
+  tabata: { label: 'Tabata', chip: 'TABATA', fields: ['rounds', 'work_seconds', 'rest_seconds'] },
+  amrap: { label: 'AMRAP', chip: 'AMRAP', fields: ['duration_seconds'] },
+  emom: { label: 'EMOM', chip: 'EMOM', fields: ['rounds', 'work_seconds'] },
+  interval: { label: 'Intervals', chip: 'INTERVALS', fields: ['rounds', 'work_seconds', 'rest_seconds'] },
+  duration: { label: 'Continuous', chip: 'CONTINUOUS', fields: ['duration_seconds'] },
+};
+
+// Types where one completed set per exercise means one finished round, so the
+// live session shows a round counter and +/- round controls.
+export const MULTI_ROUND_BLOCK_TYPES = new Set(['circuit', 'tabata', 'emom', 'interval']);
+
+// Seconds → compact human label: 90 → "1:30", 600 → "10:00", 45 → "45s".
+export const formatBlockSeconds = (seconds) => {
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${String(secs).padStart(2, '0')}`;
+};
+
+/**
+ * One-line structural summary of a block, e.g. "8 × 20s on / 10s off",
+ * "3 rounds · 1:00 rest", "Cap 20:00", "10:00 continuous".
+ * Returns null for straight_sets / typeless blocks.
+ */
+export function formatBlockSummary(block) {
+  if (!block) return null;
+  const rounds = Math.max(1, block.rounds || 1);
+  const work = formatBlockSeconds(block.work_seconds);
+  const rest = formatBlockSeconds(block.rest_seconds);
+  const duration = formatBlockSeconds(block.duration_seconds);
+
+  switch (block.type) {
+    case 'tabata':
+      return `${rounds} × ${work || '20s'} on / ${rest || '10s'} off`;
+    case 'circuit':
+      return `${rounds} rounds${rest ? ` · ${rest} rest` : ''}`;
+    case 'emom':
+      return `Every minute for ${rounds} min${work ? ` · ${work} work` : ''}`;
+    case 'interval':
+      return `${rounds} × ${work || 'interval'}${rest ? ` / ${rest} rest` : ''}`;
+    case 'amrap':
+      return duration ? `As many rounds as possible in ${duration}` : 'As many rounds as possible';
+    case 'duration':
+      return duration ? `${duration} continuous` : 'Continuous effort';
+    default:
+      return null;
+  }
+}

--- a/frontend/src/pages/CreateSessionTemplate.jsx
+++ b/frontend/src/pages/CreateSessionTemplate.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { createPageUrl } from "@/utils";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 import { DISCIPLINES } from "@/constants/disciplines";
+import BlockStructureControls from "@/components/predefined/BlockStructureControls";
 
 // Inline Search Component for "Spotlight" feel
 const BlockSearch = ({ allExercises, onSelect }) => {
@@ -126,8 +127,17 @@ export default function CreateSessionTemplate() {
     setWorkout(prev => ({ ...prev, blocks: newBlocks }));
   };
 
+  // Merge several structural fields in one update (a type switch patches
+  // type + defaults together).
+  const updateBlockStructure = (index, patch) => {
+    setWorkout(prev => ({
+      ...prev,
+      blocks: prev.blocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
+    }));
+  };
+
   const addBlock = () => {
-    const newBlocks = [...workout.blocks, { name: `Block ${workout.blocks.length + 1}`, exercises: [] }];
+    const newBlocks = [...workout.blocks, { name: `Block ${workout.blocks.length + 1}`, type: "straight_sets", rounds: 1, exercises: [] }];
     setWorkout(prev => ({ ...prev, blocks: newBlocks }));
   };
 
@@ -364,6 +374,12 @@ export default function CreateSessionTemplate() {
                                 <Trash2 className="w-5 h-5" />
                               </button>
                             </div>
+
+                            {/* Block structure (type / rounds / work / rest) */}
+                            <BlockStructureControls
+                              block={block}
+                              onUpdate={(patch) => updateBlockStructure(index, patch)}
+                            />
 
                             {/* Exercises List */}
                             <div className="p-4 space-y-2">

--- a/frontend/src/pages/LiveSession.jsx
+++ b/frontend/src/pages/LiveSession.jsx
@@ -817,8 +817,14 @@ export default function LiveSession() {
   // regenerate defaults from the new exercise's strain.
   const handleReplaceExercise = (exIndex, picked, opts = {}) => {
     const old = workout.exercises[exIndex];
-    // The replacement stays in the block it replaces from.
-    const built = buildSessionExercise(picked, exIndex, { blockIndex: old.block_index ?? null });
+    // The replacement stays in the block it replaces from, and its default
+    // sets are generated from that block's structure (a tabata replacement
+    // gets `rounds` sets, not the catalog's 3x12).
+    const oldBlockIndex = Number.isInteger(old.block_index) ? old.block_index : null;
+    const built = buildSessionExercise(picked, exIndex, {
+      blockIndex: oldBlockIndex,
+      block: oldBlockIndex === null ? null : workout.blocks?.[oldBlockIndex] ?? null,
+    });
     // Session exercises ALWAYS have a sets array, so "has sets" is always true.
     // We only want to preserve actually-logged work; otherwise adopt the new
     // exercise's own generated defaults (e.g. swapping Plank 3×60s → Bench Press
@@ -880,11 +886,17 @@ export default function LiveSession() {
 
   const handleAddExercise = (exIndex, position, picked) => {
     const insertAt = position === 'above' ? exIndex : exIndex + 1;
-    // Inherit the anchor exercise's block so an insert mid-block stays in it.
-    const anchorBlockIndex = workout.exercises[exIndex]?.block_index ?? null;
+    // Inherit the anchor exercise's block so an insert mid-block stays in it,
+    // and generate block-shaped sets (rounds count) to keep the round counter
+    // coherent.
+    const rawAnchor = workout.exercises[exIndex]?.block_index;
+    const anchorBlockIndex = Number.isInteger(rawAnchor) ? rawAnchor : null;
     const nextExercises = withOrder([
       ...workout.exercises.slice(0, insertAt),
-      buildSessionExercise(picked, insertAt, { blockIndex: anchorBlockIndex }),
+      buildSessionExercise(picked, insertAt, {
+        blockIndex: anchorBlockIndex,
+        block: anchorBlockIndex === null ? null : workout.blocks?.[anchorBlockIndex] ?? null,
+      }),
       ...workout.exercises.slice(insertAt),
     ]);
     setWorkout({ ...workout, exercises: nextExercises });
@@ -907,12 +919,35 @@ export default function LiveSession() {
     setIsSaving(true);
 
     try {
+      // Typed-block summary for history/stats: what the structure was and how
+      // many rounds actually got done. rounds_completed is derived the same
+      // way the header does it (min completed sets across the block), except
+      // AMRAP where the user counts rounds explicitly.
+      const blocksSummary = (workout.blocks || []).map((block, blockIndex) => {
+        const inBlock = workout.exercises.filter(e => e.block_index === blockIndex);
+        const roundsCompleted = block.type === 'amrap'
+          ? (block.rounds_completed || 0)
+          : inBlock.length > 0
+            ? Math.min(...inBlock.map(e => e.sets.filter(s => s.is_completed).length))
+            : 0;
+        return {
+          name: block.name,
+          type: block.type,
+          rounds: block.rounds,
+          rounds_completed: roundsCompleted,
+          ...(block.work_seconds ? { work_seconds: block.work_seconds } : {}),
+          ...(Number.isFinite(block.rest_seconds) ? { rest_seconds: block.rest_seconds } : {}),
+          ...(block.duration_seconds ? { duration_seconds: block.duration_seconds } : {})
+        };
+      });
+
       const sessionLogData = {
         title: workout.title || 'Session',
         discipline: getDiscipline(workout.type),
         startedAt: workoutStartTime.toISOString(),
         completedAt: new Date().toISOString(),
         actualDuration: Math.ceil(totalSessionTime / 60) || workout.duration_minutes || 60,
+        ...(blocksSummary.length > 0 ? { blocks: blocksSummary } : {}),
         exercises: workout.exercises.map((ex, i) => ({
           exerciseId: ex.exercise_id,
           exerciseName: ex.exercise_name,

--- a/frontend/src/pages/LiveSession.jsx
+++ b/frontend/src/pages/LiveSession.jsx
@@ -7,8 +7,10 @@ import {
   saveSessionProgress,
   clearActiveSession,
   startLiveSession,
-  buildSessionExercise
+  buildSessionExercise,
+  groupExercisesByBlock
 } from "@/utils/liveSession";
+import BlockHeader from "@/components/livesession/BlockHeader";
 import {
   Drawer,
   DrawerContent,
@@ -428,6 +430,9 @@ function SwipeableExerciseCard({ exercise, exerciseIndex, onSetUpdate, onSetComp
               <MoreVertical className="w-5 h-5" />
             </button>
           </div>
+          {exercise.volume_label && (
+            <p className="text-sm font-medium text-primary-600">{exercise.volume_label}</p>
+          )}
           {exercise.notes && (
             <p className="text-sm text-gray-500">{exercise.notes}</p>
           )}
@@ -629,6 +634,78 @@ export default function LiveSession() {
     setWorkout(newWorkout);
   };
 
+  // --- Block round handlers (typed blocks: circuit / tabata / emom / interval / amrap) ---
+
+  // One round done = the next uncompleted set of every exercise in the block.
+  const handleCompleteRound = (blockIndex) => {
+    setWorkout(w => ({
+      ...w,
+      exercises: w.exercises.map(ex => {
+        if (ex.block_index !== blockIndex) return ex;
+        const nextIdx = ex.sets.findIndex(s => !s.is_completed);
+        if (nextIdx === -1) return ex;
+        return {
+          ...ex,
+          sets: ex.sets.map((s, i) => (
+            i === nextIdx ? { ...s, is_completed: true, reps: s.reps || s.target_reps || 0 } : s
+          ))
+        };
+      })
+    }));
+    if (navigator.vibrate) navigator.vibrate(40);
+  };
+
+  // Adjust a block's round count mid-session: one set per exercise is added
+  // or removed at the tail. Completed sets are never removed, so rounds can't
+  // drop below what's already been done. AMRAP has no set-backed rounds — the
+  // +/- drives its rounds_completed counter instead.
+  const handleAdjustRounds = (blockIndex, delta) => {
+    setWorkout(w => {
+      const block = w.blocks?.[blockIndex];
+      if (!block) return w;
+
+      if (block.type === 'amrap') {
+        const blocks = w.blocks.map((b, i) => (
+          i === blockIndex ? { ...b, rounds_completed: Math.max(0, (b.rounds_completed || 0) + delta) } : b
+        ));
+        return { ...w, blocks };
+      }
+
+      const inBlock = w.exercises.filter(e => e.block_index === blockIndex);
+      const maxCompleted = inBlock.reduce(
+        (m, e) => Math.max(m, e.sets.filter(s => s.is_completed).length), 0
+      );
+      const nextRounds = Math.max(1, maxCompleted, (block.rounds || 1) + delta);
+      if (nextRounds === (block.rounds || 1)) return w;
+
+      const growing = nextRounds > (block.rounds || 1);
+      const blocks = w.blocks.map((b, i) => (i === blockIndex ? { ...b, rounds: nextRounds } : b));
+      const exercises = w.exercises.map(ex => {
+        if (ex.block_index !== blockIndex) return ex;
+        if (growing) {
+          const last = ex.sets[ex.sets.length - 1];
+          return {
+            ...ex,
+            sets: [...ex.sets, {
+              target_reps: last?.target_reps ?? null,
+              reps: 0,
+              weight: last?.weight || 0,
+              rest_seconds: last?.rest_seconds ?? null,
+              is_completed: false
+            }]
+          };
+        }
+        const lastSet = ex.sets[ex.sets.length - 1];
+        if (ex.sets.length > 1 && lastSet && !lastSet.is_completed) {
+          return { ...ex, sets: ex.sets.slice(0, -1) };
+        }
+        return ex;
+      });
+      return { ...w, blocks, exercises };
+    });
+    if (navigator.vibrate) navigator.vibrate(30);
+  };
+
   // --- Exercise modification handlers ---
 
   // Re-normalize the cosmetic `order` field to match array position.
@@ -739,8 +816,9 @@ export default function LiveSession() {
   // sets array (counts + completion). Only when the old exercise had no sets do we
   // regenerate defaults from the new exercise's strain.
   const handleReplaceExercise = (exIndex, picked, opts = {}) => {
-    const built = buildSessionExercise(picked, exIndex);
     const old = workout.exercises[exIndex];
+    // The replacement stays in the block it replaces from.
+    const built = buildSessionExercise(picked, exIndex, { blockIndex: old.block_index ?? null });
     // Session exercises ALWAYS have a sets array, so "has sets" is always true.
     // We only want to preserve actually-logged work; otherwise adopt the new
     // exercise's own generated defaults (e.g. swapping Plank 3×60s → Bench Press
@@ -802,9 +880,11 @@ export default function LiveSession() {
 
   const handleAddExercise = (exIndex, position, picked) => {
     const insertAt = position === 'above' ? exIndex : exIndex + 1;
+    // Inherit the anchor exercise's block so an insert mid-block stays in it.
+    const anchorBlockIndex = workout.exercises[exIndex]?.block_index ?? null;
     const nextExercises = withOrder([
       ...workout.exercises.slice(0, insertAt),
-      buildSessionExercise(picked, insertAt),
+      buildSessionExercise(picked, insertAt, { blockIndex: anchorBlockIndex }),
       ...workout.exercises.slice(insertAt),
     ]);
     setWorkout({ ...workout, exercises: nextExercises });
@@ -921,20 +1001,40 @@ export default function LiveSession() {
         />
       </div>
 
-      {/* Exercise Cards List */}
+      {/* Exercise Cards List — grouped into block sections. Legacy sessions
+          (no blocks / no block_index) yield one null-block section and render
+          exactly like the old flat list. Cards keep their true flat index so
+          every set/swap/delete handler is untouched. */}
       <div className="px-4 space-y-4">
-        {workout.exercises.map((exercise, index) => (
-          <SwipeableExerciseCard
-            key={index}
-            exercise={exercise}
-            exerciseIndex={index}
-            onSetUpdate={handleSetUpdate}
-            onSetComplete={handleSetComplete}
-            onCompleteAll={handleCompleteAllSets}
-            onOpenMenu={setMenuIndex}
-            onReplace={setReplaceIndex}
-            onDelete={requestDeleteExercise}
-          />
+        {groupExercisesByBlock(workout).map((section, sectionIdx) => (
+          <div key={sectionIdx} className="space-y-4">
+            {section.block && section.block.type !== 'straight_sets' && (
+              <BlockHeader
+                block={section.block}
+                items={section.items}
+                onCompleteRound={() => handleCompleteRound(section.blockIndex)}
+                onAdjustRounds={(delta) => handleAdjustRounds(section.blockIndex, delta)}
+              />
+            )}
+            {section.block && section.block.type === 'straight_sets' && workout.blocks?.length > 1 && (
+              <h2 className="font-bold text-gray-500 text-sm uppercase tracking-wide px-1">
+                {section.block.name}
+              </h2>
+            )}
+            {section.items.map(({ exercise, index }) => (
+              <SwipeableExerciseCard
+                key={index}
+                exercise={exercise}
+                exerciseIndex={index}
+                onSetUpdate={handleSetUpdate}
+                onSetComplete={handleSetComplete}
+                onCompleteAll={handleCompleteAllSets}
+                onOpenMenu={setMenuIndex}
+                onReplace={setReplaceIndex}
+                onDelete={requestDeleteExercise}
+              />
+            ))}
+          </div>
         ))}
       </div>
 

--- a/frontend/src/utils/liveSession.js
+++ b/frontend/src/utils/liveSession.js
@@ -24,7 +24,21 @@ const ACTIVE_SESSION_TTL = 24 * 60 * 60 * 1000; // 24 hours
  * @property {string} exercise_id
  * @property {string} exercise_name
  * @property {string} notes
+ * @property {number|null} block_index - index into SessionData.blocks (null for ad-hoc / legacy sessions)
+ * @property {string|null} volume_label - raw volume text shown when sets aren't a parseable NxM ("400m @ 5k pace")
  * @property {SessionSet[]} sets
+ */
+
+/**
+ * @typedef {Object} SessionBlock - structural metadata mirrored from the template's typed blocks
+ * @property {string} name
+ * @property {string} type - straight_sets|circuit|tabata|amrap|emom|interval|duration
+ * @property {number} rounds
+ * @property {number} [work_seconds]
+ * @property {number} [rest_seconds]
+ * @property {number} [duration_seconds]
+ * @property {string} [instructions]
+ * @property {number} rounds_completed - runtime counter (AMRAP)
  */
 
 /**
@@ -34,6 +48,7 @@ const ACTIVE_SESSION_TTL = 24 * 60 * 60 * 1000; // 24 hours
  * @property {number} duration_minutes
  * @property {string|null} sourceTemplateId - SessionTemplate this session started from (null for ad-hoc sessions)
  * @property {boolean} sourceTemplateIsCommon - whether that template is shared/common (permanent edits clone it)
+ * @property {SessionBlock[]} [blocks] - absent on ad-hoc sessions and blobs written before typed blocks
  * @property {SessionExercise[]} exercises
  */
 
@@ -271,29 +286,47 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
     duration_minutes: workout.estimated_duration || workout.duration_minutes || null,
     sourceTemplateId: isValidObjectId(String(sourceTemplateId || '')) ? String(sourceTemplateId) : null,
     sourceTemplateIsCommon: sourceTemplateIsCommon === true,
+    blocks: [],
     exercises: []
   };
 
-  // Handle both blocks format and flat exercises array
+  // Handle both blocks format and flat exercises array. Exercises keep a
+  // pointer to their block (block_index) instead of nesting, so set logging,
+  // swap/delete and the SessionLog mapping stay flat-index based.
   const exerciseList = [];
 
   if (workout.blocks && Array.isArray(workout.blocks)) {
     workout.blocks.forEach(block => {
+      const blockIndex = sessionData.blocks.length;
+      sessionData.blocks.push({
+        name: block.name || `Block ${blockIndex + 1}`,
+        // Missing type = every pre-typed-blocks template = classic sets x reps.
+        type: block.type || 'straight_sets',
+        rounds: Math.max(1, block.rounds || 1),
+        work_seconds: block.work_seconds || null,
+        rest_seconds: Number.isFinite(block.rest_seconds) ? block.rest_seconds : null,
+        duration_seconds: block.duration_seconds || null,
+        instructions: block.instructions || '',
+        rounds_completed: 0
+      });
       if (block.exercises && Array.isArray(block.exercises)) {
-        block.exercises.forEach(ex => exerciseList.push(ex));
+        block.exercises.forEach(ex => exerciseList.push({ ex, blockIndex }));
       }
     });
   }
 
   if (workout.exercises && Array.isArray(workout.exercises)) {
-    workout.exercises.forEach(ex => exerciseList.push(ex));
+    workout.exercises.forEach(ex => exerciseList.push({ ex, blockIndex: null }));
   }
 
-  exerciseList.forEach((ex, index) => {
+  exerciseList.forEach(({ ex, blockIndex }, index) => {
     if (!ex.exercise_name && !ex.exerciseName && !ex.name) {
       console.warn(`[LiveSession] Skipping exercise at index ${index}: missing name`);
       return;
     }
+
+    const block = blockIndex === null ? null : sessionData.blocks[blockIndex];
+    const blockType = block?.type || 'straight_sets';
 
     // exercise_id may arrive populated as an object ({_id, name, ...}) — the
     // Sessions-page list populates it — or as a plain id string.
@@ -305,9 +338,14 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
       exercise_id: isValidObjectId(rawExerciseId) ? rawExerciseId : null,
       exercise_name: ex.exercise_name || ex.exerciseName || ex.name,
       notes: ex.notes || '',
+      block_index: blockIndex,
+      volume_label: null,
       order: index,
       sets: []
     };
+
+    const volume = ex.volume || ex.sets_reps;
+    const parsedVolume = parseVolume(volume);
 
     // If exercise already has a sets array, use it
     if (ex.sets && Array.isArray(ex.sets) && ex.sets.length > 0) {
@@ -318,12 +356,41 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
         rest_seconds: set.rest_seconds || set.restSeconds || null,
         is_completed: false
       }));
+    } else if (blockType === 'duration' || blockType === 'amrap') {
+      // One continuous effort (tempo run, ARC climb) or an open AMRAP: one
+      // set, no rep target — the raw volume text is the target.
+      newExercise.volume_label = typeof volume === 'string' && volume ? volume : null;
+      newExercise.sets = [{
+        target_reps: null,
+        reps: 0,
+        weight: 0,
+        rest_seconds: Number.isFinite(block?.rest_seconds) ? block.rest_seconds : (parseRest(ex.rest) || null),
+        is_completed: false
+      }];
+    } else if (block && blockType !== 'straight_sets') {
+      // circuit / tabata / emom / interval: one set per round. Rep targets
+      // come from an NxM volume when present; otherwise the raw volume text
+      // ("400m @ 5k pace", "30s hard") is carried as a label instead of
+      // faking a 3x10.
+      const targetReps = parsedVolume?.numReps ?? null;
+      if (targetReps === null) {
+        newExercise.volume_label = typeof volume === 'string' && volume ? volume : null;
+      }
+      const restSeconds = Number.isFinite(block.rest_seconds)
+        ? block.rest_seconds
+        : (parseRest(ex.rest) || 90);
+      for (let i = 0; i < block.rounds; i++) {
+        newExercise.sets.push({
+          target_reps: targetReps,
+          reps: 0,
+          weight: 0,
+          rest_seconds: restSeconds,
+          is_completed: false
+        });
+      }
     } else {
-      // Parse from volume string or numeric fields
-      const volume = ex.volume || ex.sets_reps;
-      const parsedVolume = parseVolume(volume);
-
-      // Check for numeric sets/reps fields (from calendar format)
+      // straight_sets / typeless legacy blocks / flat calendar exercises:
+      // parse from volume string or numeric fields (unchanged behavior).
       const numericSets = typeof ex.sets === 'number' && ex.sets > 0 ? ex.sets : null;
       const numericReps = typeof ex.reps === 'number' && ex.reps > 0 ? ex.reps : null;
 
@@ -334,6 +401,7 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
 
       if (!parsedVolume && !numericSets && !numericReps) {
         console.warn(`[LiveSession] Exercise "${newExercise.exercise_name}" has no valid volume data (got: "${volume}"). Using defaults: ${numSets}x${numReps}`);
+        newExercise.volume_label = typeof volume === 'string' && volume ? volume : null;
       }
 
       for (let i = 0; i < numSets; i++) {
@@ -360,6 +428,35 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
 }
 
 /**
+ * Group a session's flat exercise list into renderable block sections.
+ *
+ * Groups CONSECUTIVE exercises sharing a block_index; ad-hoc additions and
+ * legacy blobs (no blocks array / no block_index) fall into null-block
+ * sections that render exactly like the pre-blocks flat list. Each item keeps
+ * its true flat index so set-logging/swap/delete handlers stay untouched.
+ *
+ * @param {SessionData} sessionData
+ * @returns {Array<{block: SessionBlock|null, blockIndex: number|null, items: Array<{exercise: SessionExercise, index: number}>}>}
+ */
+export function groupExercisesByBlock(sessionData) {
+  const exercises = sessionData?.exercises || [];
+  const blocks = Array.isArray(sessionData?.blocks) ? sessionData.blocks : [];
+
+  const sections = [];
+  let current = null;
+  exercises.forEach((exercise, index) => {
+    const rawIndex = exercise.block_index;
+    const blockIndex = Number.isInteger(rawIndex) && blocks[rawIndex] ? rawIndex : null;
+    if (!current || current.blockIndex !== blockIndex) {
+      current = { block: blockIndex === null ? null : blocks[blockIndex], blockIndex, items: [] };
+      sections.push(current);
+    }
+    current.items.push({ exercise, index });
+  });
+  return sections;
+}
+
+/**
  * Build a single live-session exercise from a catalog/generated exercise object.
  * Used when replacing or inserting an exercise mid-workout.
  *
@@ -372,9 +469,11 @@ export function parseTemplateToSessionData(workout, { sourceTemplateId, sourceTe
  *
  * @param {Object} exercise - a catalog exercise ({ id|_id, name, strain })
  * @param {number} [order=0]
+ * @param {Object} [options]
+ * @param {number|null} [options.blockIndex=null] - block the exercise joins (inherit the neighbor's when inserting mid-block)
  * @returns {SessionExercise}
  */
-export function buildSessionExercise(exercise, order = 0) {
+export function buildSessionExercise(exercise, order = 0, { blockIndex = null } = {}) {
   const rawId = exercise?.id || exercise?._id;
   const typicalVolume = exercise?.strain?.typicalVolume;
   const parsedVolume = parseVolume(typicalVolume);
@@ -397,6 +496,8 @@ export function buildSessionExercise(exercise, order = 0) {
     exercise_id: isValidObjectId(rawId) ? rawId : null,
     exercise_name: exercise?.name || exercise?.exercise_name || 'Exercise',
     notes: '',
+    block_index: Number.isInteger(blockIndex) ? blockIndex : null,
+    volume_label: null,
     order,
     sets
   };

--- a/frontend/src/utils/liveSession.js
+++ b/frontend/src/utils/liveSession.js
@@ -471,25 +471,61 @@ export function groupExercisesByBlock(sessionData) {
  * @param {number} [order=0]
  * @param {Object} [options]
  * @param {number|null} [options.blockIndex=null] - block the exercise joins (inherit the neighbor's when inserting mid-block)
+ * @param {SessionBlock|null} [options.block=null] - that block's metadata. REQUIRED for multi-round
+ *   blocks: set counts must match the block's rounds, or the derived round counter
+ *   (min completed sets across the block) would cap at this exercise's count forever.
  * @returns {SessionExercise}
  */
-export function buildSessionExercise(exercise, order = 0, { blockIndex = null } = {}) {
+export function buildSessionExercise(exercise, order = 0, { blockIndex = null, block = null } = {}) {
   const rawId = exercise?.id || exercise?._id;
   const typicalVolume = exercise?.strain?.typicalVolume;
   const parsedVolume = parseVolume(typicalVolume);
+  const blockType = block?.type || 'straight_sets';
 
-  const numSets = parsedVolume?.numSets || 3;
-  const numReps = parsedVolume?.numReps || 10;
-
+  let volumeLabel = null;
   const sets = [];
-  for (let i = 0; i < numSets; i++) {
+
+  if (block && (blockType === 'duration' || blockType === 'amrap')) {
+    // Continuous / open blocks: one set, no rep target.
+    volumeLabel = !parsedVolume && typeof typicalVolume === 'string' && typicalVolume ? typicalVolume : null;
     sets.push({
-      target_reps: numReps,
+      target_reps: null,
       reps: 0,
       weight: 0,
-      rest_seconds: 90,
+      rest_seconds: Number.isFinite(block.rest_seconds) ? block.rest_seconds : null,
       is_completed: false
     });
+  } else if (block && blockType !== 'straight_sets') {
+    // circuit / tabata / emom / interval: one set per round, same as
+    // parseTemplateToSessionData, so the new exercise stays round-coherent
+    // with its block neighbors.
+    const rounds = Math.max(1, block.rounds || 1);
+    const targetReps = parsedVolume?.numReps ?? null;
+    if (targetReps === null) {
+      volumeLabel = typeof typicalVolume === 'string' && typicalVolume ? typicalVolume : null;
+    }
+    const restSeconds = Number.isFinite(block.rest_seconds) ? block.rest_seconds : 90;
+    for (let i = 0; i < rounds; i++) {
+      sets.push({
+        target_reps: targetReps,
+        reps: 0,
+        weight: 0,
+        rest_seconds: restSeconds,
+        is_completed: false
+      });
+    }
+  } else {
+    const numSets = parsedVolume?.numSets || 3;
+    const numReps = parsedVolume?.numReps || 10;
+    for (let i = 0; i < numSets; i++) {
+      sets.push({
+        target_reps: numReps,
+        reps: 0,
+        weight: 0,
+        rest_seconds: 90,
+        is_completed: false
+      });
+    }
   }
 
   return {
@@ -497,7 +533,7 @@ export function buildSessionExercise(exercise, order = 0, { blockIndex = null } 
     exercise_name: exercise?.name || exercise?.exercise_name || 'Exercise',
     notes: '',
     block_index: Number.isInteger(blockIndex) ? blockIndex : null,
-    volume_label: null,
+    volume_label: volumeLabel,
     order,
     sets
   };


### PR DESCRIPTION
## PR C of the typed-blocks / sport-templates series (stacked on #168, pairs with #167)

Lets template authors (and superAdmin for commons) build typed blocks in-app.

### Changes
- New shared `BlockStructureControls` — block type select (`Sets × reps / Circuit / Tabata / AMRAP / EMOM / Intervals / Continuous`) plus only the fields meaningful for that type (per `BLOCK_TYPE_META` from #168's `constants/blocks.js`), and a block-instructions input for non-straight-sets blocks.
- Wired into **both** editors (CreateSessionTemplate page + CreateSessionModal) under each block's header, so they can't drift.
- Type switch prefills convention defaults (tabata 8×20/10, circuit 3 rounds/60s...) but only into fields that are still empty; `onUpdate(patch)` merges multi-field patches in one state update.
- `CreateSessionModal.getInitialWorkout` previously rebuilt blocks with a fixed field list — editing any typed template would have silently stripped `type/rounds/work/rest/duration/instructions` on re-save. Now carried through.
- Legacy blocks show "Sets × reps" selected; re-saving persists the default, which is semantically identical.
- Bonus: SessionDetailModal now shows the structural summary ("8 × 20s on / 10s off") next to each block in the template preview.

Verified with `npm run build`.

**Base is #168's branch** (needs `constants/blocks.js`); retargets to main automatically when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)