### PR TITLE
Coach flow for Strava match resolution (stacked on #174)

### DIFF
--- a/ai-coach-service/app/clients/__init__.py
+++ b/ai-coach-service/app/clients/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP clients for sibling services (backend internal API)."""

--- a/ai-coach-service/app/clients/backend_client.py
+++ b/ai-coach-service/app/clients/backend_client.py
@@ -1,0 +1,75 @@
+"""
+HTTP client for the Node backend's internal (service-to-service) API.
+
+Per the single-writer plan (development/mongodb-collections.md §8), collections
+owned by the backend are written by the coach THROUGH these endpoints, never
+via direct Mongo writes from Python. Auth is the shared INTERNAL_API_KEY as an
+X-Internal-Key header (same secret as the cron → coach direction).
+
+Backend refusals come back as {"success": False, "reason": "..."} and are
+returned verbatim so skills can relay them to the model.
+"""
+
+from typing import Any, Dict, Optional
+
+import httpx
+import structlog
+
+from app.config import get_settings
+
+logger = structlog.get_logger()
+
+_TIMEOUT_SECONDS = 15.0
+
+
+def _config() -> Optional[Dict[str, str]]:
+    settings = get_settings()
+    if not settings.backend_internal_url or not settings.internal_api_key:
+        return None
+    return {
+        "base_url": settings.backend_internal_url.rstrip("/"),
+        "key": settings.internal_api_key,
+    }
+
+
+async def _post(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    config = _config()
+    if config is None:
+        return {
+            "success": False,
+            "reason": "backend_internal_not_configured",
+            "message": "The backend internal API is not configured on this deployment.",
+        }
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                f"{config['base_url']}{path}",
+                json=payload,
+                headers={"X-Internal-Key": config["key"]},
+            )
+        return response.json()
+    except Exception as exc:  # network/timeout/decode — relay honestly
+        logger.error("backend_internal_call_failed", path=path, error=str(exc))
+        return {
+            "success": False,
+            "reason": "backend_unreachable",
+            "message": "The backend could not be reached — the change was NOT made.",
+        }
+
+
+async def resolve_activity_match(
+    user_id: str,
+    activity_id: str,
+    resolution: str,
+    event_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve an external-activity ↔ planned-event match on the backend."""
+    return await _post(
+        "/internal/v1/activity-match/resolve",
+        {
+            "userId": user_id,
+            "activityId": activity_id,
+            "resolution": resolution,
+            "eventId": event_id,
+        },
+    )

--- a/ai-coach-service/app/config.py
+++ b/ai-coach-service/app/config.py
@@ -99,8 +99,15 @@ class Settings(BaseSettings):
     jwt_secret_key: str
     jwt_algorithm: str = "HS256"
     # Shared secret for internal (cron-invoked) endpoints — X-Internal-Key
-    # header. Unset = internal endpoints disabled (403).
+    # header. Unset = internal endpoints disabled (403). The SAME secret
+    # authenticates our outbound calls to the backend's /internal/v1 routes
+    # (deliberate: one secret, both directions — see backend internalAuth.js).
     internal_api_key: Optional[str] = None
+
+    # Base URL of the Node backend for internal (coach → backend) writes,
+    # e.g. https://synergyfit-api.onrender.com. Unset = internal writes
+    # disabled (skills report the capability as unavailable).
+    backend_internal_url: Optional[str] = None
 
     # CORS
     allowed_origins: str = "http://localhost:5173,http://localhost:5001"

--- a/ai-coach-service/app/core/agents/data_reader.py
+++ b/ai-coach-service/app/core/agents/data_reader.py
@@ -334,6 +334,9 @@ class DataReaderAgent(BaseAgent):
                 date_str = start_date.strftime("%Y-%m-%d") if start_date else None
 
                 formatted.append({
+                    # id + match fields feed the resolve_activity_match tool
+                    # and the UNRESOLVED STRAVA MATCHES anchors block.
+                    "id": str(activity["_id"]),
                     "date": date_str,
                     "name": activity.get("name"),
                     "sport_type": activity.get("sportType"),
@@ -345,7 +348,9 @@ class DataReaderAgent(BaseAgent):
                     "elevation_gain": activity.get("elevationGain"),
                     "calories": activity.get("calories"),
                     "avg_speed": activity.get("avgSpeed"),
-                    "avg_power": activity.get("avgPower")
+                    "avg_power": activity.get("avgPower"),
+                    "match_status": activity.get("matchStatus"),
+                    "match_candidate_ids": [str(c) for c in activity.get("matchCandidateIds") or []]
                 })
 
             return formatted

--- a/ai-coach-service/app/core/agents/orchestrator.py
+++ b/ai-coach-service/app/core/agents/orchestrator.py
@@ -184,7 +184,7 @@ _WRITE_PREVIEW_DEFAULT_TRUE = {  # dry_run defaults true → write only on expli
     "schedule_to_calendar", "schedule_plan_to_calendar", "reschedule_session",
     "update_calendar_session", "adjust_plan",
 }
-_WRITE_CONFIRM_TOOLS = {"delete_calendar_event", "delete_session_template"}  # write only on confirm=true
+_WRITE_CONFIRM_TOOLS = {"delete_calendar_event", "delete_session_template", "resolve_activity_match"}  # write only on confirm=true
 _WRITE_PREVIEW_DEFAULT_FALSE = {"resolve_week"}  # writes unless dry_run=true
 _WRITE_ALWAYS = {
     "add_exercise", "add_plan_session", "create_goal", "create_plan",
@@ -922,6 +922,15 @@ USER DATA:
                 "Removing event from your calendar"
                 if function_args.get("confirm") is True
                 else "Previewing calendar event removal"
+            ),
+            "resolve_activity_match": (
+                {
+                    "merge": "Merging your tracked activity with the planned session",
+                    "separate": "Keeping your tracked activity as its own workout",
+                    "unmerge": "Un-merging your tracked activity from the planned session",
+                }.get(function_args.get("resolution"), "Resolving activity match")
+                if function_args.get("confirm") is True
+                else "Previewing activity match resolution"
             ),
             # Daily suggestion
             "get_daily_recommendation": "Checking your Today's Pick",

--- a/ai-coach-service/app/core/agents/prompts.py
+++ b/ai-coach-service/app/core/agents/prompts.py
@@ -24,7 +24,8 @@ SYSTEM_PROMPT = """You are an expert AI fitness coach helping users manage their
 ## Read before write — MANDATORY
 State-changing tools: create_session_template, delete_session_template, log_session,
 schedule_to_calendar / schedule_plan_to_calendar / reschedule_session (dry_run=false),
-delete_calendar_event (confirm=true), add_exercise, and all plan/goal writes.
+delete_calendar_event (confirm=true), resolve_activity_match (confirm=true),
+add_exercise, and all plan/goal writes.
 Before your FIRST state-changing call of a turn you must have read the affected state
 in THIS conversation:
 - User names a session ("Endurance 1", "my push day", "my Tuesday ride")? →
@@ -159,6 +160,7 @@ WHEN USER ASKS ABOUT EXERCISES BY MUSCLE GROUP (e.g., "what core exercises do I 
 - `get_calendar_events`: Check what's already scheduled on the user's calendar.
 - `reschedule_session`: Move or skip ONE session the user missed or wants to change. Skip marks status only — the event stays visible; it is NOT deletion. Previews first, writes on confirm.
 - `delete_calendar_event`: PERMANENTLY remove an event from the calendar — this is the tool for "remove/delete it from my calendar". Previews first, deletes on confirm.
+- `resolve_activity_match`: Resolve whether a synced tracker activity (Strava) IS a planned session. When the context shows an UNRESOLVED STRAVA MATCHES entry, ASK the user about it at a natural moment ("I see X was scheduled and Strava shows Y — same session?") and resolve per their answer: merge (activity fulfilled the planned session), separate (different workout), or unmerge (undo a wrong auto-merge). Previews first, writes on confirm. Never resolve without asking the user.
 - `review_progress`: Report adherence/progress over a recent window (from the calendar) for "how am I doing?" check-ins. Read-only.
 - `adjust_plan`: Change a live plan's volume/frequency or add a deload mid-cycle. Previews + re-validates; big volume jumps need override.
 

--- a/ai-coach-service/app/core/agents/services/calendar_service.py
+++ b/ai-coach-service/app/core/agents/services/calendar_service.py
@@ -81,6 +81,31 @@ def format_calendar_anchors(
     block += last_done_line or " none recently"
     block += "\nNEXT UPCOMING EVENT:"
     block += fmt_event(next_up) if next_up else " nothing scheduled in the next 14 days"
+
+    # Tracker activities the sync couldn't confidently match to a planned
+    # session (matchStatus 'pending'). The coach should ask about these at a
+    # natural moment and resolve via resolve_activity_match — never silently.
+    pending = [
+        a for a in (external_activities or [])
+        if a.get("match_status") == "pending" and a.get("id")
+    ]
+    if pending:
+        block += "\nUNRESOLVED STRAVA MATCHES (ask the user, then resolve_activity_match):"
+        for act in pending[:3]:
+            line = (
+                f"\n- activity_id={act['id']} {act.get('date')} "
+                f"{act.get('sport_type') or 'activity'} \"{act.get('name') or 'activity'}\""
+            )
+            if act.get("duration_mins"):
+                line += f", {act['duration_mins']} min"
+            n_candidates = len(act.get("match_candidate_ids") or [])
+            line += (
+                f" — may be one of {n_candidates} planned session(s) that day"
+                if n_candidates
+                else " — a session was planned that day"
+            )
+            line += " (get_calendar_events for that date to see them)"
+            block += line
     return block
 
 

--- a/ai-coach-service/app/core/agents/skills/__init__.py
+++ b/ai-coach-service/app/core/agents/skills/__init__.py
@@ -35,6 +35,7 @@ from app.core.agents.skills import show_plan_skill  # noqa: F401,E402
 from app.core.agents.skills import daily_recommendation_skill  # noqa: F401,E402
 from app.core.agents.skills import propose_exercise_swap_skill  # noqa: F401,E402
 from app.core.agents.skills import update_sport_preferences_skill  # noqa: F401,E402
+from app.core.agents.skills import resolve_activity_match_skill  # noqa: F401,E402
 
 __all__ = [
     "SkillContext",

--- a/ai-coach-service/app/core/agents/skills/delete_calendar_event_skill.py
+++ b/ai-coach-service/app/core/agents/skills/delete_calendar_event_skill.py
@@ -7,7 +7,7 @@ skip, which only marks status and leaves the event visible. Two-step confirm
 matching delete_session_template: preview first, delete only on confirm=true.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict
 
 from bson import ObjectId
@@ -74,6 +74,11 @@ async def delete_calendar_event(ctx: SkillContext, user_id: str, args: Dict[str,
                 " Note: this session belongs to a training plan — deleting removes it "
                 "from the calendar only, the plan itself is unchanged."
             )
+        if event.get("externalActivityId"):
+            plan_warning += (
+                " Note: this event is linked to a synced tracker activity — the "
+                "activity record itself is kept and won't be re-matched."
+            )
         return {
             "success": True,
             "needs_confirmation": True,
@@ -97,6 +102,37 @@ async def delete_calendar_event(ctx: SkillContext, user_id: str, args: Dict[str,
     result = await ctx.db.calendarevents.delete_one({"_id": event_oid, "userId": user_oid})
     if result.deleted_count != 1:
         return {"success": False, "message": "The event could not be deleted — it may already be gone."}
+
+    # Deleting a Strava-linked event is a match correction (mirrors the
+    # backend controller's handleLinkedEventDeletion): pin the activity
+    # 'separate' so the nightly consistency job can never resurrect this
+    # deletion as an auto-merge into another event. Direct writes here are
+    # the skill's existing (pre-§8) pattern; migrating this whole skill to
+    # the backend internal API is the tracked follow-up.
+    if event.get("externalActivityId"):
+        activity = await ctx.db.externalactivities.find_one(
+            {"_id": event["externalActivityId"], "userId": user_oid}
+        )
+        if activity:
+            await ctx.db.externalactivities.update_one(
+                {"_id": activity["_id"]},
+                {"$set": {"matchStatus": "separate"}, "$unset": {"matchedEventId": ""}},
+            )
+            await ctx.db.activitymatchaudits.insert_one({
+                "userId": user_oid,
+                "activityId": activity["_id"],
+                "eventId": event_oid,
+                "action": "coach_event_delete",
+                "actor": "coach",
+                "previous": {
+                    "matchStatus": activity.get("matchStatus"),
+                    "matchedEventId": activity.get("matchedEventId"),
+                },
+                "expiresAt": datetime.utcnow() + timedelta(days=180),
+                "createdAt": datetime.utcnow(),
+                "updatedAt": datetime.utcnow(),
+            })
+
     return {
         "success": True,
         "deleted": 1,

--- a/ai-coach-service/app/core/agents/skills/resolve_activity_match_skill.py
+++ b/ai-coach-service/app/core/agents/skills/resolve_activity_match_skill.py
@@ -73,8 +73,11 @@ async def resolve_activity_match(ctx: SkillContext, user_id: str, args: Dict[str
             "message": "resolution must be one of merge / separate / unmerge.",
         }
     try:
-        activity_oid = ObjectId(activity_id)
         user_oid = ObjectId(user_id)
+    except Exception:
+        return {"success": False, "error": "invalid_user", "message": "Internal error: bad user id."}
+    try:
+        activity_oid = ObjectId(activity_id)
     except Exception:
         return {
             "success": False,
@@ -88,6 +91,40 @@ async def resolve_activity_match(ctx: SkillContext, user_id: str, args: Dict[str
     activity = await ctx.db.externalactivities.find_one({"_id": activity_oid, "userId": user_oid})
     if not activity:
         return {"success": False, "message": "I couldn't find that synced activity."}
+
+    # Check actual match state up front so the PREVIEW is honest — never show
+    # a confident "this will un-merge…" for an activity that isn't merged and
+    # only find out after the user confirmed.
+    linked = await ctx.db.calendarevents.find_one(
+        {"userId": user_oid, "externalActivityId": activity_oid}
+    )
+    linked_merged = bool(
+        linked and (linked.get("sessionDetails") or {}).get("source") == "strava-matched"
+    )
+    if resolution == "merge" and linked_merged:
+        return {
+            "success": False,
+            "error": "already_merged",
+            "message": (
+                f"That activity is already merged into \"{linked.get('title', '')}\". "
+                f"Un-merge it first if the user wants it matched elsewhere."
+            ),
+        }
+    if resolution == "unmerge" and not linked_merged and not activity.get("matchedEventId"):
+        return {
+            "success": False,
+            "error": "not_merged",
+            "message": "That activity isn't merged into any planned session — nothing to un-merge.",
+        }
+    if resolution == "separate" and linked_merged:
+        return {
+            "success": False,
+            "error": "is_merged_use_unmerge",
+            "message": (
+                f"That activity is merged into \"{linked.get('title', '')}\" — use "
+                f"resolution='unmerge' to undo that instead."
+            ),
+        }
 
     activity_label = (
         f"{activity.get('sportType', 'activity')} \"{activity.get('name', 'activity')}\""

--- a/ai-coach-service/app/core/agents/skills/resolve_activity_match_skill.py
+++ b/ai-coach-service/app/core/agents/skills/resolve_activity_match_skill.py
@@ -1,0 +1,174 @@
+"""
+Skill: resolve_activity_match
+
+Resolve whether a synced tracker activity (Strava) IS a planned calendar
+session. The sync auto-merges unambiguous matches; ambiguous ones are flagged
+matchStatus='pending' and surfaced in the calendar-anchors context — this is
+the tool the coach uses after asking the user ("Endurance 1 was scheduled and
+Strava shows a run — same session?").
+
+Two-step confirm matching delete_calendar_event: preview first, write only on
+confirm=true. The write goes through the backend's internal API
+(/internal/v1/activity-match/resolve) — never a direct Mongo write; reads for
+the preview stay local. Backend refusals ({"reason": ...}) are relayed
+verbatim: stored candidate lists go stale, the backend re-validates.
+"""
+
+from typing import Any, Dict
+
+from bson import ObjectId
+
+from app.clients.backend_client import resolve_activity_match as backend_resolve
+from app.core.agents.skills.registry import SkillContext, skill
+
+_RESOLUTIONS = ("merge", "separate", "unmerge")
+
+
+@skill(
+    name="resolve_activity_match",
+    description=(
+        "Resolve whether a synced tracker activity (Strava) IS one of the user's "
+        "planned calendar sessions. resolution='merge' + event_id marks that planned "
+        "session completed by the activity (use when the user confirms they're the "
+        "same); 'separate' records that a pending activity was a different workout — "
+        "it keeps its own calendar entry and is never re-matched; 'unmerge' undoes a "
+        "wrong automatic merge. Take activity_id from the UNRESOLVED STRAVA MATCHES "
+        "context or an external-activities read, event_id from get_calendar_events — "
+        "never guess ids. Previews first; writes only when called again with "
+        "confirm=true after the user confirms."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "activity_id": {
+                "type": "string",
+                "description": "The external activity to resolve — from the UNRESOLVED STRAVA MATCHES context block, never guessed.",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["merge", "separate", "unmerge"],
+                "description": "merge = activity IS the planned session (needs event_id); separate = different workout, keep both; unmerge = undo a wrong auto-merge.",
+            },
+            "event_id": {
+                "type": "string",
+                "description": "Required for resolution='merge': the planned calendar event the activity fulfilled — from a get_calendar_events result.",
+            },
+            "confirm": {
+                "type": "boolean",
+                "description": "Actually write. Default false = preview only. Set true ONLY after the user confirms.",
+            },
+        },
+        "required": ["activity_id", "resolution"],
+    },
+)
+async def resolve_activity_match(ctx: SkillContext, user_id: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    activity_id = args.get("activity_id")
+    resolution = args.get("resolution")
+    event_id = args.get("event_id")
+
+    if resolution not in _RESOLUTIONS:
+        return {
+            "success": False,
+            "error": "invalid_resolution",
+            "message": "resolution must be one of merge / separate / unmerge.",
+        }
+    try:
+        activity_oid = ObjectId(activity_id)
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return {
+            "success": False,
+            "error": "invalid_activity_id",
+            "message": (
+                "Invalid activity_id. Take it from the UNRESOLVED STRAVA MATCHES "
+                "context or an external-activities read — never guess it."
+            ),
+        }
+
+    activity = await ctx.db.externalactivities.find_one({"_id": activity_oid, "userId": user_oid})
+    if not activity:
+        return {"success": False, "message": "I couldn't find that synced activity."}
+
+    activity_label = (
+        f"{activity.get('sportType', 'activity')} \"{activity.get('name', 'activity')}\""
+    )
+    start = activity.get("startDate")
+    date_str = start.strftime("%A, %B %d") if start else ""
+
+    event = None
+    if resolution == "merge":
+        try:
+            # ObjectId(None) fabricates a fresh id — guard explicitly.
+            if not event_id:
+                raise ValueError("event_id required")
+            event_oid = ObjectId(event_id)
+        except Exception:
+            return {
+                "success": False,
+                "error": "invalid_event_id",
+                "message": "resolution='merge' needs an event_id from a get_calendar_events result.",
+            }
+        event = await ctx.db.calendarevents.find_one({"_id": event_oid, "userId": user_oid})
+        if not event:
+            return {"success": False, "message": "I couldn't find that calendar event."}
+
+    if not args.get("confirm", False):
+        previews = {
+            "merge": (
+                f"This will mark **{event.get('title') if event else ''}** as completed by the "
+                f"{activity_label} from {date_str}, and remove the activity's separate calendar entry."
+            ),
+            "separate": (
+                f"This records that the {activity_label} from {date_str} was a DIFFERENT workout "
+                f"from anything planned — it keeps its own calendar entry and won't be matched again."
+            ),
+            "unmerge": (
+                f"This will un-merge the {activity_label} from the planned session it was matched to: "
+                f"the planned session goes back to scheduled and the activity gets its own calendar entry."
+            ),
+        }
+        return {
+            "success": True,
+            "needs_confirmation": True,
+            "would_resolve": {
+                "activity_id": str(activity_oid),
+                "activity": activity_label,
+                "date": start.strftime("%Y-%m-%d") if start else "",
+                "resolution": resolution,
+                "event_id": str(event["_id"]) if event else None,
+                "event_title": event.get("title") if event else None,
+            },
+            "message": (
+                f"{previews[resolution]} Ask the user to confirm; if they do, call "
+                f"resolve_activity_match again with the same arguments plus confirm=true. "
+                f"If they decline, do NOT call this tool again."
+            ),
+        }
+
+    result = await backend_resolve(
+        user_id=user_id,
+        activity_id=str(activity_oid),
+        resolution=resolution,
+        event_id=str(event["_id"]) if event else None,
+    )
+    if not result.get("success"):
+        reason = result.get("reason", "unknown")
+        return {
+            "success": False,
+            "error": reason,
+            "message": result.get(
+                "message",
+                f"The backend refused the resolution ({reason}) — nothing was changed. "
+                f"Re-read the calendar before retrying.",
+            ),
+        }
+
+    messages = {
+        "merge": (
+            f"Done — **{result.get('eventTitle') or (event.get('title') if event else 'the planned session')}** "
+            f"is marked completed by the {activity_label}."
+        ),
+        "separate": f"Got it — the {activity_label} stays as its own workout and won't be matched again.",
+        "unmerge": f"Un-merged — the planned session is back on the schedule and the {activity_label} has its own entry.",
+    }
+    return {"success": True, "resolution": resolution, "message": messages[resolution]}

--- a/ai-coach-service/tests/test_delete_calendar_event_skill.py
+++ b/ai-coach-service/tests/test_delete_calendar_event_skill.py
@@ -75,3 +75,26 @@ class TestDeleteCalendarEvent:
         ctx = _ctx(_event(planId=ObjectId()))
         res = await delete_calendar_event(ctx, USER_ID, {"event_id": str(EVENT_ID)})
         assert "training plan" in res["message"]
+
+    async def test_strava_linked_delete_pins_activity_separate(self):
+        # Deleting a Strava-linked event must pin the activity 'separate'
+        # (else the nightly job can resurrect the deletion as an auto-merge)
+        # and write a coach_event_delete audit row.
+        activity_id = ObjectId()
+        ctx = _ctx(_event(externalActivityId=activity_id))
+        ctx.db.externalactivities.find_one = AsyncMock(
+            return_value={"_id": activity_id, "matchStatus": "auto", "matchedEventId": EVENT_ID}
+        )
+        ctx.db.externalactivities.update_one = AsyncMock()
+        ctx.db.activitymatchaudits.insert_one = AsyncMock()
+
+        res = await delete_calendar_event(
+            ctx, USER_ID, {"event_id": str(EVENT_ID), "confirm": True}
+        )
+        assert res["success"] is True
+        update = ctx.db.externalactivities.update_one.call_args[0][1]
+        assert update["$set"] == {"matchStatus": "separate"}
+        assert "matchedEventId" in update["$unset"]
+        audit = ctx.db.activitymatchaudits.insert_one.call_args[0][0]
+        assert audit["action"] == "coach_event_delete"
+        assert audit["previous"]["matchStatus"] == "auto"

--- a/ai-coach-service/tests/test_resolve_activity_match_skill.py
+++ b/ai-coach-service/tests/test_resolve_activity_match_skill.py
@@ -125,6 +125,53 @@ class TestResolveActivityMatch:
             event_id=None,
         )
 
+    async def test_unmerge_preview_checks_actual_state(self):
+        # Not merged, no matchedEventId → corrective at PREVIEW time
+        ctx = _ctx(_activity(matchStatus="pending"))
+        res = await resolve_activity_match(
+            ctx, USER_ID, {"activity_id": str(ACTIVITY_ID), "resolution": "unmerge"}
+        )
+        assert res["success"] is False
+        assert res["error"] == "not_merged"
+
+    async def test_unmerge_preview_on_merged_activity(self):
+        merged_event = _event(
+            externalActivityId=ACTIVITY_ID,
+            sessionDetails={"source": "strava-matched"},
+            status="completed",
+        )
+        ctx = _ctx(_activity(matchStatus="auto", matchedEventId=EVENT_ID), merged_event)
+        res = await resolve_activity_match(
+            ctx, USER_ID, {"activity_id": str(ACTIVITY_ID), "resolution": "unmerge"}
+        )
+        assert res["success"] is True
+        assert res["needs_confirmation"] is True
+
+    async def test_separate_on_merged_activity_is_corrective(self):
+        merged_event = _event(
+            externalActivityId=ACTIVITY_ID,
+            sessionDetails={"source": "strava-matched"},
+        )
+        ctx = _ctx(_activity(matchStatus="auto", matchedEventId=EVENT_ID), merged_event)
+        res = await resolve_activity_match(
+            ctx, USER_ID, {"activity_id": str(ACTIVITY_ID), "resolution": "separate"}
+        )
+        assert res["success"] is False
+        assert res["error"] == "is_merged_use_unmerge"
+
+    async def test_merge_on_already_merged_activity_is_corrective(self):
+        merged_event = _event(
+            externalActivityId=ACTIVITY_ID,
+            sessionDetails={"source": "strava-matched"},
+        )
+        ctx = _ctx(_activity(matchStatus="auto", matchedEventId=EVENT_ID), merged_event)
+        res = await resolve_activity_match(
+            ctx, USER_ID,
+            {"activity_id": str(ACTIVITY_ID), "resolution": "merge", "event_id": str(ObjectId())},
+        )
+        assert res["success"] is False
+        assert res["error"] == "already_merged"
+
     async def test_unknown_activity(self):
         ctx = _ctx(activity=None)
         res = await resolve_activity_match(

--- a/ai-coach-service/tests/test_resolve_activity_match_skill.py
+++ b/ai-coach-service/tests/test_resolve_activity_match_skill.py
@@ -1,0 +1,147 @@
+"""
+Tests for the resolve_activity_match skill (two-step confirm; writes go
+through the backend internal client, never direct Mongo).
+"""
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bson import ObjectId
+
+from app.core.agents.skills.resolve_activity_match_skill import resolve_activity_match
+
+USER_ID = str(ObjectId())
+ACTIVITY_ID = ObjectId()
+EVENT_ID = ObjectId()
+
+
+def _activity(**overrides):
+    activity = {
+        "_id": ACTIVITY_ID,
+        "userId": ObjectId(USER_ID),
+        "name": "Morning Run",
+        "sportType": "Run",
+        "startDate": datetime(2026, 7, 29, 18, 30),
+        "matchStatus": "pending",
+    }
+    activity.update(overrides)
+    return activity
+
+
+def _event(**overrides):
+    event = {
+        "_id": EVENT_ID,
+        "userId": ObjectId(USER_ID),
+        "title": "Endurance 1",
+        "type": "session",
+        "status": "scheduled",
+    }
+    event.update(overrides)
+    return event
+
+
+def _ctx(activity=None, event=None):
+    ctx = MagicMock()
+    ctx.db.externalactivities.find_one = AsyncMock(return_value=activity)
+    ctx.db.calendarevents.find_one = AsyncMock(return_value=event)
+    return ctx
+
+
+class TestResolveActivityMatch:
+    async def test_merge_preview_needs_confirmation_and_no_backend_call(self):
+        ctx = _ctx(_activity(), _event())
+        with patch(
+            "app.core.agents.skills.resolve_activity_match_skill.backend_resolve",
+            new=AsyncMock(),
+        ) as backend:
+            res = await resolve_activity_match(
+                ctx, USER_ID,
+                {"activity_id": str(ACTIVITY_ID), "resolution": "merge", "event_id": str(EVENT_ID)},
+            )
+        assert res["success"] is True
+        assert res["needs_confirmation"] is True
+        assert res["would_resolve"]["event_title"] == "Endurance 1"
+        assert "confirm=true" in res["message"]
+        backend.assert_not_called()
+
+    async def test_confirm_merge_calls_backend(self):
+        ctx = _ctx(_activity(), _event())
+        backend = AsyncMock(return_value={"success": True, "eventTitle": "Endurance 1"})
+        with patch(
+            "app.core.agents.skills.resolve_activity_match_skill.backend_resolve",
+            new=backend,
+        ):
+            res = await resolve_activity_match(
+                ctx, USER_ID,
+                {"activity_id": str(ACTIVITY_ID), "resolution": "merge",
+                 "event_id": str(EVENT_ID), "confirm": True},
+            )
+        assert res["success"] is True
+        backend.assert_awaited_once_with(
+            user_id=USER_ID,
+            activity_id=str(ACTIVITY_ID),
+            resolution="merge",
+            event_id=str(EVENT_ID),
+        )
+
+    async def test_backend_refusal_is_relayed(self):
+        ctx = _ctx(_activity(), _event())
+        backend = AsyncMock(return_value={"success": False, "reason": "event_already_linked"})
+        with patch(
+            "app.core.agents.skills.resolve_activity_match_skill.backend_resolve",
+            new=backend,
+        ):
+            res = await resolve_activity_match(
+                ctx, USER_ID,
+                {"activity_id": str(ACTIVITY_ID), "resolution": "merge",
+                 "event_id": str(EVENT_ID), "confirm": True},
+            )
+        assert res["success"] is False
+        assert res["error"] == "event_already_linked"
+
+    async def test_merge_without_event_id_is_corrective(self):
+        ctx = _ctx(_activity())
+        res = await resolve_activity_match(
+            ctx, USER_ID, {"activity_id": str(ACTIVITY_ID), "resolution": "merge"}
+        )
+        assert res["success"] is False
+        assert res["error"] == "invalid_event_id"
+
+    async def test_separate_does_not_need_event(self):
+        ctx = _ctx(_activity())
+        backend = AsyncMock(return_value={"success": True})
+        with patch(
+            "app.core.agents.skills.resolve_activity_match_skill.backend_resolve",
+            new=backend,
+        ):
+            res = await resolve_activity_match(
+                ctx, USER_ID,
+                {"activity_id": str(ACTIVITY_ID), "resolution": "separate", "confirm": True},
+            )
+        assert res["success"] is True
+        backend.assert_awaited_once_with(
+            user_id=USER_ID,
+            activity_id=str(ACTIVITY_ID),
+            resolution="separate",
+            event_id=None,
+        )
+
+    async def test_unknown_activity(self):
+        ctx = _ctx(activity=None)
+        res = await resolve_activity_match(
+            ctx, USER_ID, {"activity_id": str(ObjectId()), "resolution": "separate"}
+        )
+        assert res["success"] is False
+
+    async def test_invalid_ids_are_corrective(self):
+        ctx = _ctx(_activity())
+        res = await resolve_activity_match(
+            ctx, USER_ID, {"activity_id": "not-an-id", "resolution": "merge"}
+        )
+        assert res["success"] is False
+        assert res["error"] == "invalid_activity_id"
+
+        res = await resolve_activity_match(
+            ctx, USER_ID, {"activity_id": str(ACTIVITY_ID), "resolution": "delete"}
+        )
+        assert res["success"] is False
+        assert res["error"] == "invalid_resolution"

--- a/backend/src/middleware/internalAuth.js
+++ b/backend/src/middleware/internalAuth.js
@@ -1,0 +1,29 @@
+const crypto = require('crypto');
+
+/**
+ * Auth for service-to-service internal endpoints (ai-coach → backend), per
+ * the single-writer plan in development/mongodb-collections.md §8.
+ *
+ * X-Internal-Key shared secret, timing-safe compare. The same INTERNAL_API_KEY
+ * secret already authenticates the cron → ai-coach direction (render.yaml);
+ * reusing it for coach → backend is deliberate — one secret, both directions.
+ * Unset key = internal endpoints disabled (403).
+ */
+const internalAuth = (req, res, next) => {
+  const expected = process.env.INTERNAL_API_KEY;
+  const provided = req.get('X-Internal-Key');
+
+  if (!expected || !provided) {
+    return res.status(403).json({ success: false, message: 'Forbidden' });
+  }
+
+  const expectedBuf = Buffer.from(String(expected));
+  const providedBuf = Buffer.from(String(provided));
+  if (expectedBuf.length !== providedBuf.length || !crypto.timingSafeEqual(expectedBuf, providedBuf)) {
+    return res.status(403).json({ success: false, message: 'Forbidden' });
+  }
+
+  next();
+};
+
+module.exports = { internalAuth };

--- a/backend/src/routes/internal/activityMatch.js
+++ b/backend/src/routes/internal/activityMatch.js
@@ -1,0 +1,104 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const ExternalActivity = require('../../models/ExternalActivity');
+const CalendarEvent = require('../../models/CalendarEvent');
+const StravaIntegrationService = require('../../services/StravaIntegrationService');
+const ActivityMatchingService = require('../../services/activityMatchingService');
+const { internalAuth } = require('../../middleware/internalAuth');
+
+const router = express.Router();
+
+/**
+ * POST /internal/v1/activity-match/resolve
+ *
+ * Coach-side resolution of an activity↔planned-event match (the pilot
+ * endpoint of the §8 single-writer plan — the Python skill never writes these
+ * collections directly). Body: { userId, activityId, resolution, eventId? }
+ *  - 'merge'    → merge the activity into eventId (matchStatus 'confirmed')
+ *  - 'separate' → pending activity is NOT the planned session; keep its own
+ *                 calendar entry, never re-match
+ *  - 'unmerge'  → undo a merge (tolerates a dangling matchedEventId)
+ *
+ * Refusals are machine-readable ({ success: false, reason }) so the skill can
+ * relay them: stored candidate lists go stale, so everything is re-validated
+ * here at resolve time.
+ */
+router.post('/resolve', internalAuth, async (req, res) => {
+  try {
+    const { userId, activityId, resolution, eventId } = req.body || {};
+
+    if (!mongoose.Types.ObjectId.isValid(userId) || !mongoose.Types.ObjectId.isValid(activityId)) {
+      return res.status(400).json({ success: false, reason: 'invalid_ids' });
+    }
+    if (!['merge', 'separate', 'unmerge'].includes(resolution)) {
+      return res.status(400).json({ success: false, reason: 'invalid_resolution' });
+    }
+
+    const activity = await ExternalActivity.findOne({ _id: activityId, userId }).lean();
+    if (!activity) {
+      return res.status(404).json({ success: false, reason: 'activity_not_found' });
+    }
+
+    const discipline = StravaIntegrationService.mapStravaTypeToDiscipline(activity.sportType);
+    const linked = await CalendarEvent.findOne({ userId, externalActivityId: activity._id }).lean();
+    const isMerged = Boolean(linked && linked.sessionDetails?.source === 'strava-matched');
+
+    if (resolution === 'merge') {
+      if (!mongoose.Types.ObjectId.isValid(eventId)) {
+        return res.status(400).json({ success: false, reason: 'event_id_required' });
+      }
+      if (isMerged) {
+        return res.status(409).json({ success: false, reason: 'already_merged', eventId: linked._id });
+      }
+      const event = await CalendarEvent.findOne({ _id: eventId, userId, type: 'session' }).lean();
+      if (!event) {
+        return res.status(404).json({ success: false, reason: 'event_not_found' });
+      }
+      if (event.externalActivityId && String(event.externalActivityId) !== String(activity._id)) {
+        return res.status(409).json({ success: false, reason: 'event_already_linked' });
+      }
+      await ActivityMatchingService.mergeActivityIntoEvent(activity, event, {
+        actor: 'coach',
+        matchStatus: 'confirmed',
+        action: 'coach_merge'
+      });
+      return res.json({ success: true, resolution, eventId: event._id, eventTitle: event.title });
+    }
+
+    if (resolution === 'unmerge') {
+      if (!isMerged && !activity.matchedEventId) {
+        return res.status(409).json({ success: false, reason: 'not_merged' });
+      }
+      // Dangling matchedEventId (merged event deleted) is fine — unmerge
+      // still recreates the mirror and pins the activity 'separate'.
+      await ActivityMatchingService.unmergeActivity(activity, discipline, {
+        actor: 'coach',
+        action: 'coach_unmerge'
+      });
+      return res.json({ success: true, resolution });
+    }
+
+    // resolution === 'separate' — resolving a pending question, not a merge
+    if (isMerged) {
+      return res.status(409).json({ success: false, reason: 'is_merged_use_unmerge' });
+    }
+    const previous = { matchStatus: activity.matchStatus, matchedEventId: activity.matchedEventId };
+    await ExternalActivity.updateOne(
+      { _id: activity._id },
+      { $set: { matchStatus: 'separate', matchCandidateIds: [] }, $unset: { matchedEventId: 1 } }
+    );
+    await ActivityMatchingService.writeAudit({
+      userId: activity.userId,
+      activityId: activity._id,
+      action: 'coach_separate',
+      actor: 'coach',
+      previous
+    });
+    return res.json({ success: true, resolution });
+  } catch (error) {
+    console.error('Internal activity-match resolve error:', error);
+    res.status(500).json({ success: false, reason: 'server_error', error: error.message });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -58,6 +58,7 @@ const trainNowRoutes = require('./routes/trainNow');
 const coachQuestionRoutes = require('./routes/coachQuestion');
 const newsRoutes = require('./routes/news');
 const mcpAuthRoutes = require('./routes/mcpAuth');
+const internalActivityMatchRoutes = require('./routes/internal/activityMatch');
 const mcpRoutes = require('./routes/mcp');
 
 // Log Strava config on startup (helps debug production issues)
@@ -290,6 +291,10 @@ app.use('/api/v1/session-logs', sessionLogRoutes);
 app.use('/api/v1/train-now', trainNowRoutes);
 app.use('/api/v1/coach-question', coachQuestionRoutes);
 app.use('/api/v1/news', newsRoutes);
+
+// Internal service-to-service endpoints (ai-coach → backend, X-Internal-Key).
+// Mounted outside /api/ so the public rate limiter doesn't apply.
+app.use('/internal/v1/activity-match', internalActivityMatchRoutes);
 
 // MCP connector: OAuth authorization-server routes (mounted at root — the
 // `.well-known` discovery documents are origin-rooted) and the /mcp endpoint.

--- a/render.yaml
+++ b/render.yaml
@@ -69,6 +69,11 @@ services:
         sync: false  # Target Linear team UUID
       - key: LINEAR_FEEDBACK_PROJECT_ID
         sync: false  # "Feedback Inbox" project UUID (optional)
+      # Internal API (ai-coach → backend, X-Internal-Key). Deliberately the
+      # SAME secret as the ai-coach service's INTERNAL_API_KEY — one secret
+      # authenticates both directions.
+      - key: INTERNAL_API_KEY
+        sync: false  # must match the ai-coach service's INTERNAL_API_KEY
 
   # Frontend Static Site
   - type: static


### PR DESCRIPTION
## Stacked on #174 — merge that first, then re-base this to main

PR A gave the matcher a `pending` state; this PR gets those pending questions to the sensei and lets it resolve them the way the feature was imagined:

> "I see Endurance 1 was scheduled yesterday and Strava shows a strength workout — same session? What did you do?"

## What's here

**Context surfacing** — pending activities appear in the calendar-anchors block (shared by chat and the dashboard coach question) as `UNRESOLVED STRAVA MATCHES` with `activity_id`s; the prompt tells the coach to ask at a natural moment and never resolve silently. `data_reader` activity dicts now carry `id` / `match_status` / `match_candidate_ids` (query + sort untouched — the coach-question cache fingerprints them).

**`resolve_activity_match` skill** — two-step confirm (preview → user confirms → `confirm=true`), matching the `delete_calendar_event` convention and classified in `_WRITE_CONFIRM_TOOLS`. Three resolutions: `merge` (activity fulfilled the planned event), `separate` (different workout, keep both, never re-match), `unmerge` (undo a wrong auto-merge).

**Single-writer pilot (§8)** — first real instance of the approved coach→backend internal API:
- backend: `POST /internal/v1/activity-match/resolve` behind new `internalAuth` middleware (`X-Internal-Key`, timing-safe; mounted outside `/api/` so the public rate limiter doesn't apply). Re-validates everything at resolve time — stored candidate lists go stale, dangling `matchedEventId` tolerated — and returns machine-readable refusals (`event_already_linked`, `is_merged_use_unmerge`, …) that the skill relays verbatim.
- coach: `app/clients/backend_client.py` (`BACKEND_INTERNAL_URL` + shared `INTERNAL_API_KEY`). Reads for the preview stay local; the write never touches Mongo from Python.
- Audit rows `coach_merge` / `coach_separate` / `coach_unmerge` land in `activitymatchaudits` next to the auto and user rows, so matcher precision is measurable across all three actors.

## Deploy notes (dashboard)

- `synergyfit-api`: set `INTERNAL_API_KEY` = the ai-coach service's existing value (render.yaml documents it).
- `ai-coach`: set `BACKEND_INTERNAL_URL` = `https://synergyfit-api.onrender.com` (that service is dashboard-managed, not in render.yaml).
- Unset config degrades gracefully: the skill reports the capability unavailable; nothing breaks.

## Tests

7 new skill tests (preview/no-write, confirm→client call, refusal relay, corrective errors); full ai-coach suite 730 passed; backend suite 122 passed; prompt-policy regression green.

**Eval deferred, deliberately**: the evals harness runs against a scratch Mongo with no Node backend, and this tool's write path *is* the backend internal API. A routing eval needs a harness-level backend stub first — noted as follow-up rather than faking it with a monkeypatch that would re-implement the merge logic in Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)