### PR TITLE
Seed: only reuse common exercises for common templates

### DIFF
--- a/backend/scripts/seed-sport-templates.js
+++ b/backend/scripts/seed-sport-templates.js
@@ -307,8 +307,12 @@ async function seedSportTemplates() {
     const exerciseMap = {};
     const insertedExerciseIds = [];
     for (const def of NEW_EXERCISES) {
+      // Only reuse COMMON exercises — a common template must never reference
+      // a user's private exercise doc (matching a private "Easy Run" by name
+      // would leak it into every user's template views).
       const existing = await Exercise.findOne({
         name: { $regex: `^${escapeRegex(def.name)}$`, $options: 'i' },
+        isCommon: true,
       });
       if (existing) {
         exerciseMap[def.name] = existing._id;


### PR DESCRIPTION
Follow-up to #171, caught during the prod seed run: the exercise find-or-create matched by name only, so the run reused a user's **private** "Easy Run" doc (isCommon: false, createdBy set) inside two common running templates — a common template must never reference a private exercise. Reuse now requires `isCommon: true`; otherwise a common variant is created.

After merge the seed will be re-run on prod: it creates a common Easy Run and the upsert-by-name rewrites the two templates' blocks in place (same template _ids, so calendar/favorite refs are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)