### PR TITLE
AI-coach: author typed session blocks

### DIFF
--- a/ai-coach-service/app/core/agents/services/session_service.py
+++ b/ai-coach-service/app/core/agents/services/session_service.py
@@ -16,6 +16,23 @@ from app.core.dedup import existing_template_duplicate_response
 
 logger = structlog.get_logger()
 
+# Mirror of BLOCK_TYPES in backend/src/models/SessionTemplate.js. Raw motor
+# inserts bypass Mongoose validation, so this whitelist is the enforcement
+# point: an off-vocab type is dropped (block falls back to straight_sets)
+# rather than persisted.
+BLOCK_TYPES = {
+    "straight_sets", "circuit", "tabata", "amrap", "emom", "interval", "duration",
+}
+
+
+def _positive_int(value, minimum=1):
+    """Coerce to int >= minimum; None when absent or junk."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number >= minimum else None
+
 
 class SessionService:
     """Service for session-related operations"""
@@ -58,20 +75,39 @@ class SessionService:
             # strips them before anything is persisted.
             blocks = []
             for block in args.get("blocks", []):
-                blocks.append({
+                # Typed-block structure (tabata / circuit / interval / ...) —
+                # optional, sanitized here because nothing downstream validates.
+                block_type = block.get("type")
+                if block_type not in BLOCK_TYPES:
+                    block_type = "straight_sets"
+                normalized = {
                     "name": block.get("name", "Main Work"),
-                    "exercises": [
-                        {
-                            "exercise_name": ex.get("exercise_name", ""),
-                            "volume": ex.get("volume", "3x10"),
-                            "rest": ex.get("rest", "60s"),
-                            "notes": ex.get("notes", ""),
-                            "muscles": ex.get("muscles"),
-                            "discipline": ex.get("discipline") or args.get("primary_disciplines"),
-                        }
-                        for ex in block.get("exercises", [])
-                    ]
-                })
+                    "type": block_type,
+                    "rounds": _positive_int(block.get("rounds")) or 1,
+                }
+                for field, minimum in (
+                    ("work_seconds", 1),
+                    ("rest_seconds", 0),
+                    ("duration_seconds", 1),
+                ):
+                    value = _positive_int(block.get(field), minimum)
+                    if value is not None:
+                        normalized[field] = value
+                instructions = block.get("instructions")
+                if isinstance(instructions, str) and instructions.strip():
+                    normalized["instructions"] = instructions.strip()
+                normalized["exercises"] = [
+                    {
+                        "exercise_name": ex.get("exercise_name", ""),
+                        "volume": ex.get("volume", "3x10"),
+                        "rest": ex.get("rest", "60s"),
+                        "notes": ex.get("notes", ""),
+                        "muscles": ex.get("muscles"),
+                        "discipline": ex.get("discipline") or args.get("primary_disciplines"),
+                    }
+                    for ex in block.get("exercises", [])
+                ]
+                blocks.append(normalized)
 
             # Resolve every exercise name to a real catalog id (verified id →
             # exact → fuzzy → vector → create). exercise_id must never be null:

--- a/ai-coach-service/app/core/agents/services/session_service.py
+++ b/ai-coach-service/app/core/agents/services/session_service.py
@@ -80,6 +80,13 @@ class SessionService:
                 block_type = block.get("type")
                 if block_type not in BLOCK_TYPES:
                     block_type = "straight_sets"
+                if block_type == "emom" and len(block.get("exercises") or []) > 1:
+                    # The tool schema pins EMOM to one exercise per block; if
+                    # the model sends more anyway, demote to circuit — the
+                    # runtime generates identical sets for both, so this only
+                    # fixes the label ("EMOM 10" over 2 exercises would imply
+                    # double the work).
+                    block_type = "circuit"
                 normalized = {
                     "name": block.get("name", "Main Work"),
                     "type": block_type,

--- a/ai-coach-service/app/core/agents/tool_definitions/session_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/session_tools.py
@@ -93,7 +93,7 @@ def get_session_tools() -> List[Dict[str, Any]]:
                                     "type": {
                                         "type": "string",
                                         "enum": ["straight_sets", "circuit", "tabata", "amrap", "emom", "interval", "duration"],
-                                        "description": "Block structure. straight_sets (default): classic sets x reps. circuit/interval: exercise list repeats `rounds` times with `rest_seconds` between. tabata: `rounds` x `work_seconds` on / `rest_seconds` off (convention 8x20/10). amrap: as many rounds as possible in `duration_seconds`. emom: `rounds` minute-slots of `work_seconds` work. duration: one continuous effort of `duration_seconds` (tempo run, endurance ride, ARC climb)."
+                                        "description": "Block structure. straight_sets (default): classic sets x reps. circuit/interval: exercise list repeats `rounds` times with `rest_seconds` between. tabata: `rounds` x `work_seconds` on / `rest_seconds` off (convention 8x20/10). amrap: as many rounds as possible in `duration_seconds`. emom: `rounds` minute-slots of `work_seconds` work — EVERY exercise in the block performs `rounds` slots, so an emom block must contain EXACTLY ONE exercise (an alternating EMOM is one block per movement, e.g. odd minutes = block A rounds:5, even minutes = block B rounds:5 — never one 10-round block with 2 exercises, which would double the work). duration: one continuous effort of `duration_seconds` (tempo run, endurance ride, ARC climb)."
                                     },
                                     "rounds": {
                                         "type": "integer",

--- a/ai-coach-service/app/core/agents/tool_definitions/session_tools.py
+++ b/ai-coach-service/app/core/agents/tool_definitions/session_tools.py
@@ -32,7 +32,8 @@ def get_session_tools() -> List[Dict[str, Any]]:
                     "NON-GYM / OUTDOOR SESSIONS (rides, runs, climbs, swims, hikes): they use the SAME shape — "
                     "exercises[] can never be empty, so express the activity itself as one entry. The minimal VALID "
                     "shape is exactly one block with one exercise: "
-                    "blocks=[{name:'Main Work', exercises:[{exercise_name:'Outdoor Cycling', volume:'60km', "
+                    "blocks=[{name:'Main Work', type:'duration', duration_seconds:3600, "
+                    "exercises:[{exercise_name:'Outdoor Cycling', volume:'60km', "
                     "rest:'none', notes:'Rolling terrain, steady zone 2', muscles:['Legs'], discipline:['cycling']}]}] "
                     "— the exercise_name IS the activity ('Outdoor Cycling', 'Trail Run', 'Sport Climbing', "
                     "'Bouldering', 'Open Water Swim'), `volume` carries the dose (distance, time, number of routes: "
@@ -40,7 +41,14 @@ def get_session_tools() -> List[Dict[str, Any]]:
                     "intensity). Set primary_disciplines to the sport (e.g. ['cycling'], ['climbing']). Add more "
                     "blocks only when the session really has them (e.g. 'Warm-up' easy spinning, 'Main Work' "
                     "intervals). Every block must contain at least one exercise — an empty/placeholder template is "
-                    "rejected by the server, so never send one."
+                    "rejected by the server, so never send one. "
+                    "STRUCTURED BLOCKS: when the session has real structure, say so with the block-level `type` "
+                    "field instead of encoding it in the block name — tabata (type:'tabata', rounds:8, "
+                    "work_seconds:20, rest_seconds:10), interval repeats (type:'interval', rounds:8, "
+                    "rest_seconds:90, exercise volume '400m @ 5k pace'), circuits (type:'circuit', rounds:3, "
+                    "rest_seconds:60), AMRAP/EMOM caps via duration_seconds, and continuous efforts (tempo run, "
+                    "endurance ride, ARC climbing) as type:'duration' with duration_seconds. Plain sets x reps "
+                    "blocks need no type."
                 ),
                 "parameters": {
                     "type": "object",
@@ -81,6 +89,35 @@ def get_session_tools() -> List[Dict[str, Any]]:
                                     "name": {
                                         "type": "string",
                                         "description": "Block name (e.g., 'Warm-up', 'Main Work', 'Finisher', 'Cool-down')"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": ["straight_sets", "circuit", "tabata", "amrap", "emom", "interval", "duration"],
+                                        "description": "Block structure. straight_sets (default): classic sets x reps. circuit/interval: exercise list repeats `rounds` times with `rest_seconds` between. tabata: `rounds` x `work_seconds` on / `rest_seconds` off (convention 8x20/10). amrap: as many rounds as possible in `duration_seconds`. emom: `rounds` minute-slots of `work_seconds` work. duration: one continuous effort of `duration_seconds` (tempo run, endurance ride, ARC climb)."
+                                    },
+                                    "rounds": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "description": "How many times the block repeats (circuit/tabata/interval rounds, emom minutes). Omit for straight_sets/duration."
+                                    },
+                                    "work_seconds": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "description": "Work window per round in seconds (tabata/interval/emom)."
+                                    },
+                                    "rest_seconds": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Rest between rounds/intervals in seconds. 0 is valid (back-to-back)."
+                                    },
+                                    "duration_seconds": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "description": "Total block duration in seconds: the amrap/emom time cap, or the length of a `duration` block."
+                                    },
+                                    "instructions": {
+                                        "type": "string",
+                                        "description": "Block-level coaching text (e.g. 'stay below the pump', 'all-out on work intervals')."
                                     },
                                     "exercises": {
                                         "type": "array",


### PR DESCRIPTION
## PR F of the typed-blocks / sport-templates series (deploy after #167)

The coach can now author structured blocks instead of faking them in block names ("AMRAP Circuit (20-30s work / 10s rest)").

### Changes
- **Tool schema** (`session_tools.py`): optional block properties `type` (`straight_sets|circuit|tabata|amrap|emom|interval|duration`), `rounds`, `work_seconds`, `rest_seconds` (0 valid), `duration_seconds`, `instructions` — each with one-line semantics. The outdoor/endurance prompt convention now shows `type:'duration'` + `duration_seconds` for continuous efforts and tells the model to express tabata/interval/circuit structure via `type` rather than the block name.
- **Normalizer** (`session_service.py`): `type` whitelisted against a mirrored `BLOCK_TYPES` set (off-vocab → `straight_sets`), integers coerced with per-field minimums, `rounds` floored at 1, `instructions` trimmed. This is the enforcement point — the raw motor insert bypasses Mongoose validation. `ExerciseResolver.resolve_blocks` mutates blocks in place, so the new fields survive resolution (verified).
- Only the create path rebuilds blocks; no other coach writer touches block shape.

All fields optional → older-model tool calls without them behave exactly as today.

Smoke test after deploy: ask the coach for "a bike tabata session" and confirm the created template carries `type:'tabata', rounds:8, work_seconds:20, rest_seconds:10` and renders with a block header in LiveSession (#168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)