### PR TITLE
Interest-based visibility for common session templates

### DIFF
--- a/backend/src/models/SportInterestResolution.js
+++ b/backend/src/models/SportInterestResolution.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+/**
+ * READ-ONLY mirror of the ai-coach service's cross-user cache that resolves
+ * free-text sport labels ("triathlon", "ninja") to canonical disciplines.
+ * Written exclusively by ai-coach-service (interest_mix.py) — Node reads it
+ * to interest-filter common session templates and must never write to it or
+ * call an LLM to fill misses; an unresolved label simply contributes nothing.
+ */
+const sportInterestResolutionSchema = new mongoose.Schema({
+  label: { type: String, index: true },
+  disciplines: [String],
+  source: String,
+}, { collection: 'sportinterestresolutions', strict: false });
+
+module.exports = mongoose.model('SportInterestResolution', sportInterestResolutionSchema);

--- a/backend/src/routes/sessionTemplates.js
+++ b/backend/src/routes/sessionTemplates.js
@@ -2,6 +2,7 @@ const express = require('express');
 const SessionTemplate = require('../models/SessionTemplate');
 const CalendarEvent = require('../models/CalendarEvent');
 const SessionService = require('../services/SessionService');
+const { resolveInterestDisciplines, isHiddenSportTemplate } = require('../services/interestDisciplines');
 const { auth, optionalAuth } = require('../middleware/auth');
 const router = express.Router();
 
@@ -12,6 +13,7 @@ router.get('/', optionalAuth, async (req, res) => {
       difficulty,
       tags,
       popular,
+      allSports,
       limit = 20,
       page = 1
     } = req.query;
@@ -30,6 +32,24 @@ router.get('/', optionalAuth, async (req, res) => {
 
     // Apply filters
     let filteredWorkouts = workouts;
+
+    // Interest-based visibility: common templates whose disciplines are all
+    // sport-specific (running/cycling/climbing/swimming) are hidden unless
+    // the user lists that sport in their interests, favorited/modified the
+    // template, or asked for everything via ?allSports=true. Any failure
+    // skips the filter entirely — never blank the catalog over it.
+    if (allSports !== 'true') {
+      try {
+        const userDisciplines = await resolveInterestDisciplines(
+          req.user?.profile?.sportPreferences || []
+        );
+        filteredWorkouts = filteredWorkouts.filter(
+          (w) => !isHiddenSportTemplate(w, userDisciplines)
+        );
+      } catch (error) {
+        console.error('[sessionTemplates] Interest filter failed, showing all:', error.message);
+      }
+    }
 
     if (difficulty) {
       filteredWorkouts = filteredWorkouts.filter(w => w.difficulty_level === difficulty);

--- a/backend/src/routes/sessionTemplates.js
+++ b/backend/src/routes/sessionTemplates.js
@@ -35,9 +35,18 @@ router.get('/', optionalAuth, async (req, res) => {
 
     // Interest-based visibility: common templates whose disciplines are all
     // sport-specific (running/cycling/climbing/swimming) are hidden unless
-    // the user lists that sport in their interests, favorited/modified the
-    // template, or asked for everything via ?allSports=true. Any failure
-    // skips the filter entirely — never blank the catalog over it.
+    // the user lists that sport in their interests, has a modification doc
+    // for the template (favorite/completion/rename — any engagement), or
+    // asked for everything via ?allSports=true. Any failure skips the filter
+    // entirely — never blank the catalog over it.
+    //
+    // Deliberate scope choices:
+    // - Users with EMPTY sportPreferences get generic commons only ("hasn't
+    //   added biking → no biking sessions"). If sport commons should instead
+    //   launch visible to everyone until interests are set, gate this filter
+    //   on prefs.length > 0.
+    // - GET /search/:term is NOT filtered — searching by name is an explicit
+    //   act, so it doubles as an escape hatch (and has no auth context).
     if (allSports !== 'true') {
       try {
         const userDisciplines = await resolveInterestDisciplines(

--- a/backend/src/services/__tests__/interestDisciplines.test.js
+++ b/backend/src/services/__tests__/interestDisciplines.test.js
@@ -90,4 +90,13 @@ describe('isHiddenSportTemplate', () => {
     expect(isHiddenSportTemplate(common(['climbing'], { userMetadata: { isFavorite: true } }), none)).toBe(false);
     expect(isHiddenSportTemplate(common(['climbing'], { isModified: true }), none)).toBe(false);
   });
+
+  test('ANY modification doc counts as opt-in, not just favorites', () => {
+    // A user who completed a template (timesCompleted metadata) but never
+    // favorited it has expressed interest too — the overlay attaches
+    // userMetadata whenever a UserSessionModification doc exists.
+    expect(isHiddenSportTemplate(
+      common(['running'], { userMetadata: { timesCompleted: 3, isFavorite: false } }), none
+    )).toBe(false);
+  });
 });

--- a/backend/src/services/__tests__/interestDisciplines.test.js
+++ b/backend/src/services/__tests__/interestDisciplines.test.js
@@ -1,0 +1,93 @@
+/**
+ * Interest-based visibility of common session templates: canonical + cached
+ * custom labels resolve to disciplines; the hide predicate only ever hides
+ * sport-specific-only commons the user hasn't opted into.
+ */
+jest.mock('../../models/SportInterestResolution', () => ({
+  find: jest.fn(),
+}));
+
+const SportInterestResolution = require('../../models/SportInterestResolution');
+const { resolveInterestDisciplines, isHiddenSportTemplate } = require('../interestDisciplines');
+
+const mockCache = (docs) => {
+  SportInterestResolution.find.mockReturnValue({ lean: () => Promise.resolve(docs) });
+};
+
+describe('resolveInterestDisciplines', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('canonical labels map to themselves without touching the cache', async () => {
+    const result = await resolveInterestDisciplines(['Climbing', 'running']);
+    expect([...result].sort()).toEqual(['climbing', 'running']);
+    expect(SportInterestResolution.find).not.toHaveBeenCalled();
+  });
+
+  test('legacy synonyms normalize (endurance -> cardio)', async () => {
+    const result = await resolveInterestDisciplines(['Endurance']);
+    expect([...result]).toEqual(['cardio']);
+  });
+
+  test('custom labels resolve through the cache', async () => {
+    mockCache([{ label: 'triathlon', disciplines: ['running', 'cycling', 'swimming'] }]);
+    const result = await resolveInterestDisciplines(['triathlon']);
+    expect([...result].sort()).toEqual(['cycling', 'running', 'swimming']);
+    expect(SportInterestResolution.find).toHaveBeenCalledWith({ label: { $in: ['triathlon'] } });
+  });
+
+  test('uncached custom labels contribute nothing', async () => {
+    mockCache([]);
+    const result = await resolveInterestDisciplines(['underwater basket weaving']);
+    expect(result.size).toBe(0);
+  });
+
+  test('off-vocab disciplines in a cache doc are ignored', async () => {
+    mockCache([{ label: 'ninja', disciplines: ['parkour', 'calisthenics'] }]);
+    const result = await resolveInterestDisciplines(['ninja']);
+    expect([...result]).toEqual(['calisthenics']);
+  });
+
+  test('empty / junk input resolves to an empty set', async () => {
+    expect((await resolveInterestDisciplines([])).size).toBe(0);
+    expect((await resolveInterestDisciplines(undefined)).size).toBe(0);
+    expect((await resolveInterestDisciplines(['', 42, null])).size).toBe(0);
+  });
+});
+
+describe('isHiddenSportTemplate', () => {
+  const common = (disciplines, extra = {}) => ({
+    isCommon: true,
+    primary_disciplines: disciplines,
+    ...extra,
+  });
+  const none = new Set();
+
+  test('generic common stays visible with no interests', () => {
+    expect(isHiddenSportTemplate(common(['strength', 'calisthenics']), none)).toBe(false);
+  });
+
+  test('sport-specific common hidden with no interests', () => {
+    expect(isHiddenSportTemplate(common(['cycling']), none)).toBe(true);
+  });
+
+  test('sport-specific common visible with matching interest', () => {
+    expect(isHiddenSportTemplate(common(['cycling']), new Set(['cycling']))).toBe(false);
+  });
+
+  test('mixed generic+sport template always visible', () => {
+    expect(isHiddenSportTemplate(common(['cardio', 'running']), none)).toBe(false);
+  });
+
+  test('no-discipline common always visible', () => {
+    expect(isHiddenSportTemplate(common([]), none)).toBe(false);
+  });
+
+  test('private templates never hidden', () => {
+    expect(isHiddenSportTemplate({ isCommon: false, primary_disciplines: ['cycling'] }, none)).toBe(false);
+  });
+
+  test('favorited/modified sport common stays visible (opt-in wins)', () => {
+    expect(isHiddenSportTemplate(common(['climbing'], { userMetadata: { isFavorite: true } }), none)).toBe(false);
+    expect(isHiddenSportTemplate(common(['climbing'], { isModified: true }), none)).toBe(false);
+  });
+});

--- a/backend/src/services/interestDisciplines.js
+++ b/backend/src/services/interestDisciplines.js
@@ -1,0 +1,75 @@
+const {
+  DISCIPLINE_SET,
+  SPORT_SPECIFIC_DISCIPLINE_SET,
+  normalizeDisciplines,
+} = require('../config/disciplines');
+const SportInterestResolution = require('../models/SportInterestResolution');
+
+/**
+ * Resolve a user's free-text sport preferences to canonical disciplines.
+ *
+ * Canonical labels (after legacy-synonym normalization) map to themselves;
+ * custom labels ("triathlon") resolve through the ai-coach's shared
+ * sportinterestresolutions cache. A label with no cache entry contributes
+ * nothing — the caller's filter is built so that can only ever UNDER-hide,
+ * never hide everything (mirrors interest_mix.py's stance that an unmappable
+ * label is unmeasurable, not absent).
+ *
+ * @param {string[]} sportPreferences - raw profile.sportPreferences values
+ * @returns {Promise<Set<string>>} canonical disciplines the user trains
+ */
+async function resolveInterestDisciplines(sportPreferences) {
+  const disciplines = new Set();
+  const customLabels = [];
+
+  for (const raw of Array.isArray(sportPreferences) ? sportPreferences : []) {
+    if (typeof raw !== 'string' || !raw.trim()) continue;
+    const [normalized] = normalizeDisciplines([raw]);
+    if (normalized && DISCIPLINE_SET.has(normalized)) {
+      disciplines.add(normalized);
+    } else {
+      customLabels.push(raw.trim().toLowerCase());
+    }
+  }
+
+  if (customLabels.length > 0) {
+    const resolutions = await SportInterestResolution
+      .find({ label: { $in: customLabels } })
+      .lean();
+    for (const resolution of resolutions) {
+      for (const discipline of resolution.disciplines || []) {
+        if (DISCIPLINE_SET.has(discipline)) disciplines.add(discipline);
+      }
+    }
+  }
+
+  return disciplines;
+}
+
+/**
+ * Should this common template be hidden from a user with these disciplines?
+ *
+ * Hidden only when ALL of the template's disciplines are sport-specific
+ * (running/cycling/climbing/swimming), none of them is among the user's, and
+ * the user hasn't opted in by favoriting/modifying it. Generic commons
+ * (strength, cardio, mobility, ...) and mixed templates are always visible,
+ * so the filter fails open for users with no or unresolvable interests.
+ *
+ * @param {Object} template - lean template, possibly with the per-user
+ *   userMetadata/isModified overlay from SessionService
+ * @param {Set<string>} userDisciplines
+ * @returns {boolean}
+ */
+function isHiddenSportTemplate(template, userDisciplines) {
+  if (!template?.isCommon) return false;
+  const disciplines = template.primary_disciplines || [];
+  if (disciplines.length === 0) return false;
+  if (!disciplines.every((d) => SPORT_SPECIFIC_DISCIPLINE_SET.has(d))) return false;
+  if (disciplines.some((d) => userDisciplines.has(d))) return false;
+  // A modification row (favorite, completions, renames) means the user opted
+  // into this template — hiding it would look like data loss.
+  if (template.userMetadata || template.isModified) return false;
+  return true;
+}
+
+module.exports = { resolveInterestDisciplines, isHiddenSportTemplate };

--- a/frontend/src/api/mongodb-entities.js
+++ b/frontend/src/api/mongodb-entities.js
@@ -74,7 +74,7 @@ export const Plan = {
 
 // SessionTemplate entity
 export const SessionTemplate = {
-  list: async () => normalizeArray(await apiService.sessionTemplates.list()),
+  list: async (params = {}) => normalizeArray(await apiService.sessionTemplates.list(params)),
   create: async (data) => normalizeId(await apiService.sessionTemplates.create(data)),
   update: async (id, data) => normalizeId(await apiService.sessionTemplates.update(id, data)),
   delete: async (id) => apiService.sessionTemplates.delete(id)

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -66,6 +66,9 @@ export default function Sessions() {
   // New state for search and filters
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("all");
+  // Escape hatch for the server's interest filter: common templates for
+  // sports outside the user's interests are hidden unless this is on.
+  const [showAllSports, setShowAllSports] = useState(false);
   const [bookmarkedSessions, setBookmarkedSessions] = useState(() => {
     // Load bookmarks from localStorage. Plain key shim for the workout→session
     // rename: read the pre-rename key when the new one is missing, then rewrite
@@ -94,14 +97,16 @@ export default function Sessions() {
   useEffect(() => {
     // Check for active workout on mount
     setActiveSession(getActiveSession());
-    loadData();
-  }, []);
+    loadData(showAllSports);
+  }, [showAllSports]);
 
-  const loadData = async () => {
+  // Refresh callers (duplicate/delete/save) omit the arg and keep the
+  // current toggle state.
+  const loadData = async (allSports = showAllSports) => {
     setIsLoading(true);
     try {
       const [workoutData, exerciseData] = await Promise.all([
-        SessionTemplate.list(),
+        SessionTemplate.list(allSports ? { allSports: 'true' } : {}),
         Exercise.list()
       ]);
       setSessionTemplates(workoutData || []);
@@ -386,6 +391,16 @@ export default function Sessions() {
             {category.label}
           </button>
         ))}
+        <button
+          onClick={() => setShowAllSports(prev => !prev)}
+          title="Include common sessions for sports outside your interests"
+          className={`px-5 py-2.5 rounded-xl font-semibold text-sm whitespace-nowrap transition-all border ${showAllSports
+            ? 'bg-accent/10 text-accent border-accent'
+            : 'bg-white text-gray-500 hover:bg-gray-50 border-dashed border-gray-300'
+            }`}
+        >
+          All sports
+        </button>
       </div>
 
       {/* Workouts Grid */}

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -106,7 +106,11 @@ export default function Sessions() {
     setIsLoading(true);
     try {
       const [workoutData, exerciseData] = await Promise.all([
-        SessionTemplate.list(allSports ? { allSports: 'true' } : {}),
+        // High limit: the route defaults to 20 newest-first, which would let
+        // freshly seeded commons displace the user's own older templates out
+        // of view (and make the All-sports toggle look like it shuffles the
+        // library instead of expanding it).
+        SessionTemplate.list({ limit: 200, ...(allSports ? { allSports: 'true' } : {}) }),
         Exercise.list()
       ]);
       setSessionTemplates(workoutData || []);

--- a/frontend/src/pages/TrainNow.jsx
+++ b/frontend/src/pages/TrainNow.jsx
@@ -346,7 +346,9 @@ export default function TrainNow() {
     setIsLoading(true);
     try {
       const [workoutData, exerciseData] = await Promise.all([
-        SessionTemplate.list(),
+        // High limit — the route's default 20 newest-first would starve the
+        // per-discipline rows of the user's older templates.
+        SessionTemplate.list({ limit: 200 }),
         Exercise.list()
       ]);
       setWorkouts(workoutData || []);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -237,7 +237,13 @@ class APIService {
 
   // SessionTemplate endpoints
   sessionTemplates = {
-    list: () => this.request('/session-templates'),
+    // Optional params: { allSports, difficulty, tags, popular, page, limit }.
+    list: (params = {}) => {
+      const query = new URLSearchParams(
+        Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== '')
+      ).toString();
+      return this.request(`/session-templates${query ? `?${query}` : ''}`);
+    },
     get: (id) => this.request(`/session-templates/${id}`),
     create: (data) => this.request('/session-templates', {
       method: 'POST',


### PR DESCRIPTION
## PR E of the typed-blocks / sport-templates series (stacked on #167 for the SPORT_SPECIFIC_DISCIPLINES constant)

Biking sessions are no longer shown to users who don't bike.

### The rule
A **common** template is hidden from the list only when ALL of these hold:
- every one of its `primary_disciplines` is sport-specific (`running / cycling / climbing / swimming`)
- none of them is among the user's resolved interests
- the user hasn't opted in (no favorite / modification row)
- `?allSports=true` wasn't passed

Generic commons (strength, cardio, hiit, mobility, …) and mixed templates (e.g. `[cardio, running]`) are **always visible** — nobody loses the basics; the filter can only under-hide, never blank the catalog. Anonymous users get the same rule.

### Custom-label resolution (the "triathlon" problem)
`profile.sportPreferences` is free text. Canonical labels map to themselves (with legacy synonym normalization); custom labels resolve through a **new read-only Node model over the ai-coach's `sportinterestresolutions` cache** (written only by `interest_mix.py` — Node never writes and never calls an LLM). Cache miss → the label contributes nothing; any thrown error → the filter is skipped for that request entirely.

### Where it lives
- Server-side only, in `GET /session-templates` (`req.user` is already the full User doc — zero extra queries for canonical-only users). Deliberately **not** in `SessionService.getSessionsForUser` (other consumers must see everything) and not in `GET /:id` (direct links, calendar-linked sessions keep working).
- `backend/src/services/interestDisciplines.js` — `resolveInterestDisciplines()` + `isHiddenSportTemplate()` (pure predicate).
- Frontend: `sessionTemplates.list(params)` + `SessionTemplate.list(params)` learn query params; Sessions tab gets an **"All sports"** toggle chip. Category chips and TrainNow's discipline rows derive from loaded data, so they adapt with no changes.

### Tests
`backend/src/services/__tests__/interestDisciplines.test.js` — 13 cases: canonical/legacy/custom-cached/uncached labels, off-vocab cache entries, junk input; predicate: generic vs sport-specific vs mixed vs no-discipline vs private vs favorited/modified. Full backend suite: 89/89. Frontend `npm run build` clean.

**Base is #167's branch**; retargets to main automatically when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)