### PR TITLE
Strava activity matching: auto-merge into planned sessions, user merge/un-merge, correction audit

### DIFF
--- a/backend/scripts/migrate-merge-strava-mirror-duplicates.js
+++ b/backend/scripts/migrate-merge-strava-mirror-duplicates.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * One-off migration for the Strava↔planned-workout matcher (see
+ * activityMatchingService): activities synced before matching existed each
+ * have a standalone mirror CalendarEvent, possibly duplicating a planned
+ * session on the same day. For every strava ExternalActivity with a linked
+ * mirror event:
+ *  - run the same classifier the sync now uses against its same-day sibling
+ *    events (the mirror itself excluded);
+ *  - merge  → link the planned event, delete the mirror, matchStatus 'auto';
+ *  - pending → keep the mirror, backfill sessionDetails.source/stravaData
+ *    (they were stripped by strict mode pre-fix), matchStatus 'pending'
+ *    + candidates;
+ *  - none  → same backfill, matchStatus 'unmatched'.
+ * Activities that already have a matchStatus are skipped (idempotent).
+ *
+ * Usage:
+ *   node scripts/migrate-merge-strava-mirror-duplicates.js             # dry run (default)
+ *   node scripts/migrate-merge-strava-mirror-duplicates.js --apply     # write
+ *   node scripts/migrate-merge-strava-mirror-duplicates.js --user <id> # limit to one user
+ */
+
+const mongoose = require('mongoose');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../.env') });
+
+const ExternalActivity = require('../src/models/ExternalActivity');
+const CalendarEvent = require('../src/models/CalendarEvent');
+const StravaIntegrationService = require('../src/services/StravaIntegrationService');
+const ActivityMatchingService = require('../src/services/activityMatchingService');
+
+const APPLY = process.argv.includes('--apply');
+const userFlagIdx = process.argv.indexOf('--user');
+const USER_ID = userFlagIdx > -1 ? process.argv[userFlagIdx + 1] : null;
+
+async function main() {
+  await mongoose.connect(process.env.MONGODB_URI);
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY RUN'}${USER_ID ? ` user=${USER_ID}` : ''}`);
+
+  const query = { source: 'strava', matchStatus: { $exists: false } };
+  if (USER_ID) query.userId = new mongoose.Types.ObjectId(USER_ID);
+
+  const activities = await ExternalActivity.find(query).lean();
+  console.log(`Examined: ${activities.length} strava activit(ies) without matchStatus`);
+
+  const stats = { merged: 0, pending: 0, unmatched: 0, noMirror: 0, errors: 0 };
+
+  for (const activity of activities) {
+    try {
+      const mirror = await CalendarEvent.findOne({
+        userId: activity.userId,
+        externalActivityId: activity._id
+      }).lean();
+
+      const discipline = StravaIntegrationService.mapStravaTypeToDiscipline(activity.sportType);
+      const events = (await ActivityMatchingService.findCandidateEvents(activity.userId, activity))
+        .filter((e) => !mirror || String(e._id) !== String(mirror._id));
+      const { decision, target, candidateIds } = ActivityMatchingService.classifyCandidates(
+        activity, discipline, events
+      );
+      const localDay = ActivityMatchingService.activityLocalDay(activity);
+
+      if (decision === 'merge') {
+        stats.merged++;
+        console.log(`MERGE     ${localDay} ${activity.name} → "${target.title}" (${String(target._id)})`);
+        if (APPLY) {
+          await ActivityMatchingService.mergeActivityIntoEvent(activity, target, {
+            actor: 'system',
+            matchStatus: 'auto',
+            action: 'auto_merge',
+            context: { candidateIds, discipline, localDay, decision }
+          });
+        }
+      } else {
+        const matchStatus = decision === 'pending' ? 'pending' : 'unmatched';
+        stats[matchStatus]++;
+        if (!mirror) stats.noMirror++;
+        console.log(`${matchStatus.toUpperCase().padEnd(9)} ${localDay} ${activity.name} (${candidateIds.length} candidate(s))`);
+        if (APPLY) {
+          // Backfill the mirror's stripped source/stravaData; creates the
+          // mirror if the consistency job hasn't yet.
+          await ActivityMatchingService.upsertMirrorEvent(activity, activity.userId, discipline);
+          await ExternalActivity.updateOne(
+            { _id: activity._id },
+            { $set: { matchStatus, matchCandidateIds: decision === 'pending' ? candidateIds : [] } }
+          );
+        }
+      }
+    } catch (error) {
+      stats.errors++;
+      console.error(`ERROR     ${activity._id}: ${error.message}`);
+    }
+  }
+
+  console.log('\nSummary:', stats);
+  if (!APPLY) console.log('Dry run — nothing written. Re-run with --apply to write.');
+  await mongoose.disconnect();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/backend/scripts/migrate-merge-strava-mirror-duplicates.js
+++ b/backend/scripts/migrate-merge-strava-mirror-duplicates.js
@@ -78,13 +78,23 @@ async function main() {
         if (!mirror) stats.noMirror++;
         console.log(`${matchStatus.toUpperCase().padEnd(9)} ${localDay} ${activity.name} (${candidateIds.length} candidate(s))`);
         if (APPLY) {
-          // Backfill the mirror's stripped source/stravaData; creates the
-          // mirror if the consistency job hasn't yet.
-          await ActivityMatchingService.upsertMirrorEvent(activity, activity.userId, discipline);
+          // Status first (crash-safe, matches classifyAndApply), then the
+          // mirror backfill of stripped source/stravaData.
           await ExternalActivity.updateOne(
             { _id: activity._id },
             { $set: { matchStatus, matchCandidateIds: decision === 'pending' ? candidateIds : [] } }
           );
+          await ActivityMatchingService.upsertMirrorEvent(activity, activity.userId, discipline);
+          // Same audit rows the live path writes — migrated classifications
+          // must count in the matcher-quality denominator too.
+          await ActivityMatchingService.writeAudit({
+            userId: activity.userId,
+            activityId: activity._id,
+            action: decision === 'pending' ? 'auto_pending' : 'auto_unmatched',
+            actor: 'system',
+            previous: { matchStatus: null, matchedEventId: null },
+            context: { candidateIds, discipline, localDay, decision }
+          });
         }
       }
     } catch (error) {

--- a/backend/src/controllers/calendarController.js
+++ b/backend/src/controllers/calendarController.js
@@ -1,6 +1,7 @@
 const CalendarEvent = require('../models/CalendarEvent');
 const SessionLog = require('../models/SessionLog');
 const SessionTemplate = require('../models/SessionTemplate');
+const ActivityMatchingService = require('../services/activityMatchingService');
 const { validationResult } = require('express-validator');
 const { flattenTemplateExercises } = require('../utils/volume');
 const {
@@ -216,6 +217,12 @@ const deleteEvent = async (req, res) => {
         success: false,
         message: 'Calendar event not found'
       });
+    }
+
+    // Deleting a Strava-linked event is a match correction: pin the activity
+    // 'separate' so the consistency job can't resurrect it as an auto-merge.
+    if (event.externalActivityId) {
+      await ActivityMatchingService.handleLinkedEventDeletion(event, req.user._id);
     }
 
     res.json({

--- a/backend/src/jobs/calendarConsistencyJob.js
+++ b/backend/src/jobs/calendarConsistencyJob.js
@@ -254,9 +254,9 @@ class CalendarConsistencyJob {
         const externalActivity = await ExternalActivity.findById(event.externalActivityId);
         if (!externalActivity) {
           // Mirrors are deleted; merged planned events survive with the link severed
-          await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId);
-          this.stats.orphanedCalendarEventsDeleted++;
-          this.logger.info(`[CalendarConsistencyJob] Cleaned Strava-linked CalendarEvent ${event._id} (ExternalActivity ${event.externalActivityId} not found)`);
+          const outcome = await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId);
+          if (outcome === 'deleted') this.stats.orphanedCalendarEventsDeleted++;
+          this.logger.info(`[CalendarConsistencyJob] ${outcome === 'deleted' ? 'Deleted' : 'Unlinked'} Strava-linked CalendarEvent ${event._id} (ExternalActivity ${event.externalActivityId} not found)`);
         }
       }
 
@@ -556,8 +556,8 @@ class CalendarConsistencyJob {
     for (const event of eventsWithExternalActivityId) {
       const externalActivity = await ExternalActivity.findById(event.externalActivityId);
       if (!externalActivity) {
-        await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId);
-        this.stats.orphanedCalendarEventsDeleted++;
+        const outcome = await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId);
+        if (outcome === 'deleted') this.stats.orphanedCalendarEventsDeleted++;
       }
     }
   }

--- a/backend/src/jobs/calendarConsistencyJob.js
+++ b/backend/src/jobs/calendarConsistencyJob.js
@@ -5,6 +5,7 @@ const ExternalActivity = require('../models/ExternalActivity');
 const Exercise = require('../models/Exercise');
 const SessionTemplate = require('../models/SessionTemplate');
 const StravaIntegrationService = require('../services/StravaIntegrationService');
+const ActivityMatchingService = require('../services/activityMatchingService');
 
 /**
  * Calendar Consistency Job
@@ -232,9 +233,15 @@ class CalendarConsistencyJob {
       for (const event of eventsWithSessionLogId) {
         const sessionLog = await SessionLog.findById(event.sessionLogId);
         if (!sessionLog) {
-          await CalendarEvent.findByIdAndDelete(event._id);
-          this.stats.orphanedCalendarEventsDeleted++;
-          this.logger.info(`[CalendarConsistencyJob] Deleted orphaned CalendarEvent ${event._id} (SessionLog ${event.sessionLogId} not found)`);
+          if (event.externalActivityId) {
+            // Strava evidence remains — keep the event, drop the dead link
+            await CalendarEvent.updateOne({ _id: event._id }, { $unset: { sessionLogId: 1 } });
+            this.logger.info(`[CalendarConsistencyJob] Unset dead SessionLog link on CalendarEvent ${event._id} (has externalActivityId)`);
+          } else {
+            await CalendarEvent.findByIdAndDelete(event._id);
+            this.stats.orphanedCalendarEventsDeleted++;
+            this.logger.info(`[CalendarConsistencyJob] Deleted orphaned CalendarEvent ${event._id} (SessionLog ${event.sessionLogId} not found)`);
+          }
         }
       }
 
@@ -246,9 +253,10 @@ class CalendarConsistencyJob {
       for (const event of eventsWithExternalActivityId) {
         const externalActivity = await ExternalActivity.findById(event.externalActivityId);
         if (!externalActivity) {
-          await CalendarEvent.findByIdAndDelete(event._id);
+          // Mirrors are deleted; merged planned events survive with the link severed
+          await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId);
           this.stats.orphanedCalendarEventsDeleted++;
-          this.logger.info(`[CalendarConsistencyJob] Deleted orphaned CalendarEvent ${event._id} (ExternalActivity ${event.externalActivityId} not found)`);
+          this.logger.info(`[CalendarConsistencyJob] Cleaned Strava-linked CalendarEvent ${event._id} (ExternalActivity ${event.externalActivityId} not found)`);
         }
       }
 
@@ -531,8 +539,12 @@ class CalendarConsistencyJob {
     for (const event of eventsWithSessionLogId) {
       const sessionLog = await SessionLog.findById(event.sessionLogId);
       if (!sessionLog) {
-        await CalendarEvent.findByIdAndDelete(event._id);
-        this.stats.orphanedCalendarEventsDeleted++;
+        if (event.externalActivityId) {
+          await CalendarEvent.updateOne({ _id: event._id }, { $unset: { sessionLogId: 1 } });
+        } else {
+          await CalendarEvent.findByIdAndDelete(event._id);
+          this.stats.orphanedCalendarEventsDeleted++;
+        }
       }
     }
 
@@ -544,7 +556,7 @@ class CalendarConsistencyJob {
     for (const event of eventsWithExternalActivityId) {
       const externalActivity = await ExternalActivity.findById(event.externalActivityId);
       if (!externalActivity) {
-        await CalendarEvent.findByIdAndDelete(event._id);
+        await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId);
         this.stats.orphanedCalendarEventsDeleted++;
       }
     }

--- a/backend/src/models/ActivityMatchAudit.js
+++ b/backend/src/models/ActivityMatchAudit.js
@@ -28,7 +28,7 @@ const activityMatchAuditSchema = new mongoose.Schema({
     enum: [
       'auto_merge', 'auto_pending', 'auto_unmatched',
       'user_merge', 'user_unmerge', 'user_event_delete',
-      'coach_merge', 'coach_separate', 'coach_unmerge'
+      'coach_merge', 'coach_separate', 'coach_unmerge', 'coach_event_delete'
     ],
     required: true
   },

--- a/backend/src/models/ActivityMatchAudit.js
+++ b/backend/src/models/ActivityMatchAudit.js
@@ -1,0 +1,60 @@
+const mongoose = require('mongoose');
+
+/**
+ * Audit trail for Strava-activity ↔ planned-event matching decisions.
+ *
+ * Every automatic classification AND every manual correction is recorded, so
+ * matcher quality is measurable: a user_unmerge/coach_unmerge following an
+ * auto_merge on the same activity means the matcher got it wrong; the auto_*
+ * rows are the denominator. Rows expire after ~180 days.
+ */
+const activityMatchAuditSchema = new mongoose.Schema({
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  activityId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'ExternalActivity',
+    required: true
+  },
+  eventId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'CalendarEvent'
+  },
+  action: {
+    type: String,
+    enum: [
+      'auto_merge', 'auto_pending', 'auto_unmatched',
+      'user_merge', 'user_unmerge', 'user_event_delete',
+      'coach_merge', 'coach_separate', 'coach_unmerge'
+    ],
+    required: true
+  },
+  actor: {
+    type: String,
+    enum: ['system', 'user', 'coach'],
+    required: true
+  },
+  // Activity match state before this action
+  previous: {
+    matchStatus: String,
+    matchedEventId: mongoose.Schema.Types.ObjectId
+  },
+  // Classifier inputs/outputs at decision time
+  context: {
+    candidateIds: [mongoose.Schema.Types.ObjectId],
+    discipline: String,
+    localDay: String,
+    decision: String
+  },
+  expiresAt: Date
+}, {
+  timestamps: true
+});
+
+activityMatchAuditSchema.index({ userId: 1, createdAt: -1 });
+activityMatchAuditSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = mongoose.model('ActivityMatchAudit', activityMatchAuditSchema);

--- a/backend/src/models/CalendarEvent.js
+++ b/backend/src/models/CalendarEvent.js
@@ -65,7 +65,20 @@ const calendarEventSchema = new mongoose.Schema({
         targetReps: Number,
         isCompleted: Boolean
       }]
-    }]
+    }],
+    // 'strava' = mirror event created for an unmatched external activity;
+    // 'strava-matched' = pre-existing planned event a Strava activity was
+    // merged into. The distinction drives unlink-vs-delete on activity
+    // deletion (see activityMatchingService.unlinkOrDeleteStravaEvent).
+    source: String,
+    stravaData: {
+      sportType: String,
+      distance: Number,
+      elevationGain: Number,
+      avgHeartRate: Number,
+      calories: Number,
+      stravaUrl: String
+    }
   },
   completedAt: Date,
   // Link to session log after completion (from TrainNow)

--- a/backend/src/models/ExternalActivity.js
+++ b/backend/src/models/ExternalActivity.js
@@ -100,7 +100,24 @@ const externalActivitySchema = new mongoose.Schema({
   // Store raw response for future use
   rawData: {
     type: mongoose.Schema.Types.Mixed
-  }
+  },
+
+  // Matching against planned calendar events (activityMatchingService).
+  // No default: null means "synced before matching existed" — the migration
+  // backfills. 'separate'/'confirmed' are user/coach decisions and are never
+  // re-classified by sync or the consistency job.
+  matchStatus: {
+    type: String,
+    enum: ['auto', 'confirmed', 'pending', 'separate', 'unmatched']
+  },
+  matchedEventId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'CalendarEvent'
+  },
+  matchCandidateIds: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'CalendarEvent'
+  }]
 
 }, { timestamps: true });
 

--- a/backend/src/routes/externalActivities.js
+++ b/backend/src/routes/externalActivities.js
@@ -344,7 +344,7 @@ router.delete('/:id', auth, async (req, res) => {
     // Clean up the calendar side immediately (mirrors deleted, merged
     // planned events survive with the link severed) instead of waiting for
     // the consistency job.
-    await StravaIntegrationService.deleteCalendarEventForActivity(activity._id, req.user.id);
+    await StravaIntegrationService.deleteCalendarEventForActivity(activity._id, req.user.id, activity);
 
     res.json({
       success: true,

--- a/backend/src/routes/externalActivities.js
+++ b/backend/src/routes/externalActivities.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const ExternalActivity = require('../models/ExternalActivity');
+const CalendarEvent = require('../models/CalendarEvent');
+const StravaIntegrationService = require('../services/StravaIntegrationService');
+const ActivityMatchingService = require('../services/activityMatchingService');
 const { auth } = require('../middleware/auth');
 
 const router = express.Router();
@@ -225,6 +228,102 @@ router.get('/:id', auth, async (req, res) => {
 });
 
 /**
+ * POST /api/v1/external-activities/:id/match
+ * Merge this activity into a calendar event the user picked. Completed
+ * events are allowed on purpose — attaching Strava evidence to an
+ * app-logged session is the legitimate double-record resolution.
+ */
+router.post('/:id/match', auth, async (req, res) => {
+  try {
+    const { eventId } = req.body;
+    if (!eventId || !mongoose.Types.ObjectId.isValid(eventId)) {
+      return res.status(400).json({ success: false, message: 'eventId is required' });
+    }
+
+    const activity = await ExternalActivity.findOne({
+      _id: req.params.id,
+      userId: req.user.id
+    }).lean();
+    if (!activity) {
+      return res.status(404).json({ success: false, message: 'Activity not found' });
+    }
+
+    const event = await CalendarEvent.findOne({
+      _id: eventId,
+      userId: req.user.id,
+      type: 'session'
+    }).lean();
+    if (!event) {
+      return res.status(404).json({ success: false, message: 'Calendar event not found' });
+    }
+    if (event.externalActivityId && String(event.externalActivityId) !== String(activity._id)) {
+      return res.status(409).json({
+        success: false,
+        message: 'That event is already linked to another activity'
+      });
+    }
+
+    await ActivityMatchingService.mergeActivityIntoEvent(activity, event, {
+      actor: 'user',
+      matchStatus: 'confirmed',
+      action: 'user_merge'
+    });
+
+    res.json({ success: true, message: 'Activity merged into event', data: { eventId: event._id } });
+  } catch (error) {
+    console.error('Match activity error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to merge activity',
+      error: error.message
+    });
+  }
+});
+
+/**
+ * POST /api/v1/external-activities/:id/unmatch
+ * Undo a merge: restore the planned event, put the activity back on the
+ * calendar as its own entry, and pin it 'separate' so it is never re-matched.
+ */
+router.post('/:id/unmatch', auth, async (req, res) => {
+  try {
+    const activity = await ExternalActivity.findOne({
+      _id: req.params.id,
+      userId: req.user.id
+    }).lean();
+    if (!activity) {
+      return res.status(404).json({ success: false, message: 'Activity not found' });
+    }
+
+    const linked = await CalendarEvent.findOne({
+      userId: req.user.id,
+      externalActivityId: activity._id
+    }).lean();
+    if (!linked || linked.sessionDetails?.source !== 'strava-matched') {
+      return res.status(400).json({
+        success: false,
+        message: 'Activity is not merged into a planned event'
+      });
+    }
+
+    const discipline = StravaIntegrationService.mapStravaTypeToDiscipline(activity.sportType);
+    await ActivityMatchingService.unmergeActivity(activity, discipline, {
+      actor: 'user',
+      action: 'user_unmerge'
+    });
+
+    res.json({ success: true, message: 'Activity un-merged' });
+  } catch (error) {
+    console.error('Unmatch activity error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to un-merge activity',
+      error: error.message
+    });
+  }
+});
+
+/**
  * DELETE /api/v1/external-activities/:id
  * Delete an activity
  */
@@ -241,6 +340,11 @@ router.delete('/:id', auth, async (req, res) => {
         message: 'Activity not found'
       });
     }
+
+    // Clean up the calendar side immediately (mirrors deleted, merged
+    // planned events survive with the link severed) instead of waiting for
+    // the consistency job.
+    await StravaIntegrationService.deleteCalendarEventForActivity(activity._id, req.user.id);
 
     res.json({
       success: true,

--- a/backend/src/services/StravaIntegrationService.js
+++ b/backend/src/services/StravaIntegrationService.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 const StravaCredential = require('../models/StravaCredential');
 const ExternalActivity = require('../models/ExternalActivity');
 const CalendarEvent = require('../models/CalendarEvent');
+const ActivityMatchingService = require('./activityMatchingService');
 
 const STRAVA_API_BASE = 'https://www.strava.com/api/v3';
 const STRAVA_OAUTH_BASE = 'https://www.strava.com/oauth';
@@ -345,45 +346,48 @@ class StravaIntegrationService {
   }
 
   /**
-   * Create or update CalendarEvent from Strava activity
+   * Reflect an activity on the calendar: refresh its linked event if one
+   * exists, otherwise classify it against planned events (auto-merge /
+   * pending / mirror). Decision rules and their invariants live in
+   * activityMatchingService.
    */
   static async syncCalendarEvent(externalActivity, userId) {
-    const eventData = {
-      userId,
-      date: externalActivity.startDate,
-      title: externalActivity.name,
-      type: 'session',
-      status: 'completed',
-      externalActivityId: externalActivity._id,
-      sessionDetails: {
-        discipline: this.mapStravaTypeToDiscipline(externalActivity.sportType),
-        durationMinutes: Math.round((externalActivity.movingTime || externalActivity.elapsedTime || 0) / 60),
-        source: 'strava',
-        stravaData: {
-          sportType: externalActivity.sportType,
-          distance: externalActivity.distance,
-          elevationGain: externalActivity.elevationGain,
-          avgHeartRate: externalActivity.avgHeartRate,
-          calories: externalActivity.calories,
-          stravaUrl: externalActivity.stravaUrl
-        }
-      },
-      completedAt: externalActivity.startDate
-    };
+    const discipline = this.mapStravaTypeToDiscipline(externalActivity.sportType);
 
-    // Upsert based on externalActivityId
-    await CalendarEvent.findOneAndUpdate(
-      { userId, externalActivityId: externalActivity._id },
-      eventData,
-      { upsert: true, new: true }
-    );
+    const linked = await CalendarEvent.findOne({
+      userId,
+      externalActivityId: externalActivity._id
+    }).lean();
+    if (linked) {
+      if (linked.sessionDetails?.source === 'strava-matched') {
+        await ActivityMatchingService.refreshMergedEvent(externalActivity, linked);
+      } else {
+        await ActivityMatchingService.upsertMirrorEvent(externalActivity, userId, discipline);
+      }
+      return;
+    }
+
+    // Resolved (or already-flagged) activities are never re-classified; they
+    // just get their mirror maintained.
+    const matchStatus = externalActivity.matchStatus;
+    if (matchStatus === 'separate' || matchStatus === 'confirmed' || matchStatus === 'pending') {
+      await ActivityMatchingService.upsertMirrorEvent(externalActivity, userId, discipline);
+      return;
+    }
+
+    await ActivityMatchingService.classifyAndApply(externalActivity, userId, discipline);
   }
 
   /**
-   * Delete CalendarEvent when Strava activity is deleted
+   * The activity was deleted (Strava webhook or app DELETE): mirrors are
+   * removed, merged planned events survive with the link severed.
    */
-  static async deleteCalendarEventForActivity(externalActivityId) {
-    await CalendarEvent.findOneAndDelete({ externalActivityId });
+  static async deleteCalendarEventForActivity(externalActivityId, userId) {
+    const query = { externalActivityId };
+    if (userId) query.userId = userId;
+    const event = await CalendarEvent.findOne(query).lean();
+    if (!event) return;
+    await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId);
   }
 
   /**
@@ -553,9 +557,9 @@ class StravaIntegrationService {
             externalId: object_id.toString()
           });
 
-          // Also delete the associated CalendarEvent
+          // Also delete/unlink the associated CalendarEvent
           if (deletedActivity) {
-            await this.deleteCalendarEventForActivity(deletedActivity._id);
+            await this.deleteCalendarEventForActivity(deletedActivity._id, credential.userId);
           }
 
           return { handled: true, action: 'delete', activityId: object_id };

--- a/backend/src/services/StravaIntegrationService.js
+++ b/backend/src/services/StravaIntegrationService.js
@@ -380,14 +380,16 @@ class StravaIntegrationService {
 
   /**
    * The activity was deleted (Strava webhook or app DELETE): mirrors are
-   * removed, merged planned events survive with the link severed.
+   * removed, merged planned events survive with the link severed. Pass the
+   * deleted activity doc when available — it lets the unlink revert only
+   * merge-set completion (a manual pre-merge completion is preserved).
    */
-  static async deleteCalendarEventForActivity(externalActivityId, userId) {
+  static async deleteCalendarEventForActivity(externalActivityId, userId, activity = null) {
     const query = { externalActivityId };
     if (userId) query.userId = userId;
     const event = await CalendarEvent.findOne(query).lean();
     if (!event) return;
-    await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId);
+    await ActivityMatchingService.unlinkOrDeleteStravaEvent(event, event.userId, activity);
   }
 
   /**
@@ -559,7 +561,7 @@ class StravaIntegrationService {
 
           // Also delete/unlink the associated CalendarEvent
           if (deletedActivity) {
-            await this.deleteCalendarEventForActivity(deletedActivity._id, credential.userId);
+            await this.deleteCalendarEventForActivity(deletedActivity._id, credential.userId, deletedActivity);
           }
 
           return { handled: true, action: 'delete', activityId: object_id };

--- a/backend/src/services/__tests__/activityMatching.test.js
+++ b/backend/src/services/__tests__/activityMatching.test.js
@@ -10,7 +10,8 @@ const {
   eventLocalDay,
   disciplinesCompatible,
   classifyCandidates,
-  shouldUnlinkNotDelete
+  shouldUnlinkNotDelete,
+  mergeSetCompletion
 } = require('../activityMatchingService');
 const CalendarEvent = require('../../models/CalendarEvent');
 const ExternalActivity = require('../../models/ExternalActivity');
@@ -168,6 +169,18 @@ describe('classifyCandidates decision matrix', () => {
     expect(classifyCandidates(activity, 'running', [logged]).decision).toBe('pending');
   });
 
+  test('skipped discipline-match → pending (the "skipped but actually done" question)', () => {
+    const skipped = makeEvent({ status: 'skipped' });
+    const result = classifyCandidates(activity, 'running', [skipped]);
+    expect(result.decision).toBe('pending');
+    expect(result.candidateIds).toEqual([skipped._id]);
+  });
+
+  test('skipped non-matching event alone does not trigger pending', () => {
+    const skipped = makeEvent({ status: 'skipped', sessionDetails: { discipline: 'strength' } });
+    expect(classifyCandidates(activity, 'running', [skipped]).decision).toBe('none');
+  });
+
   test('open candidates but no discipline match → pending with those candidates', () => {
     const strengthPlan = makeEvent({ sessionDetails: { discipline: 'strength' } });
     const result = classifyCandidates(activity, 'running', [strengthPlan]);
@@ -227,6 +240,27 @@ describe('shouldUnlinkNotDelete', () => {
   test('mirrors delete — including legacy events with stripped source', () => {
     expect(shouldUnlinkNotDelete({ sessionDetails: { source: 'strava' } })).toBe(false);
     expect(shouldUnlinkNotDelete({ sessionDetails: {} })).toBe(false);
+  });
+});
+
+describe('mergeSetCompletion (un-merge revert guard)', () => {
+  const start = new Date('2026-07-29T18:30:00Z');
+  const act = { startDate: start };
+
+  test('merge-stamped completion (completedAt === activity start) → revert allowed', () => {
+    expect(mergeSetCompletion({ completedAt: new Date(start) }, act)).toBe(true);
+  });
+
+  test('manual pre-merge completion (different completedAt) is preserved', () => {
+    expect(mergeSetCompletion({ completedAt: new Date('2026-07-29T20:00:00Z') }, act)).toBe(false);
+  });
+
+  test('unknown activity (orphan cleanup) never reverts', () => {
+    expect(mergeSetCompletion({ completedAt: new Date(start) }, null)).toBe(false);
+  });
+
+  test('no completedAt → nothing to revert', () => {
+    expect(mergeSetCompletion({}, act)).toBe(false);
   });
 });
 

--- a/backend/src/services/__tests__/activityMatching.test.js
+++ b/backend/src/services/__tests__/activityMatching.test.js
@@ -1,0 +1,260 @@
+/**
+ * Decision-matrix tests for the Strava↔planned-event matcher. Pure-function
+ * tests on plain objects — no DB. See activityMatchingService header for the
+ * rules under test.
+ */
+const mongoose = require('mongoose');
+const {
+  activityLocalDay,
+  activityUtcOffsetMs,
+  eventLocalDay,
+  disciplinesCompatible,
+  classifyCandidates,
+  shouldUnlinkNotDelete
+} = require('../activityMatchingService');
+const CalendarEvent = require('../../models/CalendarEvent');
+const ExternalActivity = require('../../models/ExternalActivity');
+
+const oid = () => new mongoose.Types.ObjectId();
+
+// Evening run in Israel (UTC+3): 21:30 local on Jul 29 = 18:30 UTC.
+const makeActivity = (overrides = {}) => ({
+  _id: oid(),
+  userId: oid(),
+  sportType: 'Run',
+  startDate: new Date('2026-07-29T18:30:00Z'),
+  movingTime: 45 * 60,
+  rawData: {
+    start_date: '2026-07-29T18:30:00Z',
+    start_date_local: '2026-07-29T21:30:00Z',
+    utc_offset: 10800
+  },
+  ...overrides
+});
+
+const makeEvent = (overrides = {}) => ({
+  _id: oid(),
+  type: 'session',
+  status: 'scheduled',
+  date: new Date('2026-07-29T00:00:00Z'),
+  sessionDetails: { discipline: 'running', estimatedDuration: 45 },
+  ...overrides
+});
+
+describe('activityLocalDay / activityUtcOffsetMs', () => {
+  test('prefers start_date_local wall time', () => {
+    // 23:30 local Jul 29 = 20:30 UTC — UTC day is still Jul 29, but at
+    // 01:30 local (22:30 UTC prev day) the local day differs from UTC day.
+    const lateNight = makeActivity({
+      startDate: new Date('2026-07-29T22:30:00Z'),
+      rawData: { start_date: '2026-07-29T22:30:00Z', start_date_local: '2026-07-30T01:30:00Z', utc_offset: 10800 }
+    });
+    expect(activityLocalDay(lateNight)).toBe('2026-07-30');
+  });
+
+  test('falls back to startDate UTC day without rawData', () => {
+    expect(activityLocalDay({ startDate: new Date('2026-07-29T18:30:00Z') })).toBe('2026-07-29');
+  });
+
+  test('offset from utc_offset, then from local-minus-utc, else 0', () => {
+    expect(activityUtcOffsetMs(makeActivity())).toBe(10800 * 1000);
+    const noOffset = makeActivity();
+    delete noOffset.rawData.utc_offset;
+    expect(activityUtcOffsetMs(noOffset)).toBe(3 * 60 * 60 * 1000);
+    expect(activityUtcOffsetMs({ rawData: {} })).toBe(0);
+  });
+});
+
+describe('eventLocalDay', () => {
+  test('midnight-UTC planned dates are day labels — never shifted', () => {
+    expect(eventLocalDay({ date: new Date('2026-07-29T00:00:00Z') }, 10800 * 1000)).toBe('2026-07-29');
+  });
+
+  test('timestamped dates shift by the activity offset across the UTC day boundary', () => {
+    // App-logged at 00:30 local Jul 30 = 21:30 UTC Jul 29
+    expect(eventLocalDay({ date: new Date('2026-07-29T21:30:00Z') }, 10800 * 1000)).toBe('2026-07-30');
+  });
+});
+
+describe('disciplinesCompatible', () => {
+  test('exact match', () => {
+    expect(disciplinesCompatible('running', 'running')).toEqual({ match: true, exact: true });
+  });
+
+  test('legacy synonyms normalize (endurance → cardio)', () => {
+    expect(disciplinesCompatible('cardio', 'endurance')).toEqual({ match: true, exact: true });
+  });
+
+  test('cardio family is bidirectional', () => {
+    expect(disciplinesCompatible('cycling', 'cardio').match).toBe(true);
+    expect(disciplinesCompatible('cardio', 'running').match).toBe(true);
+    expect(disciplinesCompatible('cycling', 'endurance').match).toBe(true);
+  });
+
+  test('specific modalities never match each other', () => {
+    expect(disciplinesCompatible('running', 'cycling').match).toBe(false);
+  });
+
+  test('hiit/hybrid are outside the cardio family', () => {
+    expect(disciplinesCompatible('cardio', 'hiit').match).toBe(false);
+    expect(disciplinesCompatible('cardio', 'hybrid').match).toBe(false);
+  });
+
+  test('other and empty never match', () => {
+    expect(disciplinesCompatible('other', 'other').match).toBe(false);
+    expect(disciplinesCompatible('running', null).match).toBe(false);
+  });
+
+  test('case-insensitive', () => {
+    expect(disciplinesCompatible('Running', 'RUNNING')).toEqual({ match: true, exact: true });
+  });
+});
+
+describe('classifyCandidates decision matrix', () => {
+  const activity = makeActivity();
+
+  test('single scheduled exact match → merge', () => {
+    const event = makeEvent();
+    const result = classifyCandidates(activity, 'running', [event]);
+    expect(result.decision).toBe('merge');
+    expect(result.target).toBe(event);
+  });
+
+  test('family match merges: planned endurance session + Strava Ride', () => {
+    const ride = makeActivity({ sportType: 'Ride' });
+    const event = makeEvent({ sessionDetails: { discipline: 'endurance', estimatedDuration: 60 } });
+    const result = classifyCandidates(ride, 'cycling', [event]);
+    expect(result.decision).toBe('merge');
+  });
+
+  test('exact match outranks family match', () => {
+    const exact = makeEvent({ sessionDetails: { discipline: 'running' } });
+    const family = makeEvent({ sessionDetails: { discipline: 'cardio' } });
+    const result = classifyCandidates(activity, 'running', [family, exact]);
+    expect(result.decision).toBe('merge');
+    expect(result.target).toBe(exact);
+  });
+
+  test('multiple matches + decisive duration tiebreak → merge', () => {
+    const close = makeEvent({ sessionDetails: { discipline: 'running', estimatedDuration: 45 } });
+    const far = makeEvent({ sessionDetails: { discipline: 'running', estimatedDuration: 120 } });
+    const result = classifyCandidates(activity, 'running', [far, close]);
+    expect(result.decision).toBe('merge');
+    expect(result.target).toBe(close);
+  });
+
+  test('multiple matches, ambiguous tiebreak → pending', () => {
+    const a = makeEvent({ sessionDetails: { discipline: 'running', estimatedDuration: 45 } });
+    const b = makeEvent({ sessionDetails: { discipline: 'running', estimatedDuration: 50 } });
+    const result = classifyCandidates(activity, 'running', [a, b]);
+    expect(result.decision).toBe('pending');
+    expect(result.candidateIds).toHaveLength(2);
+  });
+
+  test('missing estimatedDuration counts as out of tolerance', () => {
+    const a = makeEvent({ sessionDetails: { discipline: 'running' } });
+    const b = makeEvent({ sessionDetails: { discipline: 'running' } });
+    expect(classifyCandidates(activity, 'running', [a, b]).decision).toBe('pending');
+  });
+
+  test('completed discipline-match → pending, never merge', () => {
+    const done = makeEvent({ status: 'completed' });
+    const result = classifyCandidates(activity, 'running', [done]);
+    expect(result.decision).toBe('pending');
+  });
+
+  test('sessionLogId event (app-logged) → pending, never merge', () => {
+    const logged = makeEvent({ sessionLogId: oid() });
+    expect(classifyCandidates(activity, 'running', [logged]).decision).toBe('pending');
+  });
+
+  test('open candidates but no discipline match → pending with those candidates', () => {
+    const strengthPlan = makeEvent({ sessionDetails: { discipline: 'strength' } });
+    const result = classifyCandidates(activity, 'running', [strengthPlan]);
+    expect(result.decision).toBe('pending');
+    expect(result.candidateIds).toEqual([strengthPlan._id]);
+  });
+
+  test('empty day → none', () => {
+    expect(classifyCandidates(activity, 'running', []).decision).toBe('none');
+  });
+
+  test('other-day events are ignored', () => {
+    const otherDay = makeEvent({ date: new Date('2026-07-28T00:00:00Z') });
+    expect(classifyCandidates(activity, 'running', [otherDay]).decision).toBe('none');
+  });
+
+  test('already-linked events are excluded', () => {
+    const linked = makeEvent({ externalActivityId: oid() });
+    expect(classifyCandidates(activity, 'running', [linked]).decision).toBe('none');
+  });
+
+  test("'other' discipline short-circuits to none even with open candidates", () => {
+    const event = makeEvent({ sessionDetails: { discipline: 'strength' } });
+    expect(classifyCandidates(activity, 'other', [event]).decision).toBe('none');
+  });
+
+  test('template primary_disciplines is the discipline fallback', () => {
+    const event = makeEvent({
+      sessionDetails: {},
+      sessionTemplateId: { primary_disciplines: ['running'] }
+    });
+    expect(classifyCandidates(activity, 'running', [event]).decision).toBe('merge');
+  });
+
+  test('timestamped app-logged event across the UTC day boundary still counts as same-day', () => {
+    // Activity at 01:00 local Jul 30; logged event stored 21:30 UTC Jul 29 (00:30 local Jul 30)
+    const nightOwl = makeActivity({
+      startDate: new Date('2026-07-29T22:00:00Z'),
+      rawData: { start_date: '2026-07-29T22:00:00Z', start_date_local: '2026-07-30T01:00:00Z', utc_offset: 10800 }
+    });
+    const logged = makeEvent({ date: new Date('2026-07-29T21:30:00Z'), sessionLogId: oid() });
+    expect(classifyCandidates(nightOwl, 'running', [logged]).decision).toBe('pending');
+  });
+});
+
+describe('shouldUnlinkNotDelete', () => {
+  test('merged events unlink', () => {
+    expect(shouldUnlinkNotDelete({ sessionDetails: { source: 'strava-matched' } })).toBe(true);
+  });
+
+  test('template/plan/sessionLog-backed events unlink (belt and suspenders)', () => {
+    expect(shouldUnlinkNotDelete({ sessionTemplateId: oid() })).toBe(true);
+    expect(shouldUnlinkNotDelete({ planId: oid() })).toBe(true);
+    expect(shouldUnlinkNotDelete({ sessionLogId: oid() })).toBe(true);
+  });
+
+  test('mirrors delete — including legacy events with stripped source', () => {
+    expect(shouldUnlinkNotDelete({ sessionDetails: { source: 'strava' } })).toBe(false);
+    expect(shouldUnlinkNotDelete({ sessionDetails: {} })).toBe(false);
+  });
+});
+
+describe('schema persistence of the new fields', () => {
+  test('CalendarEvent keeps sessionDetails.source and stravaData (strict-mode fix)', () => {
+    const doc = new CalendarEvent({
+      userId: oid(),
+      date: new Date(),
+      title: 'Morning Run',
+      sessionDetails: {
+        discipline: 'running',
+        source: 'strava',
+        stravaData: { sportType: 'Run', distance: 10000, stravaUrl: 'https://www.strava.com/activities/1' }
+      }
+    });
+    expect(doc.validateSync()).toBeUndefined();
+    const obj = doc.toObject();
+    expect(obj.sessionDetails.source).toBe('strava');
+    expect(obj.sessionDetails.stravaData.sportType).toBe('Run');
+    expect(obj.sessionDetails.stravaData.distance).toBe(10000);
+  });
+
+  test('ExternalActivity matchStatus enum accepts known values, rejects others', () => {
+    const base = { userId: oid(), source: 'strava', externalId: '1', name: 'x', sportType: 'Run', startDate: new Date() };
+    for (const value of ['auto', 'confirmed', 'pending', 'separate', 'unmatched']) {
+      expect(new ExternalActivity({ ...base, matchStatus: value }).validateSync()).toBeUndefined();
+    }
+    const bad = new ExternalActivity({ ...base, matchStatus: 'maybe' });
+    expect(bad.validateSync().errors.matchStatus).toBeDefined();
+  });
+});

--- a/backend/src/services/activityMatchingService.js
+++ b/backend/src/services/activityMatchingService.js
@@ -207,7 +207,9 @@ async function findCandidateEvents(userId, activity) {
   return CalendarEvent.find({
     userId,
     type: 'session',
-    status: { $in: ['scheduled', 'in_progress', 'completed'] },
+    // 'skipped' included: a skipped plan the tracker shows was actually done
+    // is a textbook pending question (it can never auto-merge — see pool).
+    status: { $in: ['scheduled', 'in_progress', 'completed', 'skipped'] },
     externalActivityId: null,
     date: {
       $gte: new Date(dayStart.getTime() - DAY_MS),
@@ -289,15 +291,31 @@ async function mergeActivityIntoEvent(activity, event, { actor = 'system', match
   });
 }
 
-/** Sever a merged event's Strava link, reverting app-untouched events to scheduled. */
-async function unlinkEvent(event) {
+/**
+ * Did the MERGE set this event's completion (as opposed to the user completing
+ * it in-app before the merge)? The merge stamps completedAt = activity
+ * startDate and never touches an already-completed event, so equality is the
+ * marker. Unknown activity (orphan cleanup) → false: severing links must not
+ * risk wiping a manual completion.
+ */
+function mergeSetCompletion(event, activity) {
+  if (!activity || !event.completedAt || !activity.startDate) return false;
+  return new Date(event.completedAt).getTime() === new Date(activity.startDate).getTime();
+}
+
+/**
+ * Sever a merged event's Strava link. Status/completedAt/durationMinutes are
+ * reverted ONLY when the merge itself set them — an event the user completed
+ * in-app (with or without a session log) keeps its completion.
+ */
+async function unlinkEvent(event, activity = null) {
   const unset = {
     externalActivityId: 1,
     'sessionDetails.source': 1,
     'sessionDetails.stravaData': 1
   };
   const update = { $unset: unset };
-  if (!event.sessionLogId) {
+  if (!event.sessionLogId && mergeSetCompletion(event, activity)) {
     unset.completedAt = 1;
     unset['sessionDetails.durationMinutes'] = 1;
     update.$set = { status: 'scheduled' };
@@ -314,7 +332,12 @@ async function unmergeActivity(activity, discipline, { actor = 'user', action = 
     userId: activity.userId,
     externalActivityId: activity._id
   }).lean();
-  if (event) await unlinkEvent(event);
+  // Only unlink actual merged events. With a dangling matchedEventId the
+  // linked event can be a recreated MIRROR — unlinking that would strand a
+  // fake scheduled event; the mirror already IS the desired end state.
+  if (event && event.sessionDetails?.source === 'strava-matched') {
+    await unlinkEvent(event, activity);
+  }
 
   const previous = { matchStatus: activity.matchStatus, matchedEventId: activity.matchedEventId };
   await ExternalActivity.updateOne(
@@ -337,12 +360,13 @@ async function unmergeActivity(activity, discipline, { actor = 'user', action = 
  * external-activities DELETE): merged/planned events survive with the link
  * severed; pure mirrors are deleted.
  */
-async function unlinkOrDeleteStravaEvent(event, userId) {
+async function unlinkOrDeleteStravaEvent(event, userId, activity = null) {
   if (shouldUnlinkNotDelete(event)) {
-    await unlinkEvent(event);
-  } else {
-    await CalendarEvent.deleteOne({ _id: event._id, userId });
+    await unlinkEvent(event, activity);
+    return 'unlinked';
   }
+  await CalendarEvent.deleteOne({ _id: event._id, userId });
+  return 'deleted';
 }
 
 /**
@@ -387,12 +411,15 @@ async function classifyAndApply(activity, userId, discipline) {
     return;
   }
 
-  await upsertMirrorEvent(activity, userId, discipline);
+  // matchStatus BEFORE the mirror upsert: a crash in between self-heals (the
+  // skip-list path recreates the mirror next sync), whereas a linked mirror
+  // with no status would never be re-classified or flagged.
   const matchStatus = decision === 'pending' ? 'pending' : 'unmatched';
   await ExternalActivity.updateOne(
     { _id: activity._id },
     { $set: { matchStatus, matchCandidateIds: decision === 'pending' ? candidateIds : [] } }
   );
+  await upsertMirrorEvent(activity, userId, discipline);
   await writeAudit({
     userId,
     activityId: activity._id,
@@ -403,10 +430,19 @@ async function classifyAndApply(activity, userId, discipline) {
   });
 }
 
-/** Refresh Strava-derived details on a merged event after an activity update. */
+/**
+ * Refresh Strava-derived details on a merged event after an activity update.
+ * Completion metadata is refreshed only when the merge owns it
+ * (mergeSetCompletion) — a pre-merge manual completion is never overwritten.
+ * Caveat: a Strava edit that changes the START TIME breaks the equality
+ * marker, so that event's completion metadata goes stale; accepted.
+ */
 async function refreshMergedEvent(activity, event) {
   const set = { 'sessionDetails.stravaData': stravaDataFor(activity) };
-  if (!event.sessionLogId) set.completedAt = activity.startDate;
+  if (!event.sessionLogId && mergeSetCompletion(event, activity)) {
+    set.completedAt = activity.startDate;
+    set['sessionDetails.durationMinutes'] = activityDurationMinutes(activity);
+  }
   await CalendarEvent.updateOne({ _id: event._id }, { $set: set });
 }
 
@@ -421,6 +457,7 @@ module.exports = {
   durationInTolerance,
   classifyCandidates,
   shouldUnlinkNotDelete,
+  mergeSetCompletion,
   findCandidateEvents,
   upsertMirrorEvent,
   mergeActivityIntoEvent,

--- a/backend/src/services/activityMatchingService.js
+++ b/backend/src/services/activityMatchingService.js
@@ -1,0 +1,434 @@
+const CalendarEvent = require('../models/CalendarEvent');
+const ExternalActivity = require('../models/ExternalActivity');
+const ActivityMatchAudit = require('../models/ActivityMatchAudit');
+const { normalizeDisciplines } = require('../config/disciplines');
+
+/**
+ * Matching between synced external activities (Strava) and planned calendar
+ * events, plus the single home for merge/un-merge semantics — the sync path,
+ * the user-facing routes, and the coach internal API must all go through
+ * these helpers so the rules stay in one place.
+ *
+ * Event linkage vocabulary:
+ *  - mirror event: created BY the sync for an activity that matched nothing
+ *    (sessionDetails.source === 'strava'). Legacy linked events predating the
+ *    matcher are all mirrors — merging didn't exist yet.
+ *  - merged event: a pre-existing planned event an activity was merged into
+ *    (sessionDetails.source === 'strava-matched').
+ *
+ * Rules that are deliberate (do not "fix"):
+ *  - Activities with matchStatus 'separate', 'confirmed' or 'pending' are
+ *    never re-classified — sync and the consistency job only maintain their
+ *    mirror/linked event. A webhook update that corrects the sportType of a
+ *    pending activity therefore never re-classifies it; only the user or the
+ *    coach resolves it.
+ *  - Two same-day activities against one planned event: first processed wins
+ *    the merge (Strava page order), the second becomes a mirror.
+ *  - The cardio family excludes 'hiit' and 'hybrid': a planned hybrid session
+ *    only ever exact-matches, so it lands in pending by design.
+ */
+
+// 'cardio' is the generic endurance bucket: a planned cardio/endurance
+// session accepts any of these activity disciplines and vice versa. Specific
+// modalities never match each other (a planned run is not a Strava ride).
+const CARDIO_FAMILY = new Set(['running', 'cycling', 'swimming', 'walking', 'cardio']);
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const AUDIT_TTL_MS = 180 * DAY_MS;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested without a DB)
+// ---------------------------------------------------------------------------
+
+function normalizeDiscipline(value) {
+  return normalizeDisciplines([value])[0] || null;
+}
+
+/**
+ * The activity's local calendar day as 'YYYY-MM-DD'. Strava's
+ * start_date_local is wall time serialized with a fake Z suffix, so its date
+ * part IS the local day.
+ */
+function activityLocalDay(activity) {
+  const local = activity.rawData?.start_date_local;
+  if (typeof local === 'string' && local.length >= 10) return local.slice(0, 10);
+  return new Date(activity.startDate).toISOString().slice(0, 10);
+}
+
+/** UTC offset of the activity's timezone in ms (0 when underivable). */
+function activityUtcOffsetMs(activity) {
+  const raw = activity.rawData || {};
+  if (typeof raw.utc_offset === 'number' && Number.isFinite(raw.utc_offset)) {
+    return raw.utc_offset * 1000;
+  }
+  if (typeof raw.start_date_local === 'string' && typeof raw.start_date === 'string') {
+    const diff = new Date(raw.start_date_local).getTime() - new Date(raw.start_date).getTime();
+    return Number.isFinite(diff) ? diff : 0;
+  }
+  return 0;
+}
+
+/**
+ * The local day a candidate event belongs to. Planned events are stored at
+ * midnight UTC of the intended local day, so their UTC day-string is the day
+ * label. Timestamped dates (sessionLog-derived events) are real instants and
+ * get shifted by the activity's UTC offset first, so a 00:30-local app-logged
+ * session doesn't fall on the previous UTC day.
+ */
+function eventLocalDay(event, offsetMs) {
+  const date = new Date(event.date);
+  const isMidnightUtc = date.getUTCHours() === 0 && date.getUTCMinutes() === 0 && date.getUTCSeconds() === 0;
+  const effective = isMidnightUtc ? date : new Date(date.getTime() + offsetMs);
+  return effective.toISOString().slice(0, 10);
+}
+
+/** Discipline of a planned event, normalized; template's first primary discipline as fallback. */
+function eventDiscipline(event) {
+  return normalizeDiscipline(event.sessionDetails?.discipline)
+    || normalizeDiscipline(event.sessionTemplateId?.primary_disciplines?.[0]);
+}
+
+/** @returns {{match: boolean, exact: boolean}} */
+function disciplinesCompatible(activityDiscipline, plannedDiscipline) {
+  const a = normalizeDiscipline(activityDiscipline);
+  const p = normalizeDiscipline(plannedDiscipline);
+  if (!a || !p || a === 'other' || p === 'other') return { match: false, exact: false };
+  if (a === p) return { match: true, exact: true };
+  const family = (a === 'cardio' && CARDIO_FAMILY.has(p)) || (p === 'cardio' && CARDIO_FAMILY.has(a));
+  return { match: family, exact: false };
+}
+
+function activityDurationMinutes(activity) {
+  return Math.round((activity.movingTime || activity.elapsedTime || 0) / 60);
+}
+
+function durationInTolerance(activity, event) {
+  const planned = event.sessionDetails?.estimatedDuration;
+  if (!planned || !Number.isFinite(planned)) return false;
+  const actual = activityDurationMinutes(activity);
+  return Math.abs(actual - planned) <= Math.max(15, 0.25 * planned);
+}
+
+/**
+ * Decide what to do with a not-yet-linked activity given candidate events
+ * (pre-fetched, unlinked, status scheduled/in_progress/completed).
+ *
+ * @returns {{decision: 'merge'|'pending'|'none', target?: object, candidateIds: Array}}
+ */
+function classifyCandidates(activity, discipline, events) {
+  const normalized = normalizeDiscipline(discipline);
+  // Unmapped sport types never merge and never nag: straight to mirror.
+  if (!normalized || normalized === 'other') return { decision: 'none', candidateIds: [] };
+
+  const localDay = activityLocalDay(activity);
+  const offsetMs = activityUtcOffsetMs(activity);
+  const sameDay = (events || []).filter((e) => !e.externalActivityId && eventLocalDay(e, offsetMs) === localDay);
+
+  // Auto-merge pool: still fully open. Events completed in-app (or carrying a
+  // sessionLog — in_progress always does) are the double-record case: they
+  // can trigger a pending question but are never auto-merged.
+  const pool = sameDay.filter((e) => e.status === 'scheduled' && !e.sessionLogId);
+  const closedMatches = sameDay
+    .filter((e) => e.status !== 'scheduled' || e.sessionLogId)
+    .filter((e) => disciplinesCompatible(normalized, eventDiscipline(e)).match);
+
+  const exact = [];
+  const family = [];
+  for (const e of pool) {
+    const compat = disciplinesCompatible(normalized, eventDiscipline(e));
+    if (compat.exact) exact.push(e);
+    else if (compat.match) family.push(e);
+  }
+  const matching = exact.length > 0 ? exact : family;
+
+  if (matching.length === 1) {
+    return { decision: 'merge', target: matching[0], candidateIds: matching.map((e) => e._id) };
+  }
+  if (matching.length > 1) {
+    const inTolerance = matching.filter((e) => durationInTolerance(activity, e));
+    if (inTolerance.length === 1) {
+      return { decision: 'merge', target: inTolerance[0], candidateIds: matching.map((e) => e._id) };
+    }
+    return { decision: 'pending', candidateIds: matching.map((e) => e._id) };
+  }
+  if (closedMatches.length > 0) {
+    return { decision: 'pending', candidateIds: closedMatches.map((e) => e._id) };
+  }
+  if (pool.length > 0) {
+    // Open plans exist but none matches the discipline — the "Endurance
+    // planned, strength done" case the coach should ask about.
+    return { decision: 'pending', candidateIds: pool.map((e) => e._id) };
+  }
+  return { decision: 'none', candidateIds: [] };
+}
+
+/** Unlink vs delete for an event whose activity link must be severed. */
+function shouldUnlinkNotDelete(event) {
+  return event.sessionDetails?.source === 'strava-matched'
+    || Boolean(event.sessionTemplateId)
+    || Boolean(event.planId)
+    || Boolean(event.sessionLogId);
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function stravaDataFor(activity) {
+  return {
+    sportType: activity.sportType,
+    distance: activity.distance,
+    elevationGain: activity.elevationGain,
+    avgHeartRate: activity.avgHeartRate,
+    calories: activity.calories,
+    stravaUrl: activity.stravaUrl
+  };
+}
+
+async function writeAudit({ userId, activityId, eventId, action, actor, previous, context }) {
+  try {
+    await ActivityMatchAudit.create({
+      userId,
+      activityId,
+      eventId,
+      action,
+      actor,
+      previous,
+      context,
+      expiresAt: new Date(Date.now() + AUDIT_TTL_MS)
+    });
+  } catch (error) {
+    console.error('Failed to write activity match audit:', error.message);
+  }
+}
+
+async function findCandidateEvents(userId, activity) {
+  const dayStart = new Date(`${activityLocalDay(activity)}T00:00:00Z`);
+  return CalendarEvent.find({
+    userId,
+    type: 'session',
+    status: { $in: ['scheduled', 'in_progress', 'completed'] },
+    externalActivityId: null,
+    date: {
+      $gte: new Date(dayStart.getTime() - DAY_MS),
+      $lt: new Date(dayStart.getTime() + 2 * DAY_MS)
+    }
+  })
+    .populate('sessionTemplateId', 'primary_disciplines')
+    .lean();
+}
+
+/**
+ * Create/refresh the standalone mirror event for an activity.
+ * (The pre-matcher behavior, kept for unmatched/pending/separate activities.)
+ */
+async function upsertMirrorEvent(activity, userId, discipline) {
+  await CalendarEvent.findOneAndUpdate(
+    { userId, externalActivityId: activity._id },
+    {
+      userId,
+      date: activity.startDate,
+      title: activity.name,
+      type: 'session',
+      status: 'completed',
+      externalActivityId: activity._id,
+      sessionDetails: {
+        discipline,
+        durationMinutes: activityDurationMinutes(activity),
+        source: 'strava',
+        stravaData: stravaDataFor(activity)
+      },
+      completedAt: activity.startDate
+    },
+    { upsert: true, new: true }
+  );
+}
+
+/**
+ * Merge an activity into a planned event. Targeted dot-path $set only — a
+ * whole-sessionDetails replace would wipe the planned exercises/estimate.
+ * App-native completion data always wins: an already-completed event keeps
+ * its status/completedAt/durationMinutes and only gains the Strava link.
+ */
+async function mergeActivityIntoEvent(activity, event, { actor = 'system', matchStatus = 'auto', action = 'auto_merge', context } = {}) {
+  const set = {
+    externalActivityId: activity._id,
+    'sessionDetails.source': 'strava-matched',
+    'sessionDetails.stravaData': stravaDataFor(activity)
+  };
+  if (event.status !== 'completed') {
+    set.status = 'completed';
+    set.completedAt = activity.startDate;
+  }
+  if (event.sessionDetails?.durationMinutes == null) {
+    set['sessionDetails.durationMinutes'] = activityDurationMinutes(activity);
+  }
+  await CalendarEvent.updateOne({ _id: event._id, userId: activity.userId }, { $set: set });
+
+  // Merging supersedes any mirror this activity may have (user-initiated
+  // merges start from a mirror on the calendar).
+  await CalendarEvent.deleteOne({
+    userId: activity.userId,
+    externalActivityId: activity._id,
+    _id: { $ne: event._id }
+  });
+
+  const previous = { matchStatus: activity.matchStatus, matchedEventId: activity.matchedEventId };
+  await ExternalActivity.updateOne(
+    { _id: activity._id },
+    { $set: { matchStatus, matchedEventId: event._id, matchCandidateIds: [] } }
+  );
+  await writeAudit({
+    userId: activity.userId,
+    activityId: activity._id,
+    eventId: event._id,
+    action,
+    actor,
+    previous,
+    context
+  });
+}
+
+/** Sever a merged event's Strava link, reverting app-untouched events to scheduled. */
+async function unlinkEvent(event) {
+  const unset = {
+    externalActivityId: 1,
+    'sessionDetails.source': 1,
+    'sessionDetails.stravaData': 1
+  };
+  const update = { $unset: unset };
+  if (!event.sessionLogId) {
+    unset.completedAt = 1;
+    unset['sessionDetails.durationMinutes'] = 1;
+    update.$set = { status: 'scheduled' };
+  }
+  await CalendarEvent.updateOne({ _id: event._id }, update);
+}
+
+/**
+ * Undo a merge: restore the planned event, bring the activity back onto the
+ * calendar as a mirror, and pin it 'separate' so it is never re-matched.
+ */
+async function unmergeActivity(activity, discipline, { actor = 'user', action = 'user_unmerge' } = {}) {
+  const event = await CalendarEvent.findOne({
+    userId: activity.userId,
+    externalActivityId: activity._id
+  }).lean();
+  if (event) await unlinkEvent(event);
+
+  const previous = { matchStatus: activity.matchStatus, matchedEventId: activity.matchedEventId };
+  await ExternalActivity.updateOne(
+    { _id: activity._id },
+    { $set: { matchStatus: 'separate' }, $unset: { matchedEventId: 1 } }
+  );
+  await upsertMirrorEvent({ ...activity, matchStatus: 'separate' }, activity.userId, discipline);
+  await writeAudit({
+    userId: activity.userId,
+    activityId: activity._id,
+    eventId: event?._id,
+    action,
+    actor,
+    previous
+  });
+}
+
+/**
+ * The activity behind this event is gone (deleted on Strava, or via the
+ * external-activities DELETE): merged/planned events survive with the link
+ * severed; pure mirrors are deleted.
+ */
+async function unlinkOrDeleteStravaEvent(event, userId) {
+  if (shouldUnlinkNotDelete(event)) {
+    await unlinkEvent(event);
+  } else {
+    await CalendarEvent.deleteOne({ _id: event._id, userId });
+  }
+}
+
+/**
+ * The user deleted a Strava-linked calendar event directly. That is a match
+ * correction: pin the activity 'separate' (never re-merged, mirror not
+ * auto-resurrected as a merge) and audit it.
+ */
+async function handleLinkedEventDeletion(event, userId) {
+  const activity = await ExternalActivity.findOne({ _id: event.externalActivityId, userId }).lean();
+  if (!activity) return;
+  const previous = { matchStatus: activity.matchStatus, matchedEventId: activity.matchedEventId };
+  await ExternalActivity.updateOne(
+    { _id: activity._id },
+    { $set: { matchStatus: 'separate' }, $unset: { matchedEventId: 1 } }
+  );
+  await writeAudit({
+    userId,
+    activityId: activity._id,
+    eventId: event._id,
+    action: 'user_event_delete',
+    actor: 'user',
+    previous
+  });
+}
+
+/**
+ * Classify a not-yet-linked activity and apply the outcome (merge, or mirror
+ * with pending/unmatched bookkeeping). Called from syncCalendarEvent only.
+ */
+async function classifyAndApply(activity, userId, discipline) {
+  const events = await findCandidateEvents(userId, activity);
+  const { decision, target, candidateIds } = classifyCandidates(activity, discipline, events);
+  const context = {
+    candidateIds,
+    discipline,
+    localDay: activityLocalDay(activity),
+    decision
+  };
+
+  if (decision === 'merge') {
+    await mergeActivityIntoEvent(activity, target, { actor: 'system', matchStatus: 'auto', action: 'auto_merge', context });
+    return;
+  }
+
+  await upsertMirrorEvent(activity, userId, discipline);
+  const matchStatus = decision === 'pending' ? 'pending' : 'unmatched';
+  await ExternalActivity.updateOne(
+    { _id: activity._id },
+    { $set: { matchStatus, matchCandidateIds: decision === 'pending' ? candidateIds : [] } }
+  );
+  await writeAudit({
+    userId,
+    activityId: activity._id,
+    action: decision === 'pending' ? 'auto_pending' : 'auto_unmatched',
+    actor: 'system',
+    previous: { matchStatus: activity.matchStatus, matchedEventId: activity.matchedEventId },
+    context
+  });
+}
+
+/** Refresh Strava-derived details on a merged event after an activity update. */
+async function refreshMergedEvent(activity, event) {
+  const set = { 'sessionDetails.stravaData': stravaDataFor(activity) };
+  if (!event.sessionLogId) set.completedAt = activity.startDate;
+  await CalendarEvent.updateOne({ _id: event._id }, { $set: set });
+}
+
+module.exports = {
+  CARDIO_FAMILY,
+  normalizeDiscipline,
+  activityLocalDay,
+  activityUtcOffsetMs,
+  eventLocalDay,
+  eventDiscipline,
+  disciplinesCompatible,
+  durationInTolerance,
+  classifyCandidates,
+  shouldUnlinkNotDelete,
+  findCandidateEvents,
+  upsertMirrorEvent,
+  mergeActivityIntoEvent,
+  unlinkEvent,
+  unmergeActivity,
+  unlinkOrDeleteStravaEvent,
+  handleLinkedEventDeletion,
+  classifyAndApply,
+  refreshMergedEvent,
+  writeAudit
+};

--- a/frontend/src/api/mongodb-entities.js
+++ b/frontend/src/api/mongodb-entities.js
@@ -112,7 +112,9 @@ export const ExternalActivity = {
   },
   stats: async (days = 30) => apiService.externalActivities.stats(days),
   recent: async (limit = 20) => normalizeArray(await apiService.externalActivities.recent(limit)),
-  sportTypes: async () => apiService.externalActivities.sportTypes()
+  sportTypes: async () => apiService.externalActivities.sportTypes(),
+  match: async (id, eventId) => apiService.externalActivities.match(id, eventId),
+  unmatch: async (id) => apiService.externalActivities.unmatch(id)
 };
 
 // Strava Integration entity

--- a/frontend/src/components/calendar/CalendarEventDetailModal.jsx
+++ b/frontend/src/components/calendar/CalendarEventDetailModal.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { X, Clock, Dumbbell, CheckCircle, Calendar, Play, SkipForward, Target } from "lucide-react";
+import React, { useState } from "react";
+import { X, Clock, Dumbbell, CheckCircle, Calendar, Play, SkipForward, Target, Link2, Unlink } from "lucide-react";
 import { format } from "date-fns";
 
 const STATUS_CONFIG = {
@@ -58,10 +58,16 @@ const flattenTemplateBlocks = (blocks) => {
   );
 };
 
-export default function CalendarEventDetailModal({ event, onClose, onStartWorkout, onDelete }) {
+export default function CalendarEventDetailModal({ event, onClose, onStartWorkout, onDelete, onMatch, onUnmatch, matchCandidates = [] }) {
+  const [showMergePicker, setShowMergePicker] = useState(false);
   if (!event) return null;
 
   const status = event.status || "scheduled";
+  // Mirror = standalone Strava import; merged = planned event a Strava
+  // activity was merged into. Both carry externalActivityId (the activity id
+  // the match/unmatch endpoints take).
+  const isStravaMirror = event.externalActivityId && event.sessionDetails?.source !== 'strava-matched';
+  const isStravaMerged = event.sessionDetails?.source === 'strava-matched';
   const statusConfig = STATUS_CONFIG[status] || STATUS_CONFIG.scheduled;
   const StatusIcon = statusConfig.icon;
 
@@ -219,7 +225,51 @@ export default function CalendarEventDetailModal({ event, onClose, onStartWorkou
 
         {/* Footer Actions */}
         <div className="px-5 py-4 border-t border-gray-100 bg-gray-50 flex-shrink-0">
+          {/* Merge picker: same-day sessions this Strava import can complete */}
+          {showMergePicker && (
+            <div className="mb-3">
+              <p className="text-xs font-semibold text-gray-500 mb-2">Merge into which session?</p>
+              <div className="space-y-1.5 max-h-40 overflow-y-auto">
+                {matchCandidates.map((candidate) => (
+                  <button
+                    key={candidate.id}
+                    onClick={() => onMatch(event.externalActivityId, candidate.id)}
+                    className="w-full flex items-center justify-between px-3 py-2 bg-white border border-gray-200 rounded-xl hover:border-[#FE5334] transition-colors text-left"
+                  >
+                    <span className="text-sm font-medium text-gray-900 truncate">{candidate.title}</span>
+                    <span className="flex-shrink-0 ml-2 text-[10px] font-semibold text-gray-400">
+                      {(STATUS_CONFIG[candidate.status]?.label || 'Scheduled')}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           <div className="flex gap-3">
+            {isStravaMirror && matchCandidates.length > 0 && onMatch && (
+              <button
+                onClick={() => setShowMergePicker(!showMergePicker)}
+                className="flex-1 flex items-center justify-center gap-1.5 px-4 py-3 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 transition-colors font-medium text-sm"
+              >
+                <Link2 className="w-4 h-4 text-[#FC4C02]" />
+                {showMergePicker ? 'Cancel merge' : 'Merge into session…'}
+              </button>
+            )}
+
+            {isStravaMerged && onUnmatch && (
+              <button
+                onClick={() => {
+                  if (confirm('Un-merge this Strava activity? The planned session goes back to scheduled and the activity gets its own entry.')) {
+                    onUnmatch(event.externalActivityId);
+                  }
+                }}
+                className="flex-1 flex items-center justify-center gap-1.5 px-4 py-3 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 transition-colors font-medium text-sm"
+              >
+                <Unlink className="w-4 h-4 text-[#FC4C02]" />
+                Not the same? Un-merge
+              </button>
+            )}
             {status === 'scheduled' && onStartWorkout && (
               <button
                 onClick={() => onStartWorkout(event)}

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { CalendarEvent, Plan } from "@/api/entities";
+import { CalendarEvent, ExternalActivity, Plan } from "@/api/entities";
 import { ChevronLeft, ChevronRight, Plus, Check } from "lucide-react";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, addMonths, subMonths, startOfWeek, endOfWeek, parseISO, isValid, isToday, isSameDay } from "date-fns";
 
@@ -88,7 +88,7 @@ const getEventTypeColor = (eventType) => {
 };
 
 // Figma-style Calendar View Component (Month View Only)
-const CalendarView = ({ events, activePlans, currentDate, onDateChange, onAddEvent, onEditEvent, onDeleteEvent, onMoveEvent, weekStartDay }) => {
+const CalendarView = ({ events, activePlans, currentDate, onDateChange, onAddEvent, onEditEvent, onDeleteEvent, onMoveEvent, onMatchActivity, onUnmatchActivity, weekStartDay }) => {
   const [selectedDate, setSelectedDate] = useState(new Date()); // Default to today
   const [showWorkoutModal, setShowWorkoutModal] = useState(false);
   const [showEventDetailModal, setShowEventDetailModal] = useState(false);
@@ -362,14 +362,17 @@ const CalendarView = ({ events, activePlans, currentDate, onDateChange, onAddEve
                         const isCompleted = status === 'completed';
                         const isSkipped = status === 'skipped';
                         const isPastAndNotDone = !isCompleted && !isSkipped && new Date(event.date) < new Date().setHours(0,0,0,0);
-                        const isStrava = event.externalActivityId || event.sessionDetails?.source === 'strava';
+                        // Mirrors (standalone Strava imports) render orange; planned
+                        // events a Strava activity was merged into keep their own color.
+                        const isStravaMirror = event.sessionDetails?.source === 'strava'
+                          || (event.externalActivityId && event.sessionDetails?.source !== 'strava-matched');
                         return (
                           <div
                             key={event.id || idx}
                             className={`pointer-events-none ${isSkipped || isPastAndNotDone ? 'opacity-40' : ''}`}
                             title={`${event.title} (${STATUS_STYLES[status]?.label || 'Scheduled'})`}
                           >
-                            <div className={`h-1 rounded-full ${isStrava ? 'bg-[#FC4C02]' : colors.dot}`} />
+                            <div className={`h-1 rounded-full ${isStravaMirror ? 'bg-[#FC4C02]' : colors.dot}`} />
                           </div>
                         );
                       })}
@@ -414,13 +417,18 @@ const CalendarView = ({ events, activePlans, currentDate, onDateChange, onAddEve
                 const isCompleted = status === 'completed';
                 const isSkipped = status === 'skipped';
                 const isPastAndNotDone = !isCompleted && !isSkipped && new Date(event.date) < new Date().setHours(0,0,0,0);
-                const isStrava = event.externalActivityId || event.sessionDetails?.source === 'strava';
+                // Mirror = standalone Strava import (orange card). Merged = planned
+                // event completed by a Strava activity: keeps its planned styling,
+                // gains the Strava glyph + distance line.
+                const isStravaMirror = event.sessionDetails?.source === 'strava'
+                  || (event.externalActivityId && event.sessionDetails?.source !== 'strava-matched');
+                const isStravaMerged = event.sessionDetails?.source === 'strava-matched';
                 const stravaData = event.sessionDetails?.stravaData;
                 return (
                   <div
                     key={event.id || idx}
                     className={`group bg-white rounded-2xl shadow-sm hover:shadow-md transition-all duration-200 cursor-pointer overflow-hidden border ${
-                      isStrava
+                      isStravaMirror
                         ? 'border-l-4 border-l-[#FC4C02] border-t-orange-100 border-r-orange-100 border-b-orange-100'
                         : isCompleted
                           ? 'border-l-4 border-l-emerald-500 border-t-gray-100 border-r-gray-100 border-b-gray-100'
@@ -433,38 +441,38 @@ const CalendarView = ({ events, activePlans, currentDate, onDateChange, onAddEve
                     <div className="p-3">
                       {/* Type Badge */}
                       <div className="flex items-center gap-1.5 mb-1.5">
-                        <span className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold text-white ${isStrava ? 'bg-[#FC4C02]' : colors.dot}`}>
-                          {isStrava ? (stravaData?.sportType || workoutType) : (workoutType.charAt(0).toUpperCase() + workoutType.slice(1))}
+                        <span className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold text-white ${isStravaMirror ? 'bg-[#FC4C02]' : colors.dot}`}>
+                          {isStravaMirror ? (stravaData?.sportType || workoutType) : (workoutType.charAt(0).toUpperCase() + workoutType.slice(1))}
                         </span>
-                        {isStrava && (
+                        {(isStravaMirror || isStravaMerged) && (
                           <svg className="w-3 h-3 flex-shrink-0" viewBox="0 0 24 24" fill="#FC4C02">
                             <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"/>
                           </svg>
                         )}
-                        {isCompleted && !isStrava && (
+                        {isCompleted && !isStravaMirror && (
                           <span className="flex items-center gap-0.5 text-emerald-600">
                             <Check className="w-3 h-3" />
                           </span>
                         )}
-                        {isPastAndNotDone && !isStrava && (
+                        {isPastAndNotDone && !isStravaMirror && (
                           <span className="text-[10px] text-gray-400 font-medium">Missed</span>
                         )}
                       </div>
 
                       {/* Title and Status */}
                       <div className="flex items-start justify-between gap-2">
-                        <h4 className={`text-sm font-bold text-gray-900 line-clamp-1 ${isSkipped ? 'line-through opacity-60' : ''} ${isPastAndNotDone && !isStrava ? 'text-gray-500' : ''}`}>
+                        <h4 className={`text-sm font-bold text-gray-900 line-clamp-1 ${isSkipped ? 'line-through opacity-60' : ''} ${isPastAndNotDone && !isStravaMirror ? 'text-gray-500' : ''}`}>
                           {event.title}
                         </h4>
                         <span className={`flex-shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                          isStrava ? 'bg-orange-100 text-orange-700' : isPastAndNotDone ? 'bg-gray-100 text-gray-400' : statusStyle.badge
+                          isStravaMirror ? 'bg-orange-100 text-orange-700' : isPastAndNotDone ? 'bg-gray-100 text-gray-400' : statusStyle.badge
                         }`}>
-                          {isStrava ? 'Synced' : isPastAndNotDone ? 'Missed' : statusStyle.label}
+                          {isStravaMirror ? 'Synced' : isPastAndNotDone ? 'Missed' : statusStyle.label}
                         </span>
                       </div>
 
                       {/* Duration */}
-                      <p className={`text-xs mt-1 ${isPastAndNotDone && !isStrava ? 'text-gray-400' : 'text-gray-500'}`}>
+                      <p className={`text-xs mt-1 ${isPastAndNotDone && !isStravaMirror ? 'text-gray-400' : 'text-gray-500'}`}>
                         {event.sessionDetails?.durationMinutes || event.sessionDetails?.estimatedDuration || 60} min
                         {stravaData?.distance && ` • ${(stravaData.distance / 1000).toFixed(1)} km`}
                       </p>
@@ -506,12 +514,28 @@ const CalendarView = ({ events, activePlans, currentDate, onDateChange, onAddEve
       {showEventDetailModal && viewingEvent && (
         <CalendarEventDetailModal
           event={viewingEvent}
+          matchCandidates={events.filter(e =>
+            e.id !== viewingEvent.id
+            && !e.externalActivityId
+            && (e.type || 'session') === 'session'
+            && isSameDay(new Date(e.date), new Date(viewingEvent.date))
+          )}
           onClose={() => {
             setShowEventDetailModal(false);
             setViewingEvent(null);
           }}
           onDelete={(eventId) => {
             onDeleteEvent(eventId);
+            setShowEventDetailModal(false);
+            setViewingEvent(null);
+          }}
+          onMatch={(activityId, eventId) => {
+            onMatchActivity(activityId, eventId);
+            setShowEventDetailModal(false);
+            setViewingEvent(null);
+          }}
+          onUnmatch={(activityId) => {
+            onUnmatchActivity(activityId);
             setShowEventDetailModal(false);
             setViewingEvent(null);
           }}
@@ -640,6 +664,26 @@ export default function CalendarPage() {
     }
   };
 
+  const handleMatchActivity = async (activityId, eventId) => {
+    try {
+      await ExternalActivity.match(activityId, eventId);
+      loadData();
+    } catch (error) {
+      console.error("Error merging activity:", error);
+      alert(`Failed to merge: ${error.message}`);
+    }
+  };
+
+  const handleUnmatchActivity = async (activityId) => {
+    try {
+      await ExternalActivity.unmatch(activityId);
+      loadData();
+    } catch (error) {
+      console.error("Error un-merging activity:", error);
+      alert(`Failed to un-merge: ${error.message}`);
+    }
+  };
+
   const goToToday = () => {
     setCurrentDate(new Date());
   };
@@ -671,6 +715,8 @@ export default function CalendarPage() {
         onEditEvent={handleEditEvent}
         onDeleteEvent={handleDeleteEvent}
         onMoveEvent={handleMoveEvent}
+        onMatchActivity={handleMatchActivity}
+        onUnmatchActivity={handleUnmatchActivity}
         weekStartDay={weekStartDay}
       />
     </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -343,6 +343,13 @@ class APIService {
     delete: (id) => this.request(`/external-activities/${id}`, {
       method: 'DELETE'
     }),
+    match: (id, eventId) => this.request(`/external-activities/${id}/match`, {
+      method: 'POST',
+      body: JSON.stringify({ eventId })
+    }),
+    unmatch: (id) => this.request(`/external-activities/${id}/unmatch`, {
+      method: 'POST'
+    }),
     stats: (days = 30) => this.request(`/external-activities/stats?days=${days}`),
     byDateRange: (startDate, endDate) => this.request(`/external-activities?startDate=${startDate}&endDate=${endDate}`),
     recent: (limit = 20) => this.request(`/external-activities/recent?limit=${limit}`),


### PR DESCRIPTION
## Problem

Every synced Strava activity created a second, independent calendar event. A planned session on the same day stayed "scheduled" forever while a duplicate orange card appeared next to it.

## What this does (Layer 1 of 2)

**Auto-match at sync time** — new activities are classified against same-local-day planned events (`activityMatchingService`):
- exactly one open discipline-compatible session (exact match, or via the generic `cardio` bucket that accepts running/cycling/swimming/walking — specific modalities never cross-match) → the planned event is completed and linked, no duplicate; duration tiebreak (±max(15 min, 25%)) resolves multi-candidate days
- ambiguous (multiple candidates, app-logged double-record, discipline mismatch with open plans) → mirror event kept + `matchStatus: 'pending'` with candidates — the coach picks these up in PR B
- nothing that day → mirror + `'unmatched'` (unmapped sport types short-circuit here so pending never nags about them)

**User merge / un-merge** — in the calendar event modal: merge a Strava import into a same-day session (completed ones included — that's the legitimate double-record resolution), or "Not the same? Un-merge", which restores the planned event, gives the activity back its own card, and pins it `'separate'`.

**Every decision is audited** (`activitymatchaudits`, TTL 180d): auto decisions are the denominator, `user_unmerge` after `auto_merge` means the matcher was wrong. Deleting a Strava-linked event directly is also treated (and audited) as a correction.

**Invariants**: `separate`/`confirmed`/`pending` activities are never re-classified — sync, webhooks, and the nightly consistency job only maintain their events, so user/coach decisions can't be silently undone.

## Fixes bundled (same files)

- `sessionDetails.source`/`stravaData` were undeclared → strict-mode-stripped on write; the calendar's sport-type badge and distance line were reading fields that never persisted. Now declared.
- `DELETE /external-activities/:id` left the mirror event orphaned until the job ran; now cleaned inline (mirror deleted, merged event unlinked).
- Consistency-job orphan cleanup hard-deleted merged/template/plan-backed events; now unlinks them. A dead sessionLog link no longer deletes an event that still holds Strava evidence.
- `deleteCalendarEventForActivity` now userId-scoped.

## Timezone handling

Activity local day comes from Strava's `start_date_local`; midnight-UTC planned dates compare as day labels, timestamped (session-log-derived) dates are shifted by the activity's UTC offset first — an Israel 00:30-local logged session stays on the right day.

## Migration

`backend/scripts/migrate-merge-strava-mirror-duplicates.js` (dry-run default, `--apply`, `--user`): re-classifies pre-matcher activities, merges clean duplicates, backfills `matchStatus` + the stripped `stravaData` on remaining mirrors. **Run dry-run against prod after deploy, review counts, then `--apply`.**

## Tests

32 new jest tests: local-day/offset math (incl. UTC-day-boundary cases), full decision matrix, cardio-family rules, never-reclassify invariant inputs, unlink-vs-delete predicate, schema persistence of the previously stripped fields. Full backend suite passes (122).

## Not in this PR (PR B, next)

Coach tool `resolve_activity_match` via the backend internal-API pilot (§8 single-writer), pending matches in coach context/calendar anchors, evals routing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)